### PR TITLE
adds compliance for mesa versions <9.2

### DIFF
--- a/perception/mesh_filter/src/gl_renderer.cpp
+++ b/perception/mesh_filter/src/gl_renderer.cpp
@@ -145,13 +145,13 @@ void mesh_filter::GLRenderer::initFrameBuffers ()
 
   glGenFramebuffers(1, &fbo_id_);
   glBindFramebuffer(GL_FRAMEBUFFER, fbo_id_);
-  glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, rgb_id_, 0);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rgb_id_, 0);
 
   glGenRenderbuffers(1, &rbo_id_);
   glBindRenderbuffer(GL_RENDERBUFFER, rbo_id_);
   glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT, width_, height_);
   glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, rbo_id_);
-  glFramebufferTexture(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, depth_id_, 0);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, depth_id_, 0);
   glBindRenderbuffer(GL_RENDERBUFFER, 0);
 
   GLenum DrawBuffers[2] = {GL_COLOR_ATTACHMENT0, GL_DEPTH_ATTACHMENT};


### PR DESCRIPTION
Intel's integrated graphics use Mesa for hardware acceleration. Because the currently used `glFramebufferTexture` method got only implemented recently[1], it's not yet available (current Ubuntu deb version is 8.0.4, most recent Mesa version is 9.2).

To me (Mesa/OpenGL noob speaking) `glFramebufferTexture2D` looks like doing the same as `glFramebufferTexture` and so I switched them to enable support for older Mesa versions. Another way to solve this might be to get the latest Intel drivers from their repository [2], but then again they are probably not as thoroughly tested as the ones available through Ubuntu's repos.

[1] http://comments.gmane.org/gmane.comp.video.mesa3d.devel/57128
[2] https://01.org/linuxgraphics/

PS: This fixes the segfault problem described in issue #315
