### PR TITLE
Interactive Markers for setting objects pose

### DIFF
--- a/visualization/moveit_rviz_plugin/include/moveit_rviz_plugin/planning_frame.h
+++ b/visualization/moveit_rviz_plugin/include/moveit_rviz_plugin/planning_frame.h
@@ -38,6 +38,9 @@
 #include <move_group_interface/move_group.h>
 #include <moveit/warehouse/planning_scene_storage.h>
 #include <planning_scene_monitor/planning_scene_monitor.h>
+#include <interactive_markers/interactive_marker_server.h>
+
+#include <map>
 
 namespace rviz
 {
@@ -80,6 +83,9 @@ protected:
 
   boost::shared_ptr<move_group_interface::MoveGroup::Plan> current_plan_;
   boost::shared_ptr<moveit_warehouse::PlanningSceneStorage> planning_scene_storage_;
+
+  boost::shared_ptr<interactive_markers::InteractiveMarkerServer> interactive_marker_server_;
+  std::map<std::string, visualization_msgs::InteractiveMarker> scene_markers_;
 
 private Q_SLOTS:
 
@@ -145,6 +151,8 @@ private:
   void populateConstraintsList(const std::vector<std::string> &constr);
   void configureForPlanning(void);
   
+  void imProcessFeedback(const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback);
+
   ros::NodeHandle nh_;
   ros::Publisher planning_scene_publisher_;
   

--- a/visualization/moveit_rviz_plugin/include/moveit_rviz_plugin/planning_frame.h
+++ b/visualization/moveit_rviz_plugin/include/moveit_rviz_plugin/planning_frame.h
@@ -39,6 +39,7 @@
 #include <moveit/warehouse/planning_scene_storage.h>
 #include <planning_scene_monitor/planning_scene_monitor.h>
 #include <interactive_markers/interactive_marker_server.h>
+#include <rviz/default_plugin/interactive_markers/interactive_marker.h>
 
 #include <map>
 
@@ -74,6 +75,8 @@ protected:
 
   void constructPlanningRequest(moveit_msgs::MotionPlanRequest &mreq);
   
+  void updateSceneMarkers(float wall_dt, float ros_dt);
+
   PlanningDisplay *planning_display_;  
   rviz::DisplayContext* context_;
   Ui::MotionPlanningFrame *ui_;
@@ -84,8 +87,7 @@ protected:
   boost::shared_ptr<move_group_interface::MoveGroup::Plan> current_plan_;
   boost::shared_ptr<moveit_warehouse::PlanningSceneStorage> planning_scene_storage_;
 
-  boost::shared_ptr<interactive_markers::InteractiveMarkerServer> interactive_marker_server_;
-  std::map<std::string, visualization_msgs::InteractiveMarker> scene_markers_;
+  rviz::InteractiveMarker* scene_marker_;
 
 private Q_SLOTS:
 
@@ -113,15 +115,12 @@ private Q_SLOTS:
   void sceneScaleEndChange(void);
   void removeObjectButtonClicked(void);
   void selectedCollisionObjectChanged(void);
-  void objectXValueChanged(double v);
-  void objectYValueChanged(double v);
-  void objectZValueChanged(double v);
-  void objectRXValueChanged(double v);
-  void objectRYValueChanged(double v);
-  void objectRZValueChanged(double v);
+  void objectPoseValueChanged(double value);
   void publishSceneButtonClicked(void);
   void collisionObjectNameChanged(QListWidgetItem *item);
   void pathConstraintsIndexChanged(int index);
+  void imProcessFeedback(visualization_msgs::InteractiveMarkerFeedback &feedback);
+  void tabChanged(int index);
 
 private:
 
@@ -146,12 +145,11 @@ private:
   void populatePlannersList(const moveit_msgs::PlannerInterfaceDescription &desc);
   void changePlanningGroupHelper(void);
   void populateCollisionObjectsList(void);
-  void objectPoseValueChanged(int index, double value);
   void populateConstraintsList(void);
   void populateConstraintsList(const std::vector<std::string> &constr);
   void configureForPlanning(void);
-  
-  void imProcessFeedback(const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback);
+
+  void createSceneInteractiveMarker(void);
 
   ros::NodeHandle nh_;
   ros::Publisher planning_scene_publisher_;

--- a/visualization/moveit_rviz_plugin/include/moveit_rviz_plugin/planning_frame.h
+++ b/visualization/moveit_rviz_plugin/include/moveit_rviz_plugin/planning_frame.h
@@ -87,7 +87,7 @@ protected:
   boost::shared_ptr<move_group_interface::MoveGroup::Plan> current_plan_;
   boost::shared_ptr<moveit_warehouse::PlanningSceneStorage> planning_scene_storage_;
 
-  rviz::InteractiveMarker* scene_marker_;
+  boost::shared_ptr<rviz::InteractiveMarker> scene_marker_;
 
 private Q_SLOTS:
 

--- a/visualization/moveit_rviz_plugin/src/planning_display.cpp
+++ b/visualization/moveit_rviz_plugin/src/planning_display.cpp
@@ -1424,6 +1424,7 @@ float PlanningDisplay::getStateDisplayTime(void)
 void PlanningDisplay::update(float wall_dt, float ros_dt)
 {
   int_marker_display_->update(wall_dt, ros_dt);
+  frame_->updateSceneMarkers(wall_dt, ros_dt);
   
   Display::update(wall_dt, ros_dt);
   

--- a/visualization/moveit_rviz_plugin/src/planning_frame.cpp
+++ b/visualization/moveit_rviz_plugin/src/planning_frame.cpp
@@ -37,13 +37,17 @@
 #include <kinematic_constraints/utils.h>
 #include <planning_models/conversions.h>
 #include <geometric_shapes/shape_operations.h>
+#include <interactive_markers/tools.h>
 #include <QFileDialog>
+
+#include <moveit/robot_interaction/interactive_marker_helpers.h>
 
 moveit_rviz_plugin::PlanningFrame::PlanningFrame(PlanningDisplay *pdisplay, rviz::DisplayContext *context, QWidget *parent) :
   QWidget(parent),
   planning_display_(pdisplay),
   context_(context),
-  ui_(new Ui::MotionPlanningFrame())
+  ui_(new Ui::MotionPlanningFrame()),
+  scene_marker_(NULL)
 {
   // set up the GUI
   ui_->setupUi(this);
@@ -73,21 +77,20 @@ moveit_rviz_plugin::PlanningFrame::PlanningFrame(PlanningDisplay *pdisplay, rviz
   connect( ui_->scene_scale, SIGNAL( sliderPressed() ), this, SLOT( sceneScaleStartChange() ));
   connect( ui_->scene_scale, SIGNAL( sliderReleased() ), this, SLOT( sceneScaleEndChange() ));
   connect( ui_->remove_object_button, SIGNAL( clicked() ), this, SLOT( removeObjectButtonClicked() ));
-  connect( ui_->object_x, SIGNAL( valueChanged(double) ), this, SLOT( objectXValueChanged(double) ));
-  connect( ui_->object_y, SIGNAL( valueChanged(double) ), this, SLOT( objectYValueChanged(double) ));
-  connect( ui_->object_z, SIGNAL( valueChanged(double) ), this, SLOT( objectZValueChanged(double) ));
-  connect( ui_->object_rx, SIGNAL( valueChanged(double) ), this, SLOT( objectRXValueChanged(double) ));
-  connect( ui_->object_ry, SIGNAL( valueChanged(double) ), this, SLOT( objectRYValueChanged(double) ));
-  connect( ui_->object_rz, SIGNAL( valueChanged(double) ), this, SLOT( objectRZValueChanged(double) ));
+  connect( ui_->object_x, SIGNAL( valueChanged(double) ), this, SLOT( objectPoseValueChanged(double) ));
+  connect( ui_->object_y, SIGNAL( valueChanged(double) ), this, SLOT( objectPoseValueChanged(double) ));
+  connect( ui_->object_z, SIGNAL( valueChanged(double) ), this, SLOT( objectPoseValueChanged(double) ));
+  connect( ui_->object_rx, SIGNAL( valueChanged(double) ), this, SLOT( objectPoseValueChanged(double) ));
+  connect( ui_->object_ry, SIGNAL( valueChanged(double) ), this, SLOT( objectPoseValueChanged(double) ));
+  connect( ui_->object_rz, SIGNAL( valueChanged(double) ), this, SLOT( objectPoseValueChanged(double) ));
   connect( ui_->publish_current_scene_button, SIGNAL( clicked() ), this, SLOT( publishSceneButtonClicked() ));
   connect( ui_->collision_objects_list, SIGNAL( itemSelectionChanged() ), this, SLOT( selectedCollisionObjectChanged() ));
   connect( ui_->collision_objects_list, SIGNAL( itemChanged( QListWidgetItem * ) ), this, SLOT( collisionObjectNameChanged( QListWidgetItem * ) ));
   connect( ui_->path_constraints_combo_box, SIGNAL( currentIndexChanged ( int ) ), this, SLOT( pathConstraintsIndexChanged( int ) ));
+  connect( ui_->tabWidget, SIGNAL( currentChanged ( int ) ), this, SLOT( tabChanged( int ) ));
 
   ui_->tabWidget->setCurrentIndex(0); 
   planning_scene_publisher_ = nh_.advertise<moveit_msgs::PlanningScene>("planning_scene", 1);
-
-  interactive_marker_server_.reset(new interactive_markers::InteractiveMarkerServer("interactive_scene"));
 }
 
 moveit_rviz_plugin::PlanningFrame::~PlanningFrame(void)
@@ -172,43 +175,45 @@ void moveit_rviz_plugin::PlanningFrame::populateCollisionObjectsList(void)
 
 /* Receives feedback from the interactive marker and updates the shape pose in the world accordingly */
 void  moveit_rviz_plugin::PlanningFrame::imProcessFeedback(
-    const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback )
+    visualization_msgs::InteractiveMarkerFeedback &feedback )
 {
-  ui_->object_x->setValue(feedback->pose.position.x);
-  ui_->object_y->setValue(feedback->pose.position.y);
-  ui_->object_z->setValue(feedback->pose.position.z);
-  tf::Quaternion q(feedback->pose.orientation.x, feedback->pose.orientation.y, feedback->pose.orientation.z, feedback->pose.orientation.w);
+  ui_->object_x->setValue(feedback.pose.position.x);
+  ui_->object_y->setValue(feedback.pose.position.y);
+  ui_->object_z->setValue(feedback.pose.position.z);
+  tf::Quaternion q(feedback.pose.orientation.x, feedback.pose.orientation.y, feedback.pose.orientation.z, feedback.pose.orientation.w);
 
   double yaw, pitch, roll;
   tf::Matrix3x3(q).getEulerYPR(yaw,pitch,roll);
   ui_->object_rx->setValue(roll);
   ui_->object_ry->setValue(pitch);
   ui_->object_rz->setValue(yaw);
+}
 
+void moveit_rviz_plugin::PlanningFrame::createSceneInteractiveMarker() {
   QList<QListWidgetItem *> sel = ui_->collision_objects_list->selectedItems();
   if (sel.empty())
       return;
-  if (planning_display_->getPlanningSceneMonitor())
+  if (scene_marker_==NULL)
   {
-	  collision_detection::CollisionWorldPtr world = planning_display_->getPlanningSceneMonitor()->getPlanningScene()->getCollisionWorld();
-	  collision_detection::CollisionWorld::ObjectConstPtr obj = world->getObject(sel[0]->text().toStdString());
+    // create an interactive marker for moving the shape in the world
+    visualization_msgs::InteractiveMarker int_marker=robot_interaction::make6DOFMarker(std::string("marker_")+sel[0]->text().toStdString(), geometry_msgs::PoseStamped(), 1.0);
+    int_marker.header.frame_id = context_->getFrameManager()->getFixedFrame();
+    int_marker.description = sel[0]->text().toStdString();
 
-	  Eigen::Affine3d p;
+    //Store the interactive marker in a map, access through the name on the shape
+    rviz::InteractiveMarker* imarker=new rviz::InteractiveMarker(planning_display_->getSceneNode(), context_ );
+    interactive_markers::autoComplete(int_marker);
+    imarker->processMessage(int_marker);
+    imarker->setShowAxes(false);
+    scene_marker_=imarker;
 
-	  p = Eigen::Translation3d(feedback->pose.position.x, feedback->pose.position.y, feedback->pose.position.z)*
-		  Eigen::AngleAxisd(yaw, Eigen::Vector3d::UnitZ()) *
-	      Eigen::AngleAxisd(pitch, Eigen::Vector3d::UnitY()) *
-	      Eigen::AngleAxisd(roll, Eigen::Vector3d::UnitX());
-
-	  scene_markers_[sel[0]->text().toStdString()].pose=feedback->pose;
-	  world->moveShapeInObject(obj->id_, obj->shapes_[0], p);
-	  planning_display_->queueRenderSceneGeometry();
-
+    //Connect signals
+    connect( imarker, SIGNAL( userFeedback(visualization_msgs::InteractiveMarkerFeedback &)), this, SLOT( imProcessFeedback(visualization_msgs::InteractiveMarkerFeedback &) ));
   }
 }
 
 void moveit_rviz_plugin::PlanningFrame::importSceneButtonClicked(void)
-{ 
+{
   std::string path = QFileDialog::getOpenFileName(this, "Import Scene").toStdString();
   std::string name;
 
@@ -230,55 +235,6 @@ void moveit_rviz_plugin::PlanningFrame::importSceneButtonClicked(void)
       planning_display_->queueRenderSceneGeometry();
     }
   }
-
-  // create an interactive marker for moving the shape in the world
-  visualization_msgs::InteractiveMarker int_marker;
-  int_marker.header.frame_id = context_->getFrameManager()->getFixedFrame();
-  int_marker.name = std::string("marker_")+name;
-  int_marker.description = name;
-
-  visualization_msgs::InteractiveMarkerControl control;
-  control.orientation.w = 1;
-  control.orientation.x = 1;
-  control.orientation.y = 0;
-  control.orientation.z = 0;
-  control.name = "rotate_x";
-  control.interaction_mode = visualization_msgs::InteractiveMarkerControl::ROTATE_AXIS;
-  int_marker.controls.push_back(control);
-  control.name = "move_x";
-  control.interaction_mode = visualization_msgs::InteractiveMarkerControl::MOVE_AXIS;
-  int_marker.controls.push_back(control);
-
-  control.orientation.w = 1;
-  control.orientation.x = 0;
-  control.orientation.y = 1;
-  control.orientation.z = 0;
-  control.name = "rotate_z";
-  control.interaction_mode = visualization_msgs::InteractiveMarkerControl::ROTATE_AXIS;
-  int_marker.controls.push_back(control);
-  control.name = "move_z";
-  control.interaction_mode = visualization_msgs::InteractiveMarkerControl::MOVE_AXIS;
-  int_marker.controls.push_back(control);
-
-  control.orientation.w = 1;
-  control.orientation.x = 0;
-  control.orientation.y = 0;
-  control.orientation.z = 1;
-  control.name = "rotate_y";
-  control.interaction_mode = visualization_msgs::InteractiveMarkerControl::ROTATE_AXIS;
-  int_marker.controls.push_back(control);
-  control.name = "move_y";
-  control.interaction_mode = visualization_msgs::InteractiveMarkerControl::MOVE_AXIS;
-  int_marker.controls.push_back(control);
-
-  visualization_msgs::InteractiveMarkerControl menu_control;
-  menu_control.interaction_mode = visualization_msgs::InteractiveMarkerControl::MENU;
-  menu_control.name = "Hide";
-  int_marker.controls.push_back(menu_control);
-
-  //Store the interactive marker in a map, access through the name on the shape
-  scene_markers_.insert(std::pair<std::string, visualization_msgs::InteractiveMarker>(name, int_marker));
-  interactive_marker_server_->applyChanges();
 }
 
 void moveit_rviz_plugin::PlanningFrame::removeObjectButtonClicked(void)
@@ -340,12 +296,14 @@ void moveit_rviz_plugin::PlanningFrame::selectedCollisionObjectChanged(void)
         ui_->object_rx->setValue(xyz[0]);
         ui_->object_ry->setValue(xyz[1]);
         ui_->object_rz->setValue(xyz[2]);
+      }
 
