### PR TITLE
clarify comments and reorder.

### DIFF
--- a/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -124,66 +124,13 @@ public:
   /** \brief Get the description of the planning plugin loaded by the action server */
   bool getInterfaceDescription(moveit_msgs::PlannerInterfaceDescription &desc);
   
-  /** \brief Plan and execute a trajectory that takes the group of joints declared in the constructor to the specified target.
-      This call is not blocking (does not wait for the execution of the trajectory to complete). */
-  bool asyncMove();
-  
-  /** \brief Plan and execute a trajectory that takes the group of joints declared in the constructor to the specified target.
-      This call is always blocking (waits for the execution of the trajectory to complete). */
-  bool move();
-
-  /** \brief Compute a motion plan that takes the group declared in the constructor from the current state to the specified
-      target. No execution is performed. The resulting plan is stored in \e plan*/
-  bool plan(Plan &plan);
-  
-  /** \brief Given a \e plan, execute it without waiting for completion. Return true on success. */
-  bool asyncExecute(const Plan &plan);
-  
-  /** \brief Given a \e plan, execute it while waiting for completion. Return true on success. */
-  bool execute(const Plan &plan);
-
-  /** \brief Pick up an object */
-  bool pick(const std::string &object);
-
-  /** \brief Pick up an object given a grasp pose */
-  bool pick(const std::string &object, const manipulation_msgs::Grasp &grasp);
-
-  /** \brief Pick up an object given possible grasp poses */
-  bool pick(const std::string &object, const std::vector<manipulation_msgs::Grasp> &grasps);
-
-  /** \brief Place an object somewhere safe in the world (a safe location will be detected) */
-  bool place(const std::string &object);
-
-  /** \brief Place an object at one of the specified possible locations */
-  bool place(const std::string &object, const std::vector<manipulation_msgs::PlaceLocation> &locations);
-
-  /** \brief Place an object at one of the specified possible locations */
-  bool place(const std::string &object, const std::vector<geometry_msgs::PoseStamped> &poses);
-  
-  /** \brief Compute a Cartesian path that follows specified waypoints with a step size of at most \e eef_step meters
-      between end effector configurations of consecutive points in the result \e trajectory. No more than \e jump_threshold
-      is allowed as change in distance in the configuration space of the robot (this is to prevent 'jumps' in IK solutions).
-      Return a value that is between 0.0 and 1.0 indicating the fraction of the path achieved as described by the waypoints.
-      Return -1.0 in case of error. */
-  double computeCartesianPath(const std::vector<geometry_msgs::Pose> &waypoints, double eef_step, double jump_threshold,
-			      moveit_msgs::RobotTrajectory &trajectory);
-  
-  /** \brief Stop any trajectory execution, if one is active */
-  void stop();
-  
-  /** \brief Specify whether the robot is allowed to look around before moving if it determines it should (default is true) */
-  void allowLooking(bool flag);
-
-  /** \brief Specify whether the robot is allowed to replan if it detects changes in the environment */
-  void allowReplanning(bool flag);
-  
-  /** \brief Specify a planner name to be used for further planning */
+  /** \brief Specify a planner to be used for further planning */
   void setPlannerId(const std::string &planner_id);
 
   /** \brief Specify the maximum amount of time to use when planning */
   void setPlanningTime(double seconds);
 
-  /** \brief Gtet the number of seconds allowed for planning */
+  /** \brief Get the number of seconds set by setPlanningTime() */
   double getPlanningTime() const;
 
   /** \brief Get the tolerance that is used for reaching the goal. For
@@ -198,7 +145,9 @@ public:
       cube where the end-effector must reach.*/
   void setGoalTolerance(double tolerance);
 
-  /** \brief Specify the workspace bounding box */
+  /** \brief Specify the workspace bounding box.
+       The box is specified in the planning frame (i.e. relative to the robot root link start position).
+       This is useful when the MoveGroup's group contains the root joint of the robot -- i.e. when planning motion for the robot relative to the world. */
   void setWorkspace(double minx, double miny, double minz, double maxx, double maxy, double maxz);
   
   /** \brief If a different start state should be considered instead of the current state of the robot, this function sets that state */
@@ -211,7 +160,7 @@ public:
   void setSupportSurfaceName(const std::string &name);
   
   /**
-   * \defgroup set_joint_goal Setting a joint state goal
+   * \defgroup set_joint_goal Setting a joint state target (goal)
    */
   /**@{*/
 
@@ -221,13 +170,15 @@ public:
   /** \brief Given a map of joint names to real values, set those as the joint state goal */
   void setJointValueTarget(const std::map<std::string, double> &variable_values);
 
