### PR TITLE
Allowed planning scene monitor to ignore joint states that are not used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ qtcreator-*
 
 # Emacs
 .#*
+
+# Catkin custom files
+CATKIN_IGNORE

--- a/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -308,22 +308,30 @@ void planning_scene_monitor::CurrentStateMonitor::jointStateCallback(const senso
     current_state_time_ = joint_state->header.stamp;
     for (std::size_t i = 0 ; i < n ; ++i)
     {
-      robot_state_.setVariablePosition(joint_state->name[i], joint_state->position[i]);
+      // check if this joint name is non-fixed in our urdf
+      int joint_index;
+      if( !robot_model_->getVariableIndex(joint_state->name[i], joint_index) )
+      {
+        ROS_WARN_STREAM_ONCE("Joint '" << joint_state->name[i] << "' was published in the joint state message but is not a valid joint variable. Ignoring.");
+        continue;
+      }
+
+      robot_state_.setVariablePosition(joint_index, joint_state->position[i]);
       joint_time_[joint_state->name[i]] = joint_state->header.stamp;
       
       // continuous joints wrap, so we don't modify them (even if they are outside bounds!)
-      const robot_model::JointModel* jm = robot_model_->getJointModel(joint_state->name[i]);
+      const robot_model::JointModel* jm = robot_model_->getJointModel(joint_index);
       if (jm && jm->getType() == robot_model::JointModel::REVOLUTE)
         if (static_cast<const robot_model::RevoluteJointModel*>(jm)->isContinuous())
           continue;
       
-      const robot_model::VariableBounds &b = robot_model_->getVariableBounds(joint_state->name[i]);
+      const robot_model::VariableBounds &b = robot_model_->getVariableBounds(joint_state->name[i]); // \todo make this depend on joint index
       // if the read variable is 'almost' within bounds (up to error_ difference), then consider it to be within bounds
       if (joint_state->position[i] < b.min_position_ && joint_state->position[i] >= b.min_position_ - error_)
-        robot_state_.setVariablePosition(joint_state->name[i], b.min_position_);
+        robot_state_.setVariablePosition(joint_state->name[i], b.min_position_);  // \todo make this depend on joint index
       else
         if (joint_state->position[i] > b.max_position_ && joint_state->position[i] <= b.max_position_ + error_)
-          robot_state_.setVariablePosition(joint_state->name[i], b.max_position_);
+          robot_state_.setVariablePosition(joint_state->name[i], b.max_position_);  // \todo make this depend on joint index
     }
     
     // read root transform, if needed


### PR DESCRIPTION
Baxter publishes two [joint states that are fixed](https://github.com/RethinkRobotics/baxter_common/issues/19) in its URDF. Because these variables do not exists, it throws an exception.

I also noted some potential optimizations that perhaps could be done - I haven't done them yet though because I'm not sure if I understand it fully.