-        //Show the corresponding interactive marker
-        interactive_marker_server_->clear();
-        interactive_marker_server_->applyChanges();
-        interactive_marker_server_->insert(scene_markers_[sel[0]->text().toStdString()], boost::bind( &moveit_rviz_plugin::PlanningFrame::imProcessFeedback, this, _1 ));
-        interactive_marker_server_->applyChanges();
+      if (!scene_marker_) createSceneInteractiveMarker();
+      if (scene_marker_) {
+        Eigen::Quaterniond eq(obj->shape_poses_[0].rotation());
+        //Update the IM pose to match the current selected object
+        scene_marker_->setPose(Ogre::Vector3(obj->shape_poses_[0].translation()[0], obj->shape_poses_[0].translation()[1], obj->shape_poses_[0].translation()[2]),
+                               Ogre::Quaternion(eq.w(), eq.x(), eq.y(), eq.z()), "");
       }
     }
   }
@@ -361,37 +319,7 @@ void moveit_rviz_plugin::PlanningFrame::clearSceneButtonClicked(void)
   }
 }
 
-void moveit_rviz_plugin::PlanningFrame::objectXValueChanged(double value)
-{
-  objectPoseValueChanged(0, value);
-}
-
-void moveit_rviz_plugin::PlanningFrame::objectYValueChanged(double value)
-{
-  objectPoseValueChanged(1, value);
-}
-
-void moveit_rviz_plugin::PlanningFrame::objectZValueChanged(double value)
-{
-  objectPoseValueChanged(2, value);
-}
-
-void moveit_rviz_plugin::PlanningFrame::objectRXValueChanged(double value)
-{
-  objectPoseValueChanged(3, value);
-}
-
-void moveit_rviz_plugin::PlanningFrame::objectRYValueChanged(double value)
-{
-  objectPoseValueChanged(4, value);
-}
-
-void moveit_rviz_plugin::PlanningFrame::objectRZValueChanged(double value)
-{
-  objectPoseValueChanged(5, value);
-}
-
-void moveit_rviz_plugin::PlanningFrame::objectPoseValueChanged(int index, double value)
+void moveit_rviz_plugin::PlanningFrame::objectPoseValueChanged(double value)
 {
   QList<QListWidgetItem *> sel = ui_->collision_objects_list->selectedItems();
   if (sel.empty())
@@ -402,21 +330,25 @@ void moveit_rviz_plugin::PlanningFrame::objectPoseValueChanged(int index, double
     collision_detection::CollisionWorld::ObjectConstPtr obj = world->getObject(sel[0]->text().toStdString());
     if (obj && obj->shapes_.size() == 1)
     {
-      Eigen::Affine3d p = obj->shape_poses_[0];
-      if (index < 3)
-        p.translation()[index] = value;
-      else
-      {
-        Eigen::Vector3d xyz = obj->shape_poses_[0].rotation().eulerAngles(0, 1, 2);
-        xyz[index - 3] = value;
+      Eigen::Affine3d p;
+      p.translation()[0] = ui_->object_x->value();
+      p.translation()[1] = ui_->object_y->value();
+      p.translation()[2] = ui_->object_z->value();
 
-        p = Eigen::Translation3d(p.translation()) *
-                Eigen::AngleAxisd(xyz[0], Eigen::Vector3d::UnitX()) *
-                Eigen::AngleAxisd(xyz[1], Eigen::Vector3d::UnitY()) *
-                Eigen::AngleAxisd(xyz[2], Eigen::Vector3d::UnitZ());
-      }
+      p = Eigen::Translation3d(p.translation()) *
+          Eigen::AngleAxisd(ui_->object_rz->value(), Eigen::Vector3d::UnitZ()) *
+          Eigen::AngleAxisd(ui_->object_ry->value(), Eigen::Vector3d::UnitY()) *
+          Eigen::AngleAxisd(ui_->object_rx->value(), Eigen::Vector3d::UnitX());
+
       world->moveShapeInObject(obj->id_, obj->shapes_[0], p);  
       planning_display_->queueRenderSceneGeometry(); 
+
+      //Update the interactive marker pose to match the manually introduced one
+      if (scene_marker_) {
+        Eigen::Quaterniond eq(p.rotation());
+        scene_marker_->setPose(Ogre::Vector3(ui_->object_x->value(), ui_->object_y->value(), ui_->object_z->value()),
+                               Ogre::Quaternion(eq.w(), eq.x(), eq.y(), eq.z()), "");
+      }
     }
   }
 }
