### PR TITLE
Benchmark visualization

### DIFF
--- a/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -219,6 +219,7 @@ private Q_SLOTS:
   void visibleAxisChanged(int state);
   void checkGoalsInCollision(void);
   void checkGoalsReachable(void);
+  void loadBenchmarkResults(void);
 
   void saveStartStateButtonClicked(void);
   void removeSelectedStatesButtonClicked(void);
@@ -291,6 +292,7 @@ private:
   void checkIfGoalInCollision(const std::string & goal_name);
   void checkIfGoalInCollision(const kinematic_state::KinematicStatePtr &work_state, const std::string & goal_name);
   void checkIfGoalReachable(const kinematic_state::KinematicStatePtr &work_state, const std::string &goal_name);
+  void computeLoadBenchmarkResults(const std::string &file);
 
   //General
   void changePlanningGroupHelper(void);

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -116,6 +116,7 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay *pdisplay, rviz::
   connect( ui_->show_z_checkbox, SIGNAL( stateChanged( int ) ), this, SLOT( visibleAxisChanged( int ) ));
   connect( ui_->check_goal_collisions_button, SIGNAL( clicked( ) ), this, SLOT( checkGoalsInCollision( ) ));
   connect( ui_->check_goal_reachability_button, SIGNAL( clicked( ) ), this, SLOT( checkGoalsReachable( ) ));
+  connect( ui_->load_results_button, SIGNAL( clicked( ) ), this, SLOT( loadBenchmarkResults( ) ));
 
   QShortcut *copy_goals_shortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_C), ui_->goal_poses_list);
   connect(copy_goals_shortcut, SIGNAL( activated() ), this, SLOT( copySelectedGoalPoses() ) );

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -332,20 +332,20 @@ void MotionPlanningFrame::disable(void)
 
 void MotionPlanningFrame::tabChanged(int index)
 {
-  if (scene_marker_ && index != 2)
+  if (scene_marker_ && ui_->tabWidget->tabText(index) != "Scene Objects")
     scene_marker_.reset();
   else
-    if (index == 2)
+    if (ui_->tabWidget->tabText(index) == "Scene Objects")
       selectedCollisionObjectChanged();
 
   //Create goals when entering the goals tab. Destroy them when exiting that tab
-  if (index != 4)
+  if (ui_->tabWidget->tabText(index) != "Stored Queries")
   {
     for (GoalPoseMap::iterator it = goal_poses_.begin(); it !=  goal_poses_.end(); it++)
       it->second.hide();
   }
   else
-    if (index == 4)
+    if (ui_->tabWidget->tabText(index) == "Stored Queries")
       for (unsigned int i = 0; i < ui_->goal_poses_list->count() ; ++i)
       {
         QListWidgetItem *item = ui_->goal_poses_list->item(i);

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_queries.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_queries.cpp
@@ -1102,9 +1102,18 @@ void MotionPlanningFrame::loadBenchmarkResults(void)
 
 void MotionPlanningFrame::computeLoadBenchmarkResults(const std::string &file)
 {
-  std::string logid = file.substr( file.find_last_of(".", file.length()-5) + 1, file.find_last_of(".") - file.find_last_of(".", file.length()-5) - 1 );
-  std::string basename = file.substr(0, file.find_last_of(".", file.length()-5));
-  std::string logid_text = logid.substr(logid.find_first_of("_"), logid.length() - logid.find_first_of("_"));
+  std::string logid, basename, logid_text;
+  try
+  {
+    logid = file.substr( file.find_last_of(".", file.length()-5) + 1, file.find_last_of(".") - file.find_last_of(".", file.length()-5) - 1 );
+    basename = file.substr(0, file.find_last_of(".", file.length()-5));
+    logid_text = logid.substr(logid.find_first_of("_"), logid.length() - logid.find_first_of("_"));
+  }
+  catch (...)
+  {
+    ROS_ERROR("Invalid benchmark log file. Cannot load results.");
+    return;
+  }
 
   int count = 1;
   bool more_files = true;

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_queries.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_queries.cpp
@@ -46,6 +46,7 @@
 
 #include <QMessageBox>
 #include <QInputDialog>
+#include <QFileDialog>
 
 #include "ui_motion_planning_rviz_plugin_frame.h"
 
@@ -1087,6 +1088,113 @@ void MotionPlanningFrame::startStateItemDoubleClicked(QListWidgetItem * item)
   kinematic_state::KinematicStatePtr ks(new kinematic_state::KinematicState(*planning_display_->getQueryStartState()));
   kinematic_state::robotStateToKinematicState(start_states_[item->text().toStdString()].state_msg, *ks);
   planning_display_->setQueryStartState(ks);
+}
+
+void MotionPlanningFrame::loadBenchmarkResults(void)
+{
+  //Select a log file of the set.
+  QString path = QFileDialog::getOpenFileName(this, tr("Select a log file in the set"), tr(""), tr("Log files (*.log)"));
+  if (!path.isEmpty()) {
+    std::string robot_scene_name = planning_display_->getKinematicModel()->getName() + "_" + planning_display_->getPlanningSceneRO()->getName();
+    std::replace( robot_scene_name.begin(), robot_scene_name.end(), ' ', '_');
+    if (path.toStdString().find(robot_scene_name.c_str()) != std::string::npos) {
+      planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computeLoadBenchmarkResults, this, path.toStdString()));
+    }
+    else
+    {
+      QMessageBox::warning(this, "Cannot load results", QString("The results where not generated for the robot and scene currently loaded'"));
+    }
+  }
+}
+
+void MotionPlanningFrame::computeLoadBenchmarkResults(const std::string &file)
+{
+  file.find_last_of(".", file.length()-5);
+
+  std::string logid = file.substr( file.find_last_of(".", file.length()-5) + 1, file.find_last_of(".") - file.find_last_of(".", file.length()-5) - 1 );
+  std::string basename = file.substr(0, file.find_last_of(".", file.length()-5));
+
+  std::string logid_number = logid.substr(0, logid.find_first_of("_"));
+  std::string logid_text = logid.substr(logid.find_first_of("_"), logid.length() - logid.find_first_of("_"));
+
+  int count = 1;
+  bool more_files = true;
+  //Parse all of the set
+  do
+  {
+    std::ifstream ifile;
+    std::stringstream file_to_load;
+    file_to_load << basename << "." << count << logid_text << ".log";
+
+    ifile.open(file_to_load.str().c_str());
+    if (ifile.good()) {
+      //Parse results
+      char text_line[512];
+      static std::streamsize text_line_length = 512;
+      bool valid_file = false;
+      ifile.getline(text_line, text_line_length);
+      while (ifile.good())
+      {
+        std::string line(text_line);
+        if (line.find("total_time REAL") != std::string::npos)
+        {
+          valid_file = true;
+          break;
+        }
+
+        ifile.getline(text_line, text_line_length);
+      }
+
+      if (valid_file && ifile.good())
+      {
+        ifile.getline(text_line, text_line_length);
+        if (ifile.good())
+        {
+          //This should be the reachability results line composed of reachable, collision-free and time fields (bool; bool; float)
+          bool reachable = boost::lexical_cast<bool>(text_line[0]);
+          bool collision_free = boost::lexical_cast<bool>(text_line[3]);
+
+          //Update colors accordingly
+          std::string goal_name = ui_->goal_poses_list->item(count-1)->text().toStdString();
+          if (reachable)
+          {
+            if (collision_free)
+            {
+              //Reachable and collision-free
+              goal_poses_[goal_name].reachable = GoalPoseMarker::REACHABLE;
+              planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::updateMarkerColorFromName, this, goal_name,
+                                                            GOAL_REACHABLE_COLOR[0], GOAL_REACHABLE_COLOR[1], GOAL_REACHABLE_COLOR[2], GOAL_REACHABLE_COLOR[3]));
+            }
+            else
+            {
+              //Reachable, but in collision
+              goal_poses_[goal_name].reachable = GoalPoseMarker::IN_COLLISION;
+              planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::updateMarkerColorFromName, this, goal_name,
+                                                            GOAL_COLLISION_COLOR[0], GOAL_COLLISION_COLOR[1], GOAL_COLLISION_COLOR[2], GOAL_COLLISION_COLOR[3]));
+            }
+          }
+          else
+          {
+            //Not reachable
+              goal_poses_[goal_name].reachable = GoalPoseMarker::NOT_REACHABLE;
+              planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::updateMarkerColorFromName, this, goal_name,
+                                                            GOAL_NOT_REACHABLE_COLOR[0], GOAL_NOT_REACHABLE_COLOR[1], GOAL_NOT_REACHABLE_COLOR[2], GOAL_NOT_REACHABLE_COLOR[3]));
+          }
+        }
+      }
+      else
+      {
+        ROS_ERROR("Invalid benchmark log file");
+      }
+
+      ifile.close();
+    }
+    else
+    {
+      more_files = false;
+    }
+    count++;
+  } while (more_files);
 }
 
 }

