### PR TITLE
Added planning feedback to gui, refactored states tab

### DIFF
--- a/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/move_group/src/default_capabilities/move_action_capability.cpp
@@ -162,6 +162,7 @@ void move_group::MoveGroupMoveAction::executeMoveCallback_PlanOnly(const moveit_
 
   convertToMsg(res.trajectory_, action_res.trajectory_start, action_res.planned_trajectory);
   action_res.error_code = res.error_code_;
+  action_res.planning_time = res.planning_time_;
 }
 
 bool move_group::MoveGroupMoveAction::planUsingPlanningPipeline(const planning_interface::MotionPlanRequest &req, plan_execution::ExecutableMotionPlan &plan)

--- a/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -91,6 +91,9 @@ public:
 
     /// The trajectory of the robot (may not contain joints that are the same as for the start_state_)
     moveit_msgs::RobotTrajectory trajectory_;
+
+    /// The amount of time it took to generate the plan
+    double planning_time_;
   };
 
   /** \brief Construct a client for the MoveGroup action using a specified set of options \e opt. Optionally, specify a TF instance to use.

--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -569,6 +569,7 @@ public:
     {
       plan.trajectory_ = move_action_client_->getResult()->planned_trajectory;
       plan.start_state_ = move_action_client_->getResult()->trajectory_start;
+      plan.planning_time_ = move_action_client_->getResult()->planning_time;
       return true;
     }
     else

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -94,12 +94,27 @@ void MotionPlanningFrame::computePlanButtonClicked()
 {
   if (!move_group_)
     return;
+
+  // Clear status
+  ui_->result_label->setText("Planning...");
+
   configureForPlanning();
   current_plan_.reset(new moveit::planning_interface::MoveGroup::Plan());
   if (move_group_->plan(*current_plan_))
+  {
     ui_->execute_button->setEnabled(true);
+
+    // Success
+    ui_->result_label->setText(QString("Time: ").append(
+        QString::number(current_plan_->planning_time_,'f',3)));
+  }
   else
+  {
     current_plan_.reset();
+
+    // Failure
+    ui_->result_label->setText("Failed");
+  }
 }
 
 void MotionPlanningFrame::computeExecuteButtonClicked()

--- a/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>676</width>
+    <width>688</width>
     <height>377</height>
    </rect>
   </property>
@@ -238,6 +238,22 @@
                </widget>
               </item>
               <item>
+               <widget class="QLabel" name="result_label">
+                <property name="layoutDirection">
+                 <enum>Qt::LeftToRight</enum>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="wordWrap">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
                <spacer name="verticalSpacer">
                 <property name="orientation">
                  <enum>Qt::Vertical</enum>
@@ -291,7 +307,7 @@
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>206</width>
+                   <width>218</width>
                    <height>78</height>
                   </rect>
                  </property>
@@ -1257,52 +1273,79 @@
        <item>
         <layout class="QVBoxLayout" name="verticalLayout_4">
          <item>
-          <widget class="QPushButton" name="load_state_button">
-           <property name="text">
-            <string>Load States</string>
+          <widget class="QGroupBox" name="groupBox_15">
+           <property name="title">
+            <string>Stored States</string>
            </property>
+           <layout class="QGridLayout" name="gridLayout_17">
+            <item row="0" column="0">
+             <widget class="QPushButton" name="load_state_button">
+              <property name="text">
+               <string>Filter</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QPushButton" name="clear_states_button">
+              <property name="text">
+               <string>Clear</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="save_start_state_button">
-           <property name="text">
-            <string>Save Start State</string>
+          <widget class="QGroupBox" name="groupBox_16">
+           <property name="title">
+            <string>Selected State</string>
            </property>
+           <layout class="QGridLayout" name="gridLayout_15">
+            <item row="0" column="0">
+             <widget class="QPushButton" name="set_as_start_state_button">
+              <property name="text">
+               <string>Set as Start</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QPushButton" name="set_as_goal_state_button">
+              <property name="text">
+               <string>Set as Goal</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QPushButton" name="remove_state_button">
+              <property name="text">
+               <string>Remove</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="save_goal_state_button">
-           <property name="text">
-            <string>Save Goal State</string>
+          <widget class="QGroupBox" name="groupBox_17">
+           <property name="title">
+            <string>Current  State</string>
            </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="set_as_start_state_button">
-           <property name="text">
-            <string>Set as Start</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="set_as_goal_state_button">
-           <property name="text">
-            <string>Set as Goal</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="remove_state_button">
-           <property name="text">
-            <string>Remove State</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="clear_states_button">
-           <property name="text">
-            <string>Clear States</string>
-           </property>
+           <layout class="QGridLayout" name="gridLayout_16">
+            <item row="0" column="0">
+             <widget class="QPushButton" name="save_start_state_button">
+              <property name="text">
+               <string>Save Start</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QPushButton" name="save_goal_state_button">
+              <property name="text">
+               <string>Save Goal</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </widget>
          </item>
          <item>


### PR DESCRIPTION
Added feedback under planning button to show planning time or failure message:
![screenshot from 2013-11-01 18 29 41](https://f.cloud.github.com/assets/561060/1458132/edc31782-4355-11e3-9eaf-100448fd079d.png)

Cleaned up layout of buttons on Stored States tab:
![screenshot from 2013-11-01 18 29 22](https://f.cloud.github.com/assets/561060/1458134/f716a70e-4355-11e3-9b88-458f7bf7346a.png)

Added hooks to pass the planning time of a MoveGroupActionResult message.
