### PR TITLE
Allow moveit rviz plugin to load multiple instances of a same CAD model

### DIFF
--- a/visualization/moveit_rviz_plugin/include/moveit_rviz_plugin/planning_frame.h
+++ b/visualization/moveit_rviz_plugin/include/moveit_rviz_plugin/planning_frame.h
@@ -144,6 +144,7 @@ private:
   void populateConstraintsList(void);
   void populateConstraintsList(const std::vector<std::string> &constr);
   void configureForPlanning(void);
+  void addObject(collision_detection::CollisionWorldPtr world, const std::string &id, const shapes::ShapeConstPtr &shape, const Eigen::Affine3d &pose);
   
   ros::NodeHandle nh_;
   ros::Publisher planning_scene_publisher_;

--- a/visualization/moveit_rviz_plugin/src/planning_frame.cpp
+++ b/visualization/moveit_rviz_plugin/src/planning_frame.cpp
@@ -186,7 +186,14 @@ void moveit_rviz_plugin::PlanningFrame::importSceneButtonClicked(void)
       Eigen::Affine3d pose;
       pose.setIdentity();
       collision_detection::CollisionWorldPtr world = planning_display_->getPlanningSceneMonitor()->getPlanningScene()->getCollisionWorld();
-      world->removeObject(name);
+
+      //If the object already exist, create it with another name
+      if (world->hasObject(name)) {
+        std::stringstream ss;
+        ss << name << "-" << world->getObjectsCount();
+        name=ss.str();
+      }
+
       world->addToObject(name, shape, pose);
       populateCollisionObjectsList();
       planning_display_->queueRenderSceneGeometry();

--- a/visualization/moveit_rviz_plugin/src/planning_frame.cpp
+++ b/visualization/moveit_rviz_plugin/src/planning_frame.cpp
@@ -174,6 +174,8 @@ void moveit_rviz_plugin::PlanningFrame::populateCollisionObjectsList(void)
 void moveit_rviz_plugin::PlanningFrame::importSceneButtonClicked(void)
 { 
   std::string path = QFileDialog::getOpenFileName(this, "Import Scene").toStdString();
+  std::string name;
+
   if (!path.empty() && planning_display_->getPlanningSceneMonitor())
   {
     path = "file://" + path;
@@ -181,24 +183,59 @@ void moveit_rviz_plugin::PlanningFrame::importSceneButtonClicked(void)
     if (mesh)
     {
       std::size_t slash = path.find_last_of("/");
-      std::string name = path.substr(slash + 1);
+      name = path.substr(slash + 1);
       shapes::ShapeConstPtr shape(mesh);
       Eigen::Affine3d pose;
       pose.setIdentity();
       collision_detection::CollisionWorldPtr world = planning_display_->getPlanningSceneMonitor()->getPlanningScene()->getCollisionWorld();
 
-      //If the object already exist, create it with another name
+      //If the object already exist, ask the user whether to overwrite or rename
       if (world->hasObject(name)) {
-        std::stringstream ss;
-        ss << name << "-" << world->getObjectsCount();
-        name=ss.str();
-      }
+        QMessageBox msgBox;
+        msgBox.setText("There exists another object with the same name.");
+        msgBox.setInformativeText("Do you want to overwrite it?");
+        msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+        msgBox.setDefaultButton(QMessageBox::No);
+        int ret = msgBox.exec();
 
-      world->addToObject(name, shape, pose);
-      populateCollisionObjectsList();
-      planning_display_->queueRenderSceneGeometry();
+        switch (ret) {
+          case QMessageBox::Yes:
+            // Overwrite was clicked
+            world->removeObject(name);
+            addObject(world, name, shape, pose);
+            break;
+          case QMessageBox::No:
+          {
+            // Don't overwrite was clicked. Ask for another name
+            std::stringstream ss;
+            ss << name << "-" << world->getObjectsCount();
+
+            bool ok;
+            QString text = QInputDialog::getText(this, tr("Choose a new name"),
+                                                 tr("New object name:"), QLineEdit::Normal,
+                                                 QString(ss.str().c_str()), &ok);
+            if (ok && !text.isEmpty()) {
+              name=text.toStdString();
+              addObject(world, name, shape, pose);
+            }
+            break;
+          }
+          default:
+            //Pressed cancel, do nothing
+            break;
+        }
+      } else {
+        addObject(world, name, shape, pose);
+      }
     }
   }
+}
+
+void moveit_rviz_plugin::PlanningFrame::addObject(collision_detection::CollisionWorldPtr world, const std::string &id, const shapes::ShapeConstPtr &shape, const Eigen::Affine3d &pose)
+{
+  world->addToObject(id, shape, pose);
+  populateCollisionObjectsList();
+  planning_display_->queueRenderSceneGeometry();
 }
 
 void moveit_rviz_plugin::PlanningFrame::removeObjectButtonClicked(void)


### PR DESCRIPTION
The current behavior was to previously remove the object if already existing. But for some scenes we would need to include multiple instances of a same object (e.g. boxes at different scales, etc.)
