### PR TITLE
circumventing a GCC bug

### DIFF
--- a/planning/planning_components_tools/src/evaluate_state_operations_speed.cpp
+++ b/planning/planning_components_tools/src/evaluate_state_operations_speed.cpp
@@ -77,7 +77,7 @@ int main(int argc, char **argv)
         state.setToRandomValues();
         moveit::Profiler::End("FK Random");
       } 
-      std::vector<robot_state::RobotState*> copies(N, NULL);  
+      std::vector<robot_state::RobotState*> copies(N, (robot_state::RobotState*)NULL);  
       printf("Evaluating Copy State ...\n");
       for (int i = 0 ; i < N ; ++i)
       {


### PR DESCRIPTION
Added a cast to circumvent a bug that appears on certain 32-bit GCC versions,
cf. http://gcc.gnu.org/bugzilla/show_bug.cgi?id=43813.

This bug appeared to show up with errors like "Cannot convert 'int' to 'std::vector<robot_state::RobotState*>::value_type" for my GCC 4.6.3 on my Ubuntu 12.04 32-bit.
