### PR TITLE
Removed misleading and duplicate debug message

### DIFF
--- a/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -187,7 +187,6 @@ bool planning_scene_monitor::CurrentStateMonitor::haveCompleteState(std::vector<
     if (joint_time_.find(dof[i]) == joint_time_.end())
       if (!isPassiveDOF(dof[i]))
       {
-        ROS_DEBUG("Joint variable '%s' has never been updated", dof[i].c_str());
         missing_states.push_back(dof[i]);
         result = false;
       }


### PR DESCRIPTION
This debug message will print when moveit starts up if you have joint states being published from two different locations. The problem is it is not waiting for both messages to be received so it always has this debug message. It is not needed, though, because a proper warning for the same thing is implemented one function call higher, [here](https://github.com/davetcoleman/moveit_ros/blob/73def2db47038d470098412ea45171aa39f68e8c/planning/planning_scene_monitor/src/planning_scene_monitor.cpp#L927) - and that one has a timer to wait for a second at at startup