-  /** \brief Set the joint state goal from corresponding joint values from the specified state */
+  /** \brief Set the joint state goal from corresponding joint values from the specified state.
+      Values from state for joints not in this MoveGroup's group are ignored. */
   void setJointValueTarget(const robot_state::RobotState &kinematic_state);
 
-  /** \brief Set the joint state goal from corresponding joint values from the specified state */
+  /** \brief Set the joint state goal from corresponding joint values from the specified group.
+      joint_state_group must represent the same group as this MoveGroup. */
   void setJointValueTarget(const robot_state::JointStateGroup &joint_state_group);
   
-  /** \brief Set the joint state goal for a particula joint */
+  /** \brief Set the joint state goal for a particular joint */
   void setJointValueTarget(const robot_state::JointState &joint_state);
 
   /** \brief Set the joint state goal for a particular joint */
@@ -253,7 +204,7 @@ public:
 
 
   /**
-   * \defgroup set_pose_goal Setting a pose goal
+   * \defgroup set_pose_goal Setting a pose target (goal)
    */
   /**@{*/
 
@@ -329,6 +280,73 @@ public:
   
   /** \brief Get the reference frame set by setPoseReferenceFrame(). By default this is the reference frame of the kinematic model */
   const std::string& getPoseReferenceFrame() const;
+
+  /**@}*/
+
+  /**
+   * \defgroup plan_and_exec Planning a path from the start position to the Target (goal) position, and executing that plan.
+   */
+  /**@{*/
+
+  /** \brief Plan and execute a trajectory that takes the group of joints declared in the constructor to the specified target.
+      This call is not blocking (does not wait for the execution of the trajectory to complete). */
+  bool asyncMove();
+  
+  /** \brief Plan and execute a trajectory that takes the group of joints declared in the constructor to the specified target.
+      This call is always blocking (waits for the execution of the trajectory to complete). */
+  bool move();
+
+  /** \brief Compute a motion plan that takes the group declared in the constructor from the current state to the specified
+      target. No execution is performed. The resulting plan is stored in \e plan*/
+  bool plan(Plan &plan);
+  
+  /** \brief Given a \e plan, execute it without waiting for completion. Return true on success. */
+  bool asyncExecute(const Plan &plan);
+  
+  /** \brief Given a \e plan, execute it while waiting for completion. Return true on success. */
+  bool execute(const Plan &plan);
+
+  /** \brief Compute a Cartesian path that follows specified waypoints with a step size of at most \e eef_step meters
+      between end effector configurations of consecutive points in the result \e trajectory. No more than \e jump_threshold
+      is allowed as change in distance in the configuration space of the robot (this is to prevent 'jumps' in IK solutions).
+      Return a value that is between 0.0 and 1.0 indicating the fraction of the path achieved as described by the waypoints.
+      Return -1.0 in case of error. */
+  double computeCartesianPath(const std::vector<geometry_msgs::Pose> &waypoints, double eef_step, double jump_threshold,
+			      moveit_msgs::RobotTrajectory &trajectory);
+  
+  /** \brief Stop any trajectory execution, if one is active */
+  void stop();
+  
+  /** \brief Specify whether the robot is allowed to look around before moving if it determines it should (default is true) */
+  void allowLooking(bool flag);
+
+  /** \brief Specify whether the robot is allowed to replan if it detects changes in the environment */
+  void allowReplanning(bool flag);
+  
+  /**@}*/
+
+  /**
+   * \defgroup high_level High level actions that trigger a sequence of plans and actions.
+   */
+  /**@{*/
+
+  /** \brief Pick up an object */
+  bool pick(const std::string &object);
+
+  /** \brief Pick up an object given a grasp pose */
+  bool pick(const std::string &object, const manipulation_msgs::Grasp &grasp);
+
+  /** \brief Pick up an object given possible grasp poses */
+  bool pick(const std::string &object, const std::vector<manipulation_msgs::Grasp> &grasps);
+
+  /** \brief Place an object somewhere safe in the world (a safe location will be detected) */
+  bool place(const std::string &object);
+
+  /** \brief Place an object at one of the specified possible locations */
+  bool place(const std::string &object, const std::vector<manipulation_msgs::PlaceLocation> &locations);
+
+  /** \brief Place an object at one of the specified possible locations */
+  bool place(const std::string &object, const std::vector<geometry_msgs::PoseStamped> &poses);
 
   /**@}*/
 


### PR DESCRIPTION
Primary change is to place the "actions" in their own comment group after the methods that set the "Target".  It makes little sense to consider actions (plans and executions) until the target state has been set.
