### PR TITLE
Make KDL Plugin searchPositionIK actually const, and thread-safe

### DIFF
--- a/planning/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
+++ b/planning/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
@@ -67,7 +67,7 @@
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/robot_state.h>
 
-namespace kdl_kinematics_plugin                        
+namespace kdl_kinematics_plugin
 {
 /**
  * @brief Specific implementation of kinematics using KDL. This version can be used with any robot.
@@ -76,7 +76,7 @@ namespace kdl_kinematics_plugin
   {
     public:
 
-    /** 
+    /**
      *  @brief Default constructor
      */
     KDLKinematicsPlugin();
@@ -85,14 +85,14 @@ namespace kdl_kinematics_plugin
                                const std::vector<double> &ik_seed_state,
                                std::vector<double> &solution,
                                moveit_msgs::MoveItErrorCodes &error_code,
-                               bool lock_redundant_joints=false) const;      
-    
+                               bool lock_redundant_joints=false) const;
+
     virtual bool searchPositionIK(const geometry_msgs::Pose &ik_pose,
                                   const std::vector<double> &ik_seed_state,
                                   double timeout,
                                   std::vector<double> &solution,
                                   moveit_msgs::MoveItErrorCodes &error_code,
-                                  bool lock_redundant_joints=false) const;      
+                                  bool lock_redundant_joints=false) const;
 
     virtual bool searchPositionIK(const geometry_msgs::Pose &ik_pose,
                                   const std::vector<double> &ik_seed_state,
@@ -100,7 +100,7 @@ namespace kdl_kinematics_plugin
                                   const std::vector<double> &consistency_limits,
                                   std::vector<double> &solution,
                                   moveit_msgs::MoveItErrorCodes &error_code,
-                                  bool lock_redundant_joints=false) const;      
+                                  bool lock_redundant_joints=false) const;
 
     virtual bool searchPositionIK(const geometry_msgs::Pose &ik_pose,
                                   const std::vector<double> &ik_seed_state,
@@ -109,7 +109,7 @@ namespace kdl_kinematics_plugin
                                   const IKCallbackFn &solution_callback,
                                   moveit_msgs::MoveItErrorCodes &error_code,
                                   bool lock_redundant_joints=false) const;
-    
+
     virtual bool searchPositionIK(const geometry_msgs::Pose &ik_pose,
                                   const std::vector<double> &ik_seed_state,
                                   double timeout,
@@ -117,28 +117,28 @@ namespace kdl_kinematics_plugin
                                   std::vector<double> &solution,
                                   const IKCallbackFn &solution_callback,
                                   moveit_msgs::MoveItErrorCodes &error_code,
-                                  bool lock_redundant_joints=false) const;      
+                                  bool lock_redundant_joints=false) const;
 
     virtual bool getPositionFK(const std::vector<std::string> &link_names,
-                               const std::vector<double> &joint_angles, 
+                               const std::vector<double> &joint_angles,
                                std::vector<geometry_msgs::Pose> &poses) const;
-    
+
     virtual bool initialize(const std::string &robot_description,
                             const std::string &group_name,
                             const std::string &base_name,
                             const std::string &tip_name,
                             double search_discretization);
-        
+
     /**
      * @brief  Return all the joint names in the order they are used internally
      */
     const std::vector<std::string>& getJointNames() const;
-    
+
     /**
      * @brief  Return all the link names in the order they are represented internally
      */
     const std::vector<std::string>& getLinkNames() const;
-    
+
   protected:
 
   /**
@@ -165,13 +165,13 @@ namespace kdl_kinematics_plugin
                           const std::vector<double> &consistency_limits,
                           bool lock_redundancy=false) const;
 
-    virtual bool setRedundantJoints(const std::vector<unsigned int> &redundant_joint_indices);    
-    
+    virtual bool setRedundantJoints(const std::vector<unsigned int> &redundant_joint_indices);
+
   private:
-    
+
     bool timedOut(const ros::WallTime &start_time, double duration) const;
-    
-    
+
+
     /** @brief Check whether the solution lies within the consistency limit of the seed state
      *  @param seed_state Seed state
      *  @param redundancy Index of the redundant joint within the chain
@@ -200,27 +200,19 @@ namespace kdl_kinematics_plugin
                                 KDL::JntArray &jnt_array,
                                 bool lock_redundancy) const;
 
-    bool isRedundantJoint(unsigned int index) const;    
-    
+    bool isRedundantJoint(unsigned int index) const;
+
     bool active_; /** Internal variable that indicates whether solvers are configured and ready */
 
     moveit_msgs::KinematicSolverInfo ik_chain_info_; /** Stores information for the inverse kinematics solver */
 
     moveit_msgs::KinematicSolverInfo fk_chain_info_; /** Store information for the forward kinematics solver */
 
-    KDL::Chain kdl_chain_; 
+    KDL::Chain kdl_chain_;
 
-    boost::shared_ptr<KDL::ChainIkSolverVel> ik_solver_vel_; /** KDL IK velocity solver */
-
-    boost::shared_ptr<KDL::ChainFkSolverPos_recursive> fk_solver_;/** KDL FK solver */
-
-    boost::shared_ptr<KDL::ChainIkSolverPos> ik_solver_pos_;/** KDL IK position solver */ 
-    
     unsigned int dimension_; /** Dimension of the group */
 
     KDL::JntArray joint_min_, joint_max_; /** Joint limits */
-
-    mutable KDL::JntArray jnt_seed_state_,jnt_pos_in_,jnt_pos_out_;/** Pre-allocated for the number of joints (hence mutable) */
 
     mutable random_numbers::RandomNumberGenerator random_number_generator_;
 
@@ -228,18 +220,16 @@ namespace kdl_kinematics_plugin
 
     robot_state::RobotStatePtr kinematic_state_, kinematic_state_2_;
 
-    //    robot_state::JointStateGroup* joint_state_group_, joint_state_group_2_;
-    KDL::ChainIkSolverVel_pinv_mimic* vel_solver_;//pointer to the actual velocity solver
-
     int num_possible_redundant_joints_;
+    std::vector<unsigned int> redundant_joints_map_index_;
 
     // Storage required for when the set of redundant joints is reset
-    bool position_ik_; //whether this solver is only being used for position ik    
-    robot_model::JointModelGroup* joint_model_group_;    
+    bool position_ik_; //whether this solver is only being used for position ik
+    robot_model::JointModelGroup* joint_model_group_;
     double max_solver_iterations_;
     double epsilon_;
-    std::vector<kdl_kinematics_plugin::JointMimic> mimic_joints_;           
-    
+    std::vector<kdl_kinematics_plugin::JointMimic> mimic_joints_;
+
   };
 }
 


### PR DESCRIPTION
This fixes the KDL plugin to close https://github.com/ros-planning/moveit_core/issues/47

I've tested the IK on both my robot Maxwell, as well as the PR2 arm+torso (which uses the KDL plugin) and all looks good. I've tested that I can send pick/place requests with many grasps/place-locations without any issue on Maxwell.

The added steps to instantiate the JntArrays and IK/FK solvers in each call to searchPositionIK do not appear slow things down noticeably.
