### PR TITLE
Adds ability to set a menu handler in robot interaction

### DIFF
--- a/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
+++ b/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
@@ -34,6 +34,7 @@
 
 #include <visualization_msgs/InteractiveMarkerFeedback.h>
 #include <visualization_msgs/InteractiveMarker.h>
+#include <interactive_markers/menu_handler.h>
 #include <moveit/robot_state/robot_state.h>
 #include <boost/function.hpp>
 #include <boost/thread.hpp>
@@ -252,6 +253,11 @@ public:
 
     bool getPoseOffset(const RobotInteraction::EndEffector& eef, geometry_msgs::Pose& m);
     bool getPoseOffset(const RobotInteraction::Joint& vj, geometry_msgs::Pose& m);
+
+
+    void setMenuHandler(const boost::shared_ptr<interactive_markers::MenuHandler>& mh);
+    bool getMenuHandler(boost::shared_ptr<interactive_markers::MenuHandler>& mh);
+    void clearMenuHandler();
     
     /** \brief Get the last interactive_marker command pose for the end-effector
      * @param The end-effector in question.
@@ -302,6 +308,8 @@ public:
     std::set<std::string> error_state_;
     std::map<std::string, geometry_msgs::PoseStamped> pose_map_;
     std::map<std::string, geometry_msgs::Pose> offset_map_;
+    //std::map<std::string, boost::shared_ptr<interactive_markers::MenuHandler> > menu_handler_map_;
+    boost::shared_ptr<interactive_markers::MenuHandler> menu_handler_;
 
     // Called when the RobotState maintained by the handler changes.  The caller may, for example, redraw the robot at the new state.
     // handler is the handler that changed.
@@ -324,6 +332,7 @@ public:
     mutable boost::condition_variable state_available_condition_;
     boost::mutex pose_map_lock_;
     boost::mutex offset_map_lock_;
+    boost::mutex menu_handler_lock_;
 
     void setup();
   };

--- a/robot_interaction/src/robot_interaction.cpp
+++ b/robot_interaction/src/robot_interaction.cpp
@@ -575,13 +575,6 @@ void RobotInteraction::decideActiveJoints(const std::string &group)
   }
 }
 
-//void RobotInteraction::decideActiveMenuHandlers(const std::string &group)
-//{
-
-
-//}
-
-
 void RobotInteraction::decideActiveEndEffectors(const std::string &group, EndEffectorInteractionStyle style)
 {
   boost::unique_lock<boost::mutex> ulock(marker_access_lock_);
@@ -846,10 +839,8 @@ void RobotInteraction::addInteractiveMarkers(const InteractionHandlerPtr &handle
     int_marker_server_->insert(ims[i]);
     int_marker_server_->setCallback(ims[i].name, boost::bind(&RobotInteraction::processInteractiveMarkerFeedback, this, _1));
 
-    // not sure if "get" should lock internally. Is there danger of a deadlock?
+    // Add menu handler to all markers that this interaction handler creates.
     boost::shared_ptr<interactive_markers::MenuHandler> mh;
-//    if(handler->getMenuHandler(ims[i].name, mh))
-//      mh->apply(*int_marker_server_, ims[i].name);
     if (handler->getMenuHandler(mh))
       mh->apply(*int_marker_server_, ims[i].name);
   }

--- a/robot_interaction/src/robot_interaction.cpp
+++ b/robot_interaction/src/robot_interaction.cpp
@@ -33,6 +33,7 @@
 #include <moveit/robot_interaction/interactive_marker_helpers.h>
 #include <moveit/robot_state/transforms.h>
 #include <interactive_markers/interactive_marker_server.h>
+#include <interactive_markers/menu_handler.h>
 #include <eigen_conversions/eigen_msg.h>
 #include <tf_conversions/tf_eigen.h>
 #include <boost/lexical_cast.hpp>
@@ -169,6 +170,32 @@ void RobotInteraction::InteractionHandler::clearLastMarkerPoses()
   boost::mutex::scoped_lock slock(pose_map_lock_);
   pose_map_.clear();
 }
+
+void RobotInteraction::InteractionHandler::setMenuHandler(const boost::shared_ptr<interactive_markers::MenuHandler>& mh)
+{
+  boost::mutex::scoped_lock slock(menu_handler_lock_);
+  menu_handler_ = mh;
+}
+
+bool RobotInteraction::InteractionHandler::getMenuHandler(boost::shared_ptr<interactive_markers::MenuHandler>& mh)
+{
+  boost::mutex::scoped_lock slock(menu_handler_lock_);
+  mh = menu_handler_;
+  return (mh) ? true : false;
+}
+
+
+void RobotInteraction::InteractionHandler::clearMenuHandler()
+{
+  boost::mutex::scoped_lock slock(menu_handler_lock_);
+  menu_handler_.reset();
+}
+
+//void RobotInteraction::InteractionHandler::clearMenuHandlers()
+//{
+//  boost::mutex::scoped_lock slock(menu_handler_lock_);
+//  menu_handler_map_.clear();
+//}
 
 
 robot_state::RobotStateConstPtr RobotInteraction::InteractionHandler::getState() const
@@ -548,6 +575,13 @@ void RobotInteraction::decideActiveJoints(const std::string &group)
   }
 }
 
+//void RobotInteraction::decideActiveMenuHandlers(const std::string &group)
+//{
+
+
+//}
+
+
 void RobotInteraction::decideActiveEndEffectors(const std::string &group, EndEffectorInteractionStyle style)
 {
   boost::unique_lock<boost::mutex> ulock(marker_access_lock_);
@@ -811,6 +845,13 @@ void RobotInteraction::addInteractiveMarkers(const InteractionHandlerPtr &handle
   {
     int_marker_server_->insert(ims[i]);
     int_marker_server_->setCallback(ims[i].name, boost::bind(&RobotInteraction::processInteractiveMarkerFeedback, this, _1));
+
+    // not sure if "get" should lock internally. Is there danger of a deadlock?
+    boost::shared_ptr<interactive_markers::MenuHandler> mh;
+//    if(handler->getMenuHandler(ims[i].name, mh))
+//      mh->apply(*int_marker_server_, ims[i].name);
+    if (handler->getMenuHandler(mh))
+      mh->apply(*int_marker_server_, ims[i].name);
   }
 }
 

--- a/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -120,6 +120,8 @@ class MotionPlanningDisplay : public PlanningSceneDisplay
   
   std::string getCurrentPlanningGroup() const;
 
+  void changePlanningGroup(const std::string& group);
+
 private Q_SLOTS:
 
   // ******************************************************************************************
@@ -192,6 +194,8 @@ protected:
   float getStateDisplayTime();
   void updateBackgroundJobProgressBar();
   void backgroundJobUpdate(BackgroundProcessing::JobEvent event);
+
+  void setQueryStateHelper(robot_interaction::RobotInteraction::InteractionHandlerPtr& ih, const std::string &v);
   
   // overrides from Display  
   virtual void onInitialize();
@@ -228,6 +232,8 @@ protected:
   robot_interaction::RobotInteractionPtr robot_interaction_;
   robot_interaction::RobotInteraction::InteractionHandlerPtr query_start_state_;
   robot_interaction::RobotInteraction::InteractionHandlerPtr query_goal_state_;
+  boost::shared_ptr<interactive_markers::MenuHandler> menu_handler_start_;
+  boost::shared_ptr<interactive_markers::MenuHandler> menu_handler_goal_;
   std::map<std::string, int> collision_links_start_;
   std::map<std::string, int> collision_links_goal_;
   /// Hold the names of the groups for which the query states have been updated (and should not be altered when new info is received from the planning scene)


### PR DESCRIPTION
After much hemming and hawing, I decided the cleanest way to do menus right now is to simply allow the user to set a single menu handler for each interaction handler. Hence, different subgroups in the currently active group will all get the same set of menus. When the user changes the active group, they could change the menu handler to have different menu entries if desired. I think this is a good balance between flexibility and simplicity of API.

To show how it works, there is basic functionality added to the motion planning plugin. It creates a menu handler for the start state, and a separate one for the goal state. Now, you can right click on the markers to change planning groups, or to set the state that you have right-clicked-on to random, current, or the "other" one (start or goal). 

Try it out and let me know what you think.
#140
