### PR TITLE
Allow creating goals uniformly distributed in a bounding box

### DIFF
--- a/benchmarks_gui/CMakeLists.txt
+++ b/benchmarks_gui/CMakeLists.txt
@@ -43,6 +43,7 @@ qt4_wrap_ui(UIC_FILES
   src/ui/main_window.ui
   src/ui/run_benchmark_dialog.ui
   src/ui/robot_loader.ui
+  src/ui/bounding_box_goals.ui
 )
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/benchmarks_gui/include/main_window.h
+++ b/benchmarks_gui/include/main_window.h
@@ -44,6 +44,7 @@
 #include "ui_main_window.h"
 #include "ui_run_benchmark_dialog.h"
 #include "ui_robot_loader.h"
+#include "ui_bounding_box_goals.h"
 
 #ifndef Q_MOC_RUN
 
@@ -92,7 +93,10 @@ public Q_SLOTS:
 
   //Goals and states
   void goalPoseFeedback(visualization_msgs::InteractiveMarkerFeedback &feedback);
+  void createGoalAtPose(const std::string &name, const Eigen::Affine3d &pose);
   void createGoalPoseButtonClicked(void);
+  void showBBoxGoalsDialog();
+  void createBBoxGoalsButtonClicked(void);
   void removeSelectedGoalsButtonClicked(void);
   void removeAllGoalsButtonClicked(void);
   void goalPoseSelectionChanged(void);
@@ -145,7 +149,8 @@ private:
   Ui::MainWindow ui_;
   Ui_BenchmarkDialog run_benchmark_ui_;
   Ui_RobotLoader load_robot_ui_;
-  QDialog *robot_loader_dialog_, *run_benchmark_dialog_;
+  Ui_BoundingBoxGoalsDialog bbox_dialog_ui_;
+  QDialog *robot_loader_dialog_, *run_benchmark_dialog_, *bbox_dialog_;
   boost::shared_ptr<QSettings> settings_;
 
   //rviz

--- a/benchmarks_gui/src/main_window.cpp
+++ b/benchmarks_gui/src/main_window.cpp
@@ -190,7 +190,7 @@ MainWindow::MainWindow(int argc, char **argv, QWidget *parent) :
     connect( ui_.start_states_save_button, SIGNAL( clicked() ), this, SLOT( saveStatesOnDBButtonClicked() ));
     connect( ui_.start_states_list, SIGNAL( itemDoubleClicked(QListWidgetItem*) ), this, SLOT( startStateItemDoubleClicked(QListWidgetItem*) ));
 
-    QShortcut *copy_goals_shortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_C), ui_.goal_poses_list);
+    QShortcut *copy_goals_shortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_D), ui_.goal_poses_list);
     connect(copy_goals_shortcut, SIGNAL( activated() ), this, SLOT( copySelectedGoalPoses() ) );
 
     //Trajectories

--- a/benchmarks_gui/src/main_window.cpp
+++ b/benchmarks_gui/src/main_window.cpp
@@ -73,6 +73,9 @@ MainWindow::MainWindow(int argc, char **argv, QWidget *parent) :
   run_benchmark_dialog_ = new QDialog(0,0);
   run_benchmark_ui_.setupUi(run_benchmark_dialog_);
 
+  bbox_dialog_ = new QDialog(0,0);
+  bbox_dialog_ui_.setupUi(bbox_dialog_);
+
   //Rviz render panel
   render_panel_ = new rviz::RenderPanel();
   ui_.render_widget->addWidget(render_panel_);
@@ -163,7 +166,16 @@ MainWindow::MainWindow(int argc, char **argv, QWidget *parent) :
     connect(run_benchmark_ui_.benchmark_include_planners_checkbox, SIGNAL(clicked(bool)), run_benchmark_ui_.planning_algorithms_label,  SLOT(setEnabled(bool)));
 
     //Goal poses