--- a/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>676</width>
-    <height>338</height>
+    <height>354</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -696,7 +696,7 @@
         </widget>
        </item>
        <item row="2" column="1">
-        <widget class="QGroupBox" name="">
+        <widget class="QGroupBox" name="groupBox">
          <property name="title">
           <string>Scene Geometry</string>
          </property>
@@ -1201,14 +1201,24 @@
             <item>
              <widget class="QPushButton" name="check_goal_collisions_button">
               <property name="text">
-               <string>Check collisions</string>
+               <string>Check
+collisions</string>
               </property>
              </widget>
             </item>
             <item>
              <widget class="QPushButton" name="check_goal_reachability_button">
               <property name="text">
-               <string>Check reachability</string>
+               <string>Check
+reachability</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="load_results_button">
+              <property name="text">
+               <string>Load
+results</string>
               </property>
              </widget>
             </item>

--- a/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>676</width>
-    <height>354</height>
+    <height>338</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -696,7 +696,7 @@
         </widget>
        </item>
        <item row="2" column="1">
-        <widget class="QGroupBox" name="groupBox">
+        <widget class="QGroupBox" name="">
          <property name="title">
           <string>Scene Geometry</string>
          </property>


### PR DESCRIPTION
This will add a new button to the queries tab that allows users to load benchmark log files and visualize the results. A file dialog is displayed and the user selects a log file belonging to a set. All the files of that set will be parsed looking for results of reachability and collision-free reachability. The goal colors will be updated accordingly (green: collision-free reachable, yellow: reachable in collision, red: not reachable)
