### PR TITLE
fix segfault in approach translate

### DIFF
--- a/manipulation/pick_place/src/approach_and_translate_stage.cpp
+++ b/manipulation/pick_place/src/approach_and_translate_stage.cpp
@@ -115,7 +115,7 @@ bool isStateCollisionFree(const planning_scene::PlanningScene *planning_scene,
   if (grasp_posture->joint_names.size() > 0)
   {
     // apply the grasp posture for the end effector (we always apply it here since it could be the case the sampler changes this posture)
-    for (std::size_t i = 0 ; i < grasp_posture->joint_names.size() ; ++i)
+    for (std::size_t i = 0 ; i < grasp_posture->points.size() ; ++i)
     {
       state->setVariablePositions(grasp_posture->joint_names, grasp_posture->points[i].positions);
       collision_detection::CollisionResult res;


### PR DESCRIPTION
Not sure why we're iterating through the points and not just taking the last one, but we certainly can't iterate through joint names and then use the index with points.
