### PR TITLE
moveit_ros_robot_interaction: linkedit error on OS X

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 endif()
 
 find_package(Eigen REQUIRED)
-find_package(Boost REQUIRED thread program_options date_time system filesystem)
+find_package(Boost REQUIRED COMPONENTS date_time filesystem program_options system thread)
 
 find_package(catkin REQUIRED COMPONENTS
   moveit_ros_planning

--- a/benchmarks/benchmarks/src/run_benchmarks.cpp
+++ b/benchmarks/benchmarks/src/run_benchmarks.cpp
@@ -36,6 +36,7 @@
 
 #include <moveit/benchmarks/benchmark_execution.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
+#include <boost/program_options.hpp>
 #include <ros/ros.h>
 
 static const std::string ROBOT_DESCRIPTION="robot_description";      // name of the robot description (a param name, so it can be changed externally)

--- a/manipulation/CMakeLists.txt
+++ b/manipulation/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(Boost REQUIRED thread system filesystem date_time program_options)
 find_package(catkin REQUIRED COMPONENTS
   moveit_core
   moveit_ros_planning
-  moveit_ros_move_group 
+  moveit_ros_move_group
   dynamic_reconfigure
   roscpp
   rosconsole

--- a/move_group/CMakeLists.txt
+++ b/move_group/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 catkin_package(
-  LIBRARIES
+  LIBRARIES move_group_capability
   INCLUDE_DIRS
     include
   CATKIN_DEPENDS
@@ -34,9 +34,12 @@ include_directories(SYSTEM
 link_directories(${Boost_LIBRARY_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
 
-add_executable(move_group
+add_library(move_group_capability
   src/move_group_context.cpp
   src/move_group_capability.cpp
+)
+
+add_executable(move_group
   src/move_group.cpp
 )
 
@@ -53,11 +56,12 @@ add_library(moveit_move_group_default_capabilities
   src/default_capabilities/get_planning_scene_service_capability.cpp
   )
 
-target_link_libraries(move_group ${catkin_LIBRARIES} ${Boost_LIBRARIES})
-target_link_libraries(moveit_move_group_default_capabilities ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(move_group_capability ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(move_group move_group_capability ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(moveit_move_group_default_capabilities move_group_capability ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 target_link_libraries(list_move_group_capabilities ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
-install(TARGETS move_group list_move_group_capabilities moveit_move_group_default_capabilities
+install(TARGETS move_group list_move_group_capabilities moveit_move_group_default_capabilities move_group_capability
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/planning_interface/CMakeLists.txt
+++ b/planning_interface/CMakeLists.txt
@@ -6,14 +6,22 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 endif()
 
 find_package(Eigen REQUIRED)
-find_package(Boost REQUIRED thread date_time system filesystem program_options python)
-find_package(PythonLibs)
+find_package(Boost REQUIRED COMPONENTS
+  date_time
+  filesystem
+  program_options
+  python
+  system
+  thread
+)
+find_package(PythonLibs REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
   moveit_ros_planning
   moveit_ros_warehouse
   moveit_ros_manipulation
   moveit_ros_move_group
   eigen_conversions
+  tf_conversions
   tf
   roscpp
   actionlib

--- a/planning_interface/common_planning_interface_objects/CMakeLists.txt
+++ b/planning_interface/common_planning_interface_objects/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_common_planning_interface_objects)
 
 add_library(${MOVEIT_LIB_NAME} src/common_objects.cpp)
-target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${PYTHON_LIBRARIES} ${Boost_LIBRARIES})
 
 install(TARGETS ${MOVEIT_LIB_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/planning_interface/package.xml
+++ b/planning_interface/package.xml
@@ -25,6 +25,7 @@
   <build_depend>actionlib</build_depend> 
   <build_depend>tf</build_depend>
   <build_depend>eigen_conversions</build_depend>
+  <build_depend>tf_conversions</build_depend>
   <build_depend>python</build_depend>
 
   <run_depend>moveit_ros_planning</run_depend>
@@ -37,6 +38,7 @@
   <run_depend>actionlib</run_depend> 
   <run_depend>tf</run_depend>
   <run_depend>eigen_conversions</run_depend>
+  <run_depend>tf_conversions</run_depend>
   <run_depend>python</run_depend>
 
 </package>

--- a/planning_interface/py_bindings_tools/CMakeLists.txt
+++ b/planning_interface/py_bindings_tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MOVEIT_LIB_NAME moveit_py_bindings_tools)
 
 add_library(${MOVEIT_LIB_NAME} src/roscpp_initializer.cpp)
-target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${PYTHON_LIBRARIES})
 
 install(TARGETS ${MOVEIT_LIB_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/robot_interaction/CMakeLists.txt
+++ b/robot_interaction/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
   moveit_ros_planning
   interactive_markers
   eigen_conversions
+  tf_conversions
   tf
   roscpp
 )


### PR DESCRIPTION
When compiling `moveit_ros_robot_interaction` on OS X I get:

```
==> Processing catkin package: 'moveit_ros_robot_interaction'
==> Creating build directory: 'build_isolated/moveit_ros_robot_interaction'
==> Building with env: '/Users/william/moveit_ws/install_isolated/env.sh'
==> cmake /Users/william/moveit_ws/src/moveit_ros/robot_interaction -DCATKIN_DEVEL_PREFIX=/Users/william/moveit_ws/devel_isolated/moveit_ros_robot_interaction -DCMAKE_INSTALL_PREFIX=/Users/william/moveit_ws/install_isolated
-- The C compiler identification is Clang 4.2.0
-- The CXX compiler identification is Clang 4.2.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Boost version: 1.53.0
-- Found the following Boost libraries:
--   thread
-- Using CATKIN_DEVEL_PREFIX: /Users/william/moveit_ws/devel_isolated/moveit_ros_robot_interaction
-- Using CMAKE_PREFIX_PATH: /Users/william/moveit_ws/install_isolated
-- This workspace overlays: /Users/william/moveit_ws/install_isolated
-- Found PythonInterp: /usr/bin/python (found version "2.7.2")
-- Found PY_em: /Library/Python/2.7/site-packages/em.pyc
-- Found gtest: gtests will be built
-- Using CATKIN_TEST_RESULTS_DIR: /Users/william/moveit_ws/build_isolated/moveit_ros_robot_interaction/test_results
-- catkin 0.5.65
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/william/moveit_ws/build_isolated/moveit_ros_robot_interaction
==> make -j1 -l1 in '/Users/william/moveit_ws/build_isolated/moveit_ros_robot_interaction'
Scanning dependencies of target moveit_robot_interaction
[ 50%] Building CXX object CMakeFiles/moveit_robot_interaction.dir/src/interactive_marker_helpers.cpp.o
[100%] Building CXX object CMakeFiles/moveit_robot_interaction.dir/src/robot_interaction.cpp.o
Linking CXX shared library /Users/william/moveit_ws/devel_isolated/moveit_ros_robot_interaction/lib/libmoveit_robot_interaction.dylib
Undefined symbols for architecture x86_64:
  "tf::poseEigenToTF(Eigen::Transform<double, 3, 2, 0> const&, tf::Transform&)", referenced from:
      robot_interaction::RobotInteraction::addEndEffectorMarkers(boost::shared_ptr<robot_interaction::RobotInteraction::InteractionHandler> const&, robot_interaction::RobotInteraction::EndEffector const&, geometry_msgs::Pose_<std::allocator<void> > const&, visualization_msgs::InteractiveMarker_<std::allocator<void> >&) in robot_interaction.cpp.o
      robot_interaction::RobotInteraction::computeMarkerPose(boost::shared_ptr<robot_interaction::RobotInteraction::InteractionHandler> const&, robot_interaction::RobotInteraction::EndEffector const&, robot_state::RobotState const&, geometry_msgs::Pose_<std::allocator<void> >&, geometry_msgs::Pose_<std::allocator<void> >&) const in robot_interaction.cpp.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [/Users/william/moveit_ws/devel_isolated/moveit_ros_robot_interaction/lib/libmoveit_robot_interaction.dylib] Error 1
make[1]: *** [CMakeFiles/moveit_robot_interaction.dir/all] Error 2
make: *** [all] Error 2
Traceback (most recent call last):
  File "./src/catkin/bin/../python/catkin/builder.py", line 659, in build_workspace_isolated
    number=index + 1, of=len(ordered_packages)
  File "./src/catkin/bin/../python/catkin/builder.py", line 443, in build_package
    install, jobs, force_cmake, quiet, last_env, cmake_args, make_args
  File "./src/catkin/bin/../python/catkin/builder.py", line 297, in build_catkin_package
    run_command(make_cmd, build_dir, quiet)
  File "./src/catkin/bin/../python/catkin/builder.py", line 186, in run_command
    raise subprocess.CalledProcessError(proc.returncode, ' '.join(cmd))
CalledProcessError: Command '/Users/william/moveit_ws/install_isolated/env.sh make -j1 -l1' returned non-zero exit status 2
<== Failed to process package 'moveit_ros_robot_interaction':
  Command '/Users/william/moveit_ws/install_isolated/env.sh make -j1 -l1' returned non-zero exit status 2

Reproduce this error by running:
==> /Users/william/moveit_ws/install_isolated/env.sh make -j1 -l1

Command failed, exiting.
```

I have a fix for this, I'll open a pull request asap.
