### PR TITLE
Improvements to benchmark_gui

### DIFF
--- a/benchmarks_gui/CMakeLists.txt
+++ b/benchmarks_gui/CMakeLists.txt
@@ -38,7 +38,7 @@ include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
 
-qt4_wrap_cpp(MOC_FILES include/main_window.h include/trajectory.h)
+qt4_wrap_cpp(MOC_FILES include/main_window.h include/trajectory.h include/benchmark_processing_thread.h)
 qt4_wrap_ui(UIC_FILES
   src/ui/main_window.ui
   src/ui/run_benchmark_dialog.ui
@@ -54,6 +54,7 @@ set(SOURCES
   src/main.cpp
   src/main_window.cpp
   src/job_processing.cpp
+  src/benchmark_processing_thread.cpp
   src/ui_utils.cpp
   src/frame_marker.cpp
   src/trajectory.cpp

--- a/benchmarks_gui/include/benchmark_processing_thread.h
+++ b/benchmarks_gui/include/benchmark_processing_thread.h
@@ -1,0 +1,29 @@
+#ifndef BENCHMARK_PROCESSING_THREAD_H
+#define BENCHMARK_PROCESSING_THREAD_H
+
+#include <QtCore/QThread>
+#include <QProgressDialog>
+
+#include <moveit/benchmarks/benchmark_execution.h>
+
+class BenchmarkProcessingThread : public QThread
+{
+  Q_OBJECT
+
+public:
+  BenchmarkProcessingThread(const moveit_benchmarks::BenchmarkExecution &be, const moveit_benchmarks::BenchmarkType &bt, QObject *parent = 0);
+  ~BenchmarkProcessingThread();
+
+  void startAndShow();
+
+private:
+  boost::shared_ptr<QProgressDialog> progress_dialog_;
+
+  moveit_benchmarks::BenchmarkExecution be_;
+  moveit_benchmarks::BenchmarkType bt_;
+
+protected:
+  void run();
+};
+
+#endif // BENCHMARK_PROCESSING_THREAD_H

--- a/benchmarks_gui/include/main_window.h
+++ b/benchmarks_gui/include/main_window.h
@@ -103,7 +103,9 @@ public Q_SLOTS:
   void checkGoalsInCollision(void);
   void checkGoalsReachable(void);
   void runBenchmark(void);
-  void runBenchmarkOKButtonClicked(void);
+  void saveBenchmarkConfigButtonClicked(void);
+  void cancelBenchmarkButtonClicked(void);
+  void runBenchmarkButtonClicked(void);
   void benchmarkFolderButtonClicked(void);
   void loadBenchmarkResults(void);
   void updateMarkerState(GripperMarkerPtr marker, const GripperMarker::GripperMarkerState &state);
@@ -143,7 +145,7 @@ private:
   Ui::MainWindow ui_;
   Ui_BenchmarkDialog run_benchmark_ui_;
   Ui_RobotLoader load_robot_ui_;
-  QDialog *robot_loader_dialog_;
+  QDialog *robot_loader_dialog_, *run_benchmark_dialog_;
   boost::shared_ptr<QSettings> settings_;
 
   //rviz
@@ -165,6 +167,8 @@ private:
   rviz::Display *int_marker_display_;
 
   //Warehouse
+  std::string database_host_;
+  std::size_t database_port_;
   boost::shared_ptr<moveit_warehouse::PlanningSceneStorage> planning_scene_storage_;
   boost::shared_ptr<moveit_warehouse::ConstraintsStorage> constraints_storage_;
   boost::shared_ptr<moveit_warehouse::TrajectoryConstraintsStorage> trajectory_constraints_storage_;

--- a/benchmarks_gui/src/benchmark_processing_thread.cpp
+++ b/benchmarks_gui/src/benchmark_processing_thread.cpp
@@ -1,0 +1,29 @@
+#include <ros/ros.h>
+#include <benchmark_processing_thread.h>
+
+BenchmarkProcessingThread::BenchmarkProcessingThread(const moveit_benchmarks::BenchmarkExecution &be, const moveit_benchmarks::BenchmarkType &bt, QObject *parent)
+: be_(be), bt_(bt), QThread(parent)
+{
+  setTerminationEnabled();
+}
+
+BenchmarkProcessingThread::~BenchmarkProcessingThread()
+{
+}
+
+void BenchmarkProcessingThread::startAndShow()
+{
+  this->start();
+
+  progress_dialog_.reset(new QProgressDialog("Running benchmark","Cancel",0,0));
+  connect( this, SIGNAL( finished() ), progress_dialog_.get(), SLOT( cancel() ));
+  progress_dialog_->setMinimum(0);
+  progress_dialog_->setMaximum(0);
+  progress_dialog_->exec();
+}
+
+void BenchmarkProcessingThread::run()
+{
+  ROS_INFO("Thread running");
+  be_.runAllBenchmarks(bt_);
+}

--- a/benchmarks_gui/src/tab_states_and_goals.cpp
+++ b/benchmarks_gui/src/tab_states_and_goals.cpp
@@ -36,12 +36,13 @@
 
 #include <main_window.h>
 #include <job_processing.h>
+#include <benchmark_processing_thread.h>
 
 #include <moveit/kinematic_constraints/utils.h>
 #include <moveit/robot_state/conversions.h>
 #include <moveit/warehouse/constraints_storage.h>
 #include <moveit/warehouse/state_storage.h>
-
+#include <moveit/benchmarks/benchmark_execution.h>
 #include <rviz/display_context.h>
 #include <rviz/window_manager_interface.h>
 
@@ -50,7 +51,7 @@
 #include <QMessageBox>
 #include <QInputDialog>
 #include <QFileDialog>
-
+#include <QProgressDialog>
 
 #include <boost/math/constants/constants.hpp>
 
@@ -857,19 +858,14 @@ void MainWindow::startStateItemDoubleClicked(QListWidgetItem * item)
 
 void MainWindow::runBenchmark(void)
 {
-  QDialog *dialog = new QDialog(0,0);
-
-  run_benchmark_ui_.setupUi(dialog);
-  run_benchmark_ui_.benchmark_select_folder_button->setIcon(QIcon::fromTheme("document-open", QApplication::style()->standardIcon(QStyle::SP_DirOpenIcon)));
-  connect( run_benchmark_ui_.benchmark_button_box, SIGNAL( accepted( ) ), this, SLOT( runBenchmarkOKButtonClicked( ) ));
-  connect( run_benchmark_ui_.benchmark_select_folder_button, SIGNAL( clicked( ) ), this, SLOT( benchmarkFolderButtonClicked( ) ));
+  run_benchmark_ui_.benchmark_start_state_combo->clear();
 
   for (StartStateMap::iterator it = start_states_.begin(); it != start_states_.end(); ++it)
   {
     run_benchmark_ui_.benchmark_start_state_combo->addItem(it->first.c_str());
   }
 
-  dialog->show();
+  run_benchmark_dialog_->show();
 }
 
 void MainWindow::benchmarkFolderButtonClicked(void)
@@ -879,7 +875,12 @@ void MainWindow::benchmarkFolderButtonClicked(void)
   run_benchmark_ui_.benchmark_output_folder_text->setText(dir);
 }
 
-void MainWindow::runBenchmarkOKButtonClicked(void)
+void MainWindow::cancelBenchmarkButtonClicked(void)
+{
+  run_benchmark_dialog_->close();
+}
+
+void MainWindow::saveBenchmarkConfigButtonClicked(void)
 {
   if (run_benchmark_ui_.benchmark_output_folder_text->text().isEmpty())
   {
@@ -900,10 +901,10 @@ void MainWindow::runBenchmarkOKButtonClicked(void)
     //TODO: Let the user select the timeout, runs, and start regex
     outfile << "timeout=1" << std::endl;
     outfile << "runs=1" << std::endl;
-    outfile << "output=" << scene_display_->getPlanningSceneMonitor()->getRobotModel()->getName() << "_" <<
-                        scene_display_->getPlanningSceneRO()->getName() << "_" <<
-                        ros::Time::now() << std::endl;
-    outfile << "start=" << run_benchmark_ui_.benchmark_output_folder_text->text().toStdString() << std::endl;
+    outfile << "output=" << run_benchmark_ui_.benchmark_output_folder_text->text().toStdString() << "/" << scene_display_->getPlanningSceneMonitor()->getRobotModel()->getName() << "_" <<
+        scene_display_->getPlanningSceneRO()->getName() << "_" <<
+        ros::Time::now() << std::endl;
+    outfile << "start=" << run_benchmark_ui_.benchmark_start_state_combo->currentText().toStdString() << std::endl;
     outfile << "query=" << std::endl;
     outfile << "goal=" << ui_.load_poses_filter_text->text().toStdString() << std::endl;
     outfile << "goal_offset_roll=" << ui_.goal_offset_roll->value() << std::endl;
@@ -916,10 +917,65 @@ void MainWindow::runBenchmarkOKButtonClicked(void)
     outfile << "planners=RRTConnectkConfigDefault" << std::endl;
 
     outfile.close();
+
+    run_benchmark_dialog_->close();
   }
   else
   {
     QMessageBox::warning(this, "Error", QString("Cannot open file ").append(outfilename).append(" for writing"));
+  }
+}
+
+void MainWindow::runBenchmarkButtonClicked(void)
+{
+  QMessageBox msgBox;
+  msgBox.setText("This will run the benchmark pipeline. The process will take several minutes during which you will not be able to interact with the interface. You can follow the progress in the console output");
+  msgBox.setInformativeText("Do you want to continue?");
+  msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+  msgBox.setDefaultButton(QMessageBox::Yes);
+  int ret = msgBox.exec();
+
+  switch (ret)
+  {
+    case QMessageBox::Yes:
+    {
+      msgBox.close();
+      saveBenchmarkConfigButtonClicked();
+
+      if (run_benchmark_ui_.benchmark_output_folder_text->text().isEmpty())
+        return;
+
+      QString outfilename =  run_benchmark_ui_.benchmark_output_folder_text->text().append("/config.cfg");
+      moveit_benchmarks::BenchmarkType btype = 0;
+      moveit_benchmarks::BenchmarkExecution be(scene_display_->getPlanningSceneMonitor()->getPlanningScene(), database_host_, database_port_);
+      if (run_benchmark_ui_.benchmark_include_planners_checkbox->isChecked())
+        btype += moveit_benchmarks::BENCHMARK_PLANNERS;
+      if (run_benchmark_ui_.benchmark_check_reachability_checkbox->isChecked())
+        btype += moveit_benchmarks::BENCHMARK_GOAL_EXISTANCE;
+
+      if (be.readOptions(outfilename.toStdString()))
+      {
+        std::stringstream ss;
+        be.printOptions(ss);
+        ROS_INFO_STREAM("Calling benchmark with options:" << std::endl << ss.str() << std::endl);
+
+        BenchmarkProcessingThread benchmark_thread(be, btype, this);
+        benchmark_thread.startAndShow();
+
+        if (benchmark_thread.isRunning())
+        {
+          benchmark_thread.terminate();
+          benchmark_thread.wait();
+          QMessageBox::warning(this, "", "Benchmark computation canceled");
+        }
+        else
+        {
+          QMessageBox::information(this, "Benchmark computation finished", QString("The results were logged into '").append(run_benchmark_ui_.benchmark_output_folder_text->text()));
+        }
+      }
+
+      break;
+    }
   }
 }
 

--- a/benchmarks_gui/src/tab_states_and_goals.cpp
+++ b/benchmarks_gui/src/tab_states_and_goals.cpp
@@ -858,12 +858,8 @@ void MainWindow::startStateItemDoubleClicked(QListWidgetItem * item)
 
 void MainWindow::runBenchmark(void)
 {
-  run_benchmark_ui_.benchmark_start_state_combo->clear();
-
-  for (StartStateMap::iterator it = start_states_.begin(); it != start_states_.end(); ++it)
-  {
-    run_benchmark_ui_.benchmark_start_state_combo->addItem(it->first.c_str());
-  }
+  run_benchmark_ui_.benchmark_goal_text->setText(ui_.load_poses_filter_text->text());
+  run_benchmark_ui_.benchmark_start_state_text->setText(ui_.load_states_filter_text->text());
 
   run_benchmark_dialog_->show();
 }
@@ -898,15 +894,15 @@ void MainWindow::saveBenchmarkConfigButtonClicked(void)
     outfile << "planning_frame=" << scene_display_->getPlanningSceneMonitor()->getRobotModel()->getModelFrame() << std::endl;
     outfile << "name=" << scene_display_->getPlanningSceneRO()->getName() << std::endl;
 
-    //TODO: Let the user select the timeout, runs, and start regex
+    //TODO: Let the user select the timeout and runs
     outfile << "timeout=1" << std::endl;
     outfile << "runs=1" << std::endl;
     outfile << "output=" << run_benchmark_ui_.benchmark_output_folder_text->text().toStdString() << "/" << scene_display_->getPlanningSceneMonitor()->getRobotModel()->getName() << "_" <<
         scene_display_->getPlanningSceneRO()->getName() << "_" <<
         ros::Time::now() << std::endl;
-    outfile << "start=" << run_benchmark_ui_.benchmark_start_state_combo->currentText().toStdString() << std::endl;
+    outfile << "start=" << run_benchmark_ui_.benchmark_start_state_text->text().toStdString() << std::endl;
     outfile << "query=" << std::endl;
-    outfile << "goal=" << ui_.load_poses_filter_text->text().toStdString() << std::endl;
+    outfile << "goal=" << run_benchmark_ui_.benchmark_goal_text->text().toStdString() << std::endl;
     outfile << "goal_offset_roll=" << ui_.goal_offset_roll->value() << std::endl;
     outfile << "goal_offset_pitch=" << ui_.goal_offset_pitch->value() << std::endl;
     outfile << "goal_offset_yaw=" << ui_.goal_offset_yaw->value() << std::endl << std::endl;
@@ -914,7 +910,7 @@ void MainWindow::saveBenchmarkConfigButtonClicked(void)
     //TODO: Let the user select the planners
     outfile << "[plugin]" << std::endl;
     outfile << "name=ompl_interface_ros/OMPLPlanner" << std::endl;
-    outfile << "planners=RRTConnectkConfigDefault" << std::endl;
+    outfile << "planners=" << std::endl;
 
     outfile.close();
 

--- a/benchmarks_gui/src/ui/main_window.ui
+++ b/benchmarks_gui/src/ui/main_window.ui
@@ -473,7 +473,7 @@ reachability</string>
                <item>
                 <widget class="QPushButton" name="run_benchmark_button">
                  <property name="text">
-                  <string>Generate benchmark config file</string>
+                  <string>Run benchmark or generate config file</string>
                  </property>
                 </widget>
                </item>

--- a/benchmarks_gui/src/ui/run_benchmark_dialog.ui
+++ b/benchmarks_gui/src/ui/run_benchmark_dialog.ui
@@ -103,53 +103,32 @@
     </spacer>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="benchmark_button_box">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QPushButton" name="save_config_button">
+       <property name="text">
+        <string>Just save config file</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="run_benchmark_button">
+       <property name="text">
+        <string>Run benchmark</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="cancel_button">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
  <resources/>
- <connections>
-  <connection>
-   <sender>benchmark_button_box</sender>
-   <signal>accepted()</signal>
-   <receiver>BenchmarkDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>benchmark_button_box</sender>
-   <signal>rejected()</signal>
-   <receiver>BenchmarkDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/benchmarks_gui/src/ui/run_benchmark_dialog.ui
+++ b/benchmarks_gui/src/ui/run_benchmark_dialog.ui
@@ -16,14 +16,14 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QFormLayout" name="formLayout">
-     <item row="2" column="0">
+     <item row="3" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>Check reachability</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
+     <item row="4" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Include planners</string>
@@ -37,17 +37,14 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QComboBox" name="benchmark_start_state_combo"/>
-     </item>
-     <item row="2" column="1">
+     <item row="3" column="1">
       <widget class="QCheckBox" name="benchmark_check_reachability_checkbox">
        <property name="text">
         <string/>
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+     <item row="4" column="1">
       <widget class="QCheckBox" name="benchmark_include_planners_checkbox">
        <property name="text">
         <string/>
@@ -86,6 +83,19 @@
         </widget>
        </item>
       </layout>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Goal</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="benchmark_goal_text"/>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="benchmark_start_state_text"/>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
This PR includes improvements in the UI and code so that a user can directly start a benchmark computation from the benchmark GUI, without first having to store the config file and then running the benchmark client from the command line.