@@ -550,6 +482,14 @@ void moveit_rviz_plugin::PlanningFrame::pathConstraintsIndexChanged(int index)
       move_group_->setPathConstraints(ui_->path_constraints_combo_box->itemText(index).toStdString());
     else
       move_group_->clearPathConstraints();
+  }
+}
+
+void moveit_rviz_plugin::PlanningFrame::tabChanged(int index)
+{
+  if(scene_marker_!=NULL) {
+    delete scene_marker_;
+    scene_marker_=NULL;
   }
 }
 
@@ -704,6 +644,12 @@ void moveit_rviz_plugin::PlanningFrame::configureForPlanning(void)
                             ui_->wcenter_x->value() + ui_->wsize_x->value() / 2.0,
                             ui_->wcenter_y->value() + ui_->wsize_y->value() / 2.0,
                             ui_->wcenter_z->value() + ui_->wsize_z->value() / 2.0);
+}
+
+void moveit_rviz_plugin::PlanningFrame::updateSceneMarkers(float wall_dt, float ros_dt)
+{
+  if (scene_marker_!=NULL)
+    scene_marker_->update(wall_dt);
 }
 
 void moveit_rviz_plugin::PlanningFrame::computePlanButtonClicked(void)

--- a/visualization/moveit_rviz_plugin/src/planning_frame.cpp
+++ b/visualization/moveit_rviz_plugin/src/planning_frame.cpp
@@ -304,6 +304,11 @@ void moveit_rviz_plugin::PlanningFrame::addObject(const collision_detection::Col
 {
   world->addToObject(id, shape, pose);
   populateCollisionObjectsList();
+
+  //Automatically select the inserted object so that its IM is displayed
+  if (ui_->collision_objects_list->findItems(QString(id.c_str()), Qt::MatchExactly).size()>0)
+    ui_->collision_objects_list->setItemSelected(ui_->collision_objects_list->findItems(QString(id.c_str()), Qt::MatchExactly)[0], true);
+
   planning_display_->queueRenderSceneGeometry();
 }
 

--- a/visualization/moveit_rviz_plugin/src/planning_frame.cpp
+++ b/visualization/moveit_rviz_plugin/src/planning_frame.cpp
@@ -193,10 +193,23 @@ void moveit_rviz_plugin::PlanningFrame::createSceneInteractiveMarker() {
   QList<QListWidgetItem *> sel = ui_->collision_objects_list->selectedItems();
   if (sel.empty())
       return;
-  if (scene_marker_==NULL)
+
+  collision_detection::CollisionWorldPtr world = planning_display_->getPlanningSceneMonitor()->getPlanningScene()->getCollisionWorld();
+  collision_detection::CollisionWorld::ObjectConstPtr obj = world->getObject(sel[0]->text().toStdString());
+  if (scene_marker_==NULL && obj && obj->shapes_.size() == 1)
   {
+    Eigen::Quaterniond eq(obj->shape_poses_[0].rotation());
+    geometry_msgs::PoseStamped shape_pose;
+    shape_pose.pose.position.x=obj->shape_poses_[0].translation()[0];
+    shape_pose.pose.position.y=obj->shape_poses_[0].translation()[1];
+    shape_pose.pose.position.z=obj->shape_poses_[0].translation()[2];
+    shape_pose.pose.orientation.x=eq.x();
+    shape_pose.pose.orientation.y=eq.y();
+    shape_pose.pose.orientation.z=eq.z();
+    shape_pose.pose.orientation.w=eq.w();
+
     // create an interactive marker for moving the shape in the world
-    visualization_msgs::InteractiveMarker int_marker=robot_interaction::make6DOFMarker(std::string("marker_")+sel[0]->text().toStdString(), geometry_msgs::PoseStamped(), 1.0);
+    visualization_msgs::InteractiveMarker int_marker=robot_interaction::make6DOFMarker(std::string("marker_")+sel[0]->text().toStdString(), shape_pose, 1.0);
     int_marker.header.frame_id = context_->getFrameManager()->getFixedFrame();
     int_marker.description = sel[0]->text().toStdString();
 
@@ -296,14 +309,14 @@ void moveit_rviz_plugin::PlanningFrame::selectedCollisionObjectChanged(void)
         ui_->object_rx->setValue(xyz[0]);
         ui_->object_ry->setValue(xyz[1]);
         ui_->object_rz->setValue(xyz[2]);
-      }
 
-      if (!scene_marker_) createSceneInteractiveMarker();
-      if (scene_marker_) {
-        Eigen::Quaterniond eq(obj->shape_poses_[0].rotation());
-        //Update the IM pose to match the current selected object
-        scene_marker_->setPose(Ogre::Vector3(obj->shape_poses_[0].translation()[0], obj->shape_poses_[0].translation()[1], obj->shape_poses_[0].translation()[2]),
-                               Ogre::Quaternion(eq.w(), eq.x(), eq.y(), eq.z()), "");
+        if (!scene_marker_) createSceneInteractiveMarker();
+        if (scene_marker_) {
+          Eigen::Quaterniond eq(obj->shape_poses_[0].rotation());
+          //Update the IM pose to match the current selected object
+          scene_marker_->setPose(Ogre::Vector3(obj->shape_poses_[0].translation()[0], obj->shape_poses_[0].translation()[1], obj->shape_poses_[0].translation()[2]),
+                                 Ogre::Quaternion(eq.w(), eq.x(), eq.y(), eq.z()), "");
+        }
       }
     }
   }