-    connect( ui_.goal_poses_add_button, SIGNAL( clicked() ), this, SLOT( createGoalPoseButtonClicked() ));
+    QMenu *add_button_menu = new QMenu(ui_.goal_poses_add_button);
+    QAction *add_single_goal_action = new QAction("Single goal", add_button_menu);
+    QAction *bbox_goals_action = new QAction("Goals in a bounding box", add_button_menu);
+    add_button_menu->addAction(add_single_goal_action);
+    add_button_menu->addAction(bbox_goals_action);
+    ui_.goal_poses_add_button->setMenu(add_button_menu);
+    connect( add_single_goal_action, SIGNAL( triggered() ), this, SLOT( createGoalPoseButtonClicked() ));
+    connect( bbox_goals_action, SIGNAL( triggered() ), this, SLOT( showBBoxGoalsDialog() ));
+    connect( bbox_dialog_ui_.ok_button, SIGNAL(clicked()), this, SLOT(createBBoxGoalsButtonClicked()));
+    connect( bbox_dialog_ui_.cancel_button, SIGNAL(clicked()), bbox_dialog_, SLOT(hide()));
     connect( ui_.goal_poses_remove_button, SIGNAL( clicked() ), this, SLOT( deleteGoalsOnDBButtonClicked() ));
     connect( ui_.load_poses_filter_text, SIGNAL( returnPressed() ), this, SLOT( loadGoalsFromDBButtonClicked() ));
     connect( ui_.goal_poses_open_button, SIGNAL( clicked() ), this, SLOT( loadGoalsFromDBButtonClicked() ));

--- a/benchmarks_gui/src/ui/bounding_box_goals.ui
+++ b/benchmarks_gui/src/ui/bounding_box_goals.ui
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>BoundingBoxGoalsDialog</class>
+ <widget class="QDialog" name="BoundingBoxGoalsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>383</width>
+    <height>193</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Run benchmark</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+     </property>
+     <item row="1" column="0">
+      <widget class="QLabel" name="center_label">
+       <property name="text">
+        <string>Center</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QLabel" name="label_8">
+         <property name="text">
+          <string>x:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QDoubleSpinBox" name="center_x_text"/>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_9">
+         <property name="text">
+          <string>y:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QDoubleSpinBox" name="center_y_text"/>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_10">
+         <property name="text">
+          <string>z:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QDoubleSpinBox" name="center_z_text"/>
+       </item>
+      </layout>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="size_label">
+       <property name="text">
+        <string>Size</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item>
+        <widget class="QLabel" name="label_13">
+         <property name="text">
+          <string>x:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QDoubleSpinBox" name="size_x_text">
+         <property name="value">
+          <double>1.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_12">
+         <property name="text">
+          <string>y:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QDoubleSpinBox" name="size_y_text">
+         <property name="value">
+          <double>1.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_11">
+         <property name="text">
+          <string>z:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QDoubleSpinBox" name="size_z_text">
+         <property name="value">
+          <double>1.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="ngoals_label">
+       <property name="text">
+        <string>Number of goals</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout_4">
+       <item>
+        <widget class="QLabel" name="label_14">
+         <property name="text">
+          <string>x:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="ngoals_x_text">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="value">
+          <number>2</number>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_15">
+         <property name="text">
+          <string>y:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="ngoals_y_text">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="value">
+          <number>2</number>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_16">
+         <property name="text">
+          <string>z:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="ngoals_z_text">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="value">
+          <number>2</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Base name</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="base_name_text"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QPushButton" name="cancel_button">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="ok_button">
+       <property name="text">
+        <string>OK</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/benchmarks_gui/src/ui/main_window.ui
+++ b/benchmarks_gui/src/ui/main_window.ui
@@ -334,7 +334,7 @@
                   </size>
                  </property>
                  <property name="toolTip">
-                  <string>Press Ctrl+C to duplicate the selected goals</string>
+                  <string>Press Ctrl+D to duplicate the selected goals</string>
                  </property>
                  <property name="editTriggers">
                   <set>QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed</set>


### PR DESCRIPTION
This PR makes the "add goals" button in the benchmark GUI show two options: one for creating single goals at the current end-effector pose (the previous default behavior), and another one for creating a set of goals uniformly distributed in a bounding box given by origin and size.

It also switches the goal duplication shortcut from Ctrl-C (which is normally used for copy) to Ctrl-D.
