### PR TITLE
Improvements in visualization of goal pose makers

### DIFF
--- a/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -188,6 +188,7 @@ private Q_SLOTS:
   void goalPoseSelectionChanged();
   void goalPoseDoubleClicked(QListWidgetItem *item);
   void copySelectedGoalPoses(void);
+  void visibleAxisChanged(int state);
 
   //Slots for start states
   void saveStartStateButtonClicked(void);
@@ -255,7 +256,7 @@ private:
                                              const geometry_msgs::Pose &pose,
                                              double scale,
                                              bool selected = false);
- 
+
   void selectItemJob(QListWidgetItem *item, bool flag);
   void displayMessageBox(const QString &title, const QString &text);
   void updateMarkerColorFromName(const std::string & name, float r, float g, float b, float a);

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -179,9 +179,9 @@ MotionPlanningFrame::MsgMarkerPair MotionPlanningFrame::make6DOFEndEffectorMarke
   visualization_msgs::InteractiveMarkerControl m_control;
   m_control.always_visible = true;
   m_control.interaction_mode = m_control.BUTTON;
-  if (selected)
+  if (selected && ui_->goal_poses_list->selectedItems().size() == 1)
   {
-    //If selected, display the actual end effector mesh
+    //If selected (and only one selected), display the actual end effector mesh
     const kinematic_state::JointStateGroup *joint_state_group = planning_display_->getQueryGoalState()->getJointStateGroup(eef.eef_group);
     const kinematic_state::KinematicState *kinematic_state = joint_state_group->getKinematicState();
 

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -129,6 +129,9 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay *pdisplay, rviz::
   connect( ui_->goal_poses_save_button, SIGNAL( clicked() ), this, SLOT( saveGoalsOnDBButtonClicked() ));
   connect( ui_->goal_poses_list, SIGNAL( itemSelectionChanged() ), this, SLOT( goalPoseSelectionChanged() ));
   connect( ui_->goal_poses_list, SIGNAL( itemDoubleClicked(QListWidgetItem *) ), this, SLOT( goalPoseDoubleClicked(QListWidgetItem *) ));
+  connect( ui_->show_x_checkbox, SIGNAL( stateChanged( int ) ), this, SLOT( visibleAxisChanged( int ) ));
+  connect( ui_->show_y_checkbox, SIGNAL( stateChanged( int ) ), this, SLOT( visibleAxisChanged( int ) ));
+  connect( ui_->show_z_checkbox, SIGNAL( stateChanged( int ) ), this, SLOT( visibleAxisChanged( int ) ));
   
   QShortcut *copy_goals_shortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_C), ui_->goal_poses_list);
   connect(copy_goals_shortcut, SIGNAL( activated() ), this, SLOT( copySelectedGoalPoses() ) );
@@ -224,30 +227,40 @@ MotionPlanningFrame::MsgMarkerPair MotionPlanningFrame::make6DOFEndEffectorMarke
     m.scale.z = 0.1 * m.scale.x;
     m.ns = "goal_pose_marker";
     m.action = visualization_msgs::Marker::ADD;
-    m.color.r = 1.0f;
-    m.color.g = 0.0f;
-    m.color.b = 0.0f;
-    m.color.a = 1.0f;
-    m_control.markers.push_back(m);
+
+    if (ui_->show_x_checkbox->isChecked())
+    {
+      m.color.r = 1.0f;
+      m.color.g = 0.0f;
+      m.color.b = 0.0f;
+      m.color.a = 1.0f;
+      m_control.markers.push_back(m);
+    }
 
     //Y axis
-    tf::Quaternion imq;
-    imq = tf::createQuaternionFromRPY(0, 0, boost::math::constants::pi<double>() / 2.0);
-    tf::quaternionTFToMsg(imq, m.pose.orientation);
-    m.color.r = 0.0f;
-    m.color.g = 1.0f;
-    m.color.b = 0.0f;
-    m.color.a = 1.0f;
-    m_control.markers.push_back(m);
+    if (ui_->show_y_checkbox->isChecked())
+    {
+      tf::Quaternion imq;
+      imq = tf::createQuaternionFromRPY(0, 0, boost::math::constants::pi<double>() / 2.0);
+      tf::quaternionTFToMsg(imq, m.pose.orientation);
+      m.color.r = 0.0f;
+      m.color.g = 1.0f;
+      m.color.b = 0.0f;
+      m.color.a = 1.0f;
+      m_control.markers.push_back(m);
+    }
 
     //Z axis
