### PR TITLE
waits until the planning scene monitor has been created 

### DIFF
--- a/benchmarks_gui/include/main_window.h
+++ b/benchmarks_gui/include/main_window.h
@@ -146,6 +146,7 @@ private:
   rviz::VisualizationManager *visualization_manager_;
   moveit_rviz_plugin::PlanningSceneDisplay *scene_display_;
 
+  bool waitForPlanningSceneMonitor(moveit_rviz_plugin::PlanningSceneDisplay *scene_display);
   void scheduleStateUpdate();
   void scheduleStateUpdateBackgroundJob();
   bool isIKSolutionCollisionFree(robot_state::JointStateGroup *group, const std::vector<double> &ik_solution);


### PR DESCRIPTION
This is a fix for the benchmark gui. As the planning scene display now creates the planning scene monitor in a background process, we need to query until the planning scene monitor has been created before trying to access it.
