### PR TITLE
Disabled repearting published debug info

### DIFF
--- a/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -287,7 +287,7 @@ void planning_scene_monitor::PlanningSceneMonitor::scenePublishingThread(void)
     if (have_diff)
     {
       planning_scene_publisher_.publish(msg);
-      ROS_DEBUG("Published planning scene diff: '%s'", msg.name.c_str());
+      //ROS_DEBUG("Published planning scene diff: '%s'", msg.name.c_str());
       rate.sleep(); 
     } 
     else


### PR DESCRIPTION
Super small change to prevent the planning_scene_monitor from continuously publishing debug information every time it publishes. This debug info can be found elsewhere by setting rosout or roscpp to debug instead.