-    imq = tf::createQuaternionFromRPY(0, -boost::math::constants::pi<double>() / 2.0, 0);
-    tf::quaternionTFToMsg(imq, m.pose.orientation);
-    m.color.r = 0.0f;
-    m.color.g = 0.0f;
-    m.color.b = 1.0f;
-    m.color.a = 1.0f;
-    m_control.markers.push_back(m);
+    if (ui_->show_z_checkbox->isChecked()) {
+      tf::Quaternion imq;
+      imq = tf::createQuaternionFromRPY(0, -boost::math::constants::pi<double>() / 2.0, 0);
+      tf::quaternionTFToMsg(imq, m.pose.orientation);
+      m.color.r = 0.0f;
+      m.color.g = 0.0f;
+      m.color.b = 1.0f;
+      m.color.a = 1.0f;
+      m_control.markers.push_back(m);
+    }
   }
   int_marker.controls.push_back(m_control);
 
@@ -636,6 +649,29 @@ void MotionPlanningFrame::deleteStatesOnDBButtonClicked(void)
   removeSelectedStatesButtonClicked();
 }
 
+void MotionPlanningFrame::visibleAxisChanged(int state)
+{
+  if ( ! planning_display_->getRobotInteraction()->getActiveEndEffectors().empty() )
+  {
+    for (GoalPoseMap::iterator it = goal_poses_.begin(); it != goal_poses_.end(); ++it)
+    {
+      Ogre::Vector3 position = it->second.imarker->getPosition();
+      Ogre::Quaternion orientation = it->second.imarker->getOrientation();
+
+      MsgMarkerPair marker_pair;
+      marker_pair = make6DOFEndEffectorMarker(it->first,
+                                              planning_display_->getRobotInteraction()->getActiveEndEffectors()[0],
+                                              it->second.imarker_msg.pose, it->second.imarker_msg.scale, it->second.selected);
+
+      connect( marker_pair.second.get(), SIGNAL( userFeedback(visualization_msgs::InteractiveMarkerFeedback &)), this, SLOT( goalPoseFeedback(visualization_msgs::InteractiveMarkerFeedback &) ));
+
+      marker_pair.second->setPose(position, orientation, "");
+      it->second.imarker_msg = marker_pair.first;
+      it->second.imarker = marker_pair.second;
+    }
+  }
+}
+
 void MotionPlanningFrame::populateGoalPosesList(void) 
 {
   ui_->goal_poses_list->clear();
@@ -751,14 +787,20 @@ void MotionPlanningFrame::goalPoseFeedback(visualization_msgs::InteractiveMarker
 
   if (feedback.event_type == feedback.BUTTON_CLICK)
   {
-    //Unselect all but the clicked one
+    //Unselect all but the clicked one. Needs to be in order, first unselect, then select.
+    QListWidgetItem *item = 0;
     for (unsigned int i = 0; i < ui_->goal_poses_list->count(); ++i)
     {
-      QListWidgetItem *item = ui_->goal_poses_list->item(i);
+      item = ui_->goal_poses_list->item(i);
+      if ( item->text().toStdString() != feedback.marker_name)
+        planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::selectItemJob, this, item, false));
+    }
+
+    for (unsigned int i = 0; i < ui_->goal_poses_list->count(); ++i)
+    {
+      item = ui_->goal_poses_list->item(i);
       if (item->text().toStdString() == feedback.marker_name)
         planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::selectItemJob, this, item, true));
-      else
-        planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::selectItemJob, this, item, false));
     }
   }
   else if (feedback.event_type == feedback.MOUSE_DOWN)

--- a/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -26,7 +26,7 @@
       <bool>false</bool>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>4</number>
      </property>
      <widget class="QWidget" name="context">
       <attribute name="title">
@@ -1026,18 +1026,39 @@
           <string>End-Effector Goal Poses</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_7">
-          <item row="7" column="0" colspan="2">
-           <widget class="QListWidget" name="goal_poses_list">
-            <property name="toolTip">
-             <string>Press Ctrl+C to duplicate the selected goals</string>
-            </property>
-            <property name="editTriggers">
-             <set>QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed</set>
-            </property>
-            <property name="selectionMode">
-             <enum>QAbstractItemView::ExtendedSelection</enum>
-            </property>
-           </widget>
+          <item row="10" column="0">
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QCheckBox" name="show_x_checkbox">
+              <property name="text">
+               <string>Show X</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="show_y_checkbox">
+              <property name="text">
+               <string>Show Y</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="show_z_checkbox">
+              <property name="text">
+               <string>Show Z</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item row="6" column="0">
            <layout class="QHBoxLayout" name="horizontalLayout_13">
@@ -1132,6 +1153,19 @@
              </widget>
             </item>
            </layout>
+          </item>
+          <item row="7" column="0" colspan="2">
+           <widget class="QListWidget" name="goal_poses_list">
+            <property name="toolTip">
+             <string>Press Ctrl+C to duplicate the selected goals</string>
+            </property>
+            <property name="editTriggers">
+             <set>QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed</set>
+            </property>
+            <property name="selectionMode">
+             <enum>QAbstractItemView::ExtendedSelection</enum>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
- Load the gripper mesh only if one goal is selected. Things were becoming very slow with multiple grippers loaded
- Checkboxes to select which axis of the goal pose coordinate system to display