@@ -487,9 +500,11 @@ void moveit_rviz_plugin::PlanningFrame::pathConstraintsIndexChanged(int index)
 
 void moveit_rviz_plugin::PlanningFrame::tabChanged(int index)
 {
-  if(scene_marker_!=NULL) {
+  if(scene_marker_!=NULL && index!=3) {
     delete scene_marker_;
     scene_marker_=NULL;
+  } else if (index==3){
+    createSceneInteractiveMarker();
   }
 }
 

--- a/visualization/moveit_rviz_plugin/src/planning_frame.cpp
+++ b/visualization/moveit_rviz_plugin/src/planning_frame.cpp
@@ -48,8 +48,7 @@ moveit_rviz_plugin::PlanningFrame::PlanningFrame(PlanningDisplay *pdisplay, rviz
   QWidget(parent),
   planning_display_(pdisplay),
   context_(context),
-  ui_(new Ui::MotionPlanningFrame()),
-  scene_marker_(NULL)
+  ui_(new Ui::MotionPlanningFrame())
 {
   // set up the GUI
   ui_->setupUi(this);
@@ -192,14 +191,15 @@ void  moveit_rviz_plugin::PlanningFrame::imProcessFeedback(
   ui_->object_rz->setValue(yaw);
 }
 
-void moveit_rviz_plugin::PlanningFrame::createSceneInteractiveMarker() {
+void moveit_rviz_plugin::PlanningFrame::createSceneInteractiveMarker()
+{
   QList<QListWidgetItem *> sel = ui_->collision_objects_list->selectedItems();
   if (sel.empty())
       return;
 
   collision_detection::CollisionWorldPtr world = planning_display_->getPlanningSceneMonitor()->getPlanningScene()->getCollisionWorld();
   collision_detection::CollisionWorld::ObjectConstPtr obj = world->getObject(sel[0]->text().toStdString());
-  if (scene_marker_==NULL && obj && obj->shapes_.size() == 1)
+  if (!scene_marker_ && obj && obj->shapes_.size() == 1)
   {
     Eigen::Quaterniond eq(obj->shape_poses_[0].rotation());
     geometry_msgs::PoseStamped shape_pose;
@@ -221,7 +221,7 @@ void moveit_rviz_plugin::PlanningFrame::createSceneInteractiveMarker() {
     interactive_markers::autoComplete(int_marker);
     imarker->processMessage(int_marker);
     imarker->setShowAxes(false);
-    scene_marker_=imarker;
+    scene_marker_.reset(imarker);
 
     //Connect signals
     connect( imarker, SIGNAL( userFeedback(visualization_msgs::InteractiveMarkerFeedback &)), this, SLOT( imProcessFeedback(visualization_msgs::InteractiveMarkerFeedback &) ));
@@ -322,8 +322,7 @@ void moveit_rviz_plugin::PlanningFrame::removeObjectButtonClicked(void)
     collision_detection::CollisionWorldPtr world = planning_display_->getPlanningSceneMonitor()->getPlanningScene()->getCollisionWorld();
     for (int i = 0 ; i < sel.count() ; ++i)
       world->removeObject(sel[i]->text().toStdString());
-    delete scene_marker_;
-    scene_marker_=NULL;
+    scene_marker_.reset();
     populateCollisionObjectsList();
     planning_display_->queueRenderSceneGeometry(); 
   }
@@ -375,7 +374,8 @@ void moveit_rviz_plugin::PlanningFrame::selectedCollisionObjectChanged(void)
         ui_->object_rz->setValue(xyz[2]);
 
         if (!scene_marker_) createSceneInteractiveMarker();
-        if (scene_marker_) {
+        if (scene_marker_)
+        {
           Eigen::Quaterniond eq(obj->shape_poses_[0].rotation());
           //Update the IM pose to match the current selected object
           scene_marker_->setPose(Ogre::Vector3(obj->shape_poses_[0].translation()[0], obj->shape_poses_[0].translation()[1], obj->shape_poses_[0].translation()[2]),
@@ -421,7 +421,8 @@ void moveit_rviz_plugin::PlanningFrame::objectPoseValueChanged(double value)
       planning_display_->queueRenderSceneGeometry(); 
 
       //Update the interactive marker pose to match the manually introduced one
-      if (scene_marker_) {
+      if (scene_marker_)
+      {
         Eigen::Quaterniond eq(p.rotation());
         scene_marker_->setPose(Ogre::Vector3(ui_->object_x->value(), ui_->object_y->value(), ui_->object_z->value()),
                                Ogre::Quaternion(eq.w(), eq.x(), eq.y(), eq.z()), "");
@@ -564,12 +565,10 @@ void moveit_rviz_plugin::PlanningFrame::pathConstraintsIndexChanged(int index)
 
 void moveit_rviz_plugin::PlanningFrame::tabChanged(int index)
 {
-  if(scene_marker_!=NULL && index!=3) {
-    delete scene_marker_;
-    scene_marker_=NULL;
-  } else if (index==3){
+  if(scene_marker_ && index!=3)
+    scene_marker_.reset();
+  else if (index==3)
     createSceneInteractiveMarker();
-  }
 }
 
 void moveit_rviz_plugin::PlanningFrame::planningAlgorithmIndexChanged(int index)
@@ -765,7 +764,7 @@ void moveit_rviz_plugin::PlanningFrame::configureForPlanning(void)
 
 void moveit_rviz_plugin::PlanningFrame::updateSceneMarkers(float wall_dt, float ros_dt)
 {
-  if (scene_marker_!=NULL)
+  if (scene_marker_)
     scene_marker_->update(wall_dt);
 }
 

--- a/visualization/moveit_rviz_plugin/src/planning_frame.cpp
+++ b/visualization/moveit_rviz_plugin/src/planning_frame.cpp
@@ -322,6 +322,8 @@ void moveit_rviz_plugin::PlanningFrame::removeObjectButtonClicked(void)
     collision_detection::CollisionWorldPtr world = planning_display_->getPlanningSceneMonitor()->getPlanningScene()->getCollisionWorld();
     for (int i = 0 ; i < sel.count() ; ++i)
       world->removeObject(sel[i]->text().toStdString());
+    delete scene_marker_;
+    scene_marker_=NULL;
     populateCollisionObjectsList();
     planning_display_->queueRenderSceneGeometry(); 
   }

--- a/visualization/moveit_rviz_plugin/src/planning_frame.cpp
+++ b/visualization/moveit_rviz_plugin/src/planning_frame.cpp
@@ -86,6 +86,8 @@ moveit_rviz_plugin::PlanningFrame::PlanningFrame(PlanningDisplay *pdisplay, rviz
 
   ui_->tabWidget->setCurrentIndex(0); 
   planning_scene_publisher_ = nh_.advertise<moveit_msgs::PlanningScene>("planning_scene", 1);
+
+  interactive_marker_server_.reset(new interactive_markers::InteractiveMarkerServer("interactive_scene"));
 }
 
 moveit_rviz_plugin::PlanningFrame::~PlanningFrame(void)
@@ -168,9 +170,48 @@ void moveit_rviz_plugin::PlanningFrame::populateCollisionObjectsList(void)
   ui_->collision_objects_list->setUpdatesEnabled(true);
 }
 
+/* Receives feedback from the interactive marker and updates the shape pose in the world accordingly */
+void  moveit_rviz_plugin::PlanningFrame::imProcessFeedback(
+    const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback )
+{
+  ui_->object_x->setValue(feedback->pose.position.x);
+  ui_->object_y->setValue(feedback->pose.position.y);
+  ui_->object_z->setValue(feedback->pose.position.z);
+  tf::Quaternion q(feedback->pose.orientation.x, feedback->pose.orientation.y, feedback->pose.orientation.z, feedback->pose.orientation.w);
+
+  double yaw, pitch, roll;
+  tf::Matrix3x3(q).getEulerYPR(yaw,pitch,roll);
+  ui_->object_rx->setValue(roll);
+  ui_->object_ry->setValue(pitch);
+  ui_->object_rz->setValue(yaw);
+
+  QList<QListWidgetItem *> sel = ui_->collision_objects_list->selectedItems();
+  if (sel.empty())
+      return;
+  if (planning_display_->getPlanningSceneMonitor())
+  {
+	  collision_detection::CollisionWorldPtr world = planning_display_->getPlanningSceneMonitor()->getPlanningScene()->getCollisionWorld();
+	  collision_detection::CollisionWorld::ObjectConstPtr obj = world->getObject(sel[0]->text().toStdString());
+
+	  Eigen::Affine3d p;
+
+	  p = Eigen::Translation3d(feedback->pose.position.x, feedback->pose.position.y, feedback->pose.position.z)*
+		  Eigen::AngleAxisd(yaw, Eigen::Vector3d::UnitZ()) *
+	      Eigen::AngleAxisd(pitch, Eigen::Vector3d::UnitY()) *
+	      Eigen::AngleAxisd(roll, Eigen::Vector3d::UnitX());
+
+	  scene_markers_[sel[0]->text().toStdString()].pose=feedback->pose;
+	  world->moveShapeInObject(obj->id_, obj->shapes_[0], p);
+	  planning_display_->queueRenderSceneGeometry();
+
+  }
+}
+
 void moveit_rviz_plugin::PlanningFrame::importSceneButtonClicked(void)
 { 
   std::string path = QFileDialog::getOpenFileName(this, "Import Scene").toStdString();
+  std::string name;
+
   if (!path.empty() && planning_display_->getPlanningSceneMonitor())
   {
     path = "file://" + path;
@@ -178,7 +219,7 @@ void moveit_rviz_plugin::PlanningFrame::importSceneButtonClicked(void)
     if (mesh)
     {
       std::size_t slash = path.find_last_of("/");
-      std::string name = path.substr(slash + 1);
+      name = path.substr(slash + 1);
       shapes::ShapeConstPtr shape(mesh);
       Eigen::Affine3d pose;
       pose.setIdentity();
@@ -189,6 +230,55 @@ void moveit_rviz_plugin::PlanningFrame::importSceneButtonClicked(void)
       planning_display_->queueRenderSceneGeometry();
     }
   }
+
+  // create an interactive marker for moving the shape in the world
+  visualization_msgs::InteractiveMarker int_marker;
+  int_marker.header.frame_id = context_->getFrameManager()->getFixedFrame();
+  int_marker.name = std::string("marker_")+name;
+  int_marker.description = name;
+
+  visualization_msgs::InteractiveMarkerControl control;
+  control.orientation.w = 1;
+  control.orientation.x = 1;
+  control.orientation.y = 0;
+  control.orientation.z = 0;
+  control.name = "rotate_x";
+  control.interaction_mode = visualization_msgs::InteractiveMarkerControl::ROTATE_AXIS;
+  int_marker.controls.push_back(control);
+  control.name = "move_x";
+  control.interaction_mode = visualization_msgs::InteractiveMarkerControl::MOVE_AXIS;
+  int_marker.controls.push_back(control);
+
+  control.orientation.w = 1;
+  control.orientation.x = 0;
+  control.orientation.y = 1;
+  control.orientation.z = 0;
+  control.name = "rotate_z";
+  control.interaction_mode = visualization_msgs::InteractiveMarkerControl::ROTATE_AXIS;
+  int_marker.controls.push_back(control);
+  control.name = "move_z";
+  control.interaction_mode = visualization_msgs::InteractiveMarkerControl::MOVE_AXIS;
+  int_marker.controls.push_back(control);
+
+  control.orientation.w = 1;
+  control.orientation.x = 0;
+  control.orientation.y = 0;
+  control.orientation.z = 1;
+  control.name = "rotate_y";
+  control.interaction_mode = visualization_msgs::InteractiveMarkerControl::ROTATE_AXIS;
+  int_marker.controls.push_back(control);
+  control.name = "move_y";
+  control.interaction_mode = visualization_msgs::InteractiveMarkerControl::MOVE_AXIS;
+  int_marker.controls.push_back(control);
+
+  visualization_msgs::InteractiveMarkerControl menu_control;
+  menu_control.interaction_mode = visualization_msgs::InteractiveMarkerControl::MENU;
+  menu_control.name = "Hide";
+  int_marker.controls.push_back(menu_control);
+
+  //Store the interactive marker in a map, access through the name on the shape
+  scene_markers_.insert(std::pair<std::string, visualization_msgs::InteractiveMarker>(name, int_marker));
+  interactive_marker_server_->applyChanges();
 }
 
 void moveit_rviz_plugin::PlanningFrame::removeObjectButtonClicked(void)
@@ -250,6 +340,12 @@ void moveit_rviz_plugin::PlanningFrame::selectedCollisionObjectChanged(void)
         ui_->object_rx->setValue(xyz[0]);
         ui_->object_ry->setValue(xyz[1]);
         ui_->object_rz->setValue(xyz[2]);
+
+        //Show the corresponding interactive marker
+        interactive_marker_server_->clear();
+        interactive_marker_server_->applyChanges();
+        interactive_marker_server_->insert(scene_markers_[sel[0]->text().toStdString()], boost::bind( &moveit_rviz_plugin::PlanningFrame::imProcessFeedback, this, _1 ));
+        interactive_marker_server_->applyChanges();
       }
     }
   }
@@ -313,10 +409,11 @@ void moveit_rviz_plugin::PlanningFrame::objectPoseValueChanged(int index, double
       {
         Eigen::Vector3d xyz = obj->shape_poses_[0].rotation().eulerAngles(0, 1, 2);
         xyz[index - 3] = value;
-        p = Eigen::Translation3d(p.translation()) * 
-          Eigen::AngleAxisd(xyz[0], Eigen::Vector3d::UnitX()) * 
-          Eigen::AngleAxisd(xyz[1], Eigen::Vector3d::UnitY()) * 
-          Eigen::AngleAxisd(xyz[2], Eigen::Vector3d::UnitZ());
+
+        p = Eigen::Translation3d(p.translation()) *
+                Eigen::AngleAxisd(xyz[0], Eigen::Vector3d::UnitX()) *
+                Eigen::AngleAxisd(xyz[1], Eigen::Vector3d::UnitY()) *
+                Eigen::AngleAxisd(xyz[2], Eigen::Vector3d::UnitZ());
       }
       world->moveShapeInObject(obj->id_, obj->shapes_[0], p);  
       planning_display_->queueRenderSceneGeometry(); 


### PR DESCRIPTION
This pull request adds the functionality for setting an object pose (when creating a planning scene) using interactive markers. It is a new layer on top of the existing manual approach where the user could introduce the position and orientation numbers directly. Now the user can do it manually as before, or dragging the interactive marker, which automatically fills the position and orientation fields. The interactive markers are created by a direct instantiation of the rviz InteractiveMarker class, without requiring a server and a display. This is done thanks to the InteractiveMarker class refactoring recently introduced in rviz.
