### PR TITLE
Fixed doxygen function-grouping.

### DIFF
--- a/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -175,7 +175,7 @@ public:
   void setSupportSurfaceName(const std::string &name);
 
   /**
-   * \defgroup set_joint_goal Setting a joint state target (goal)
+   * \name Setting a joint state target (goal)
    */
   /**@{*/
 
@@ -236,7 +236,7 @@ public:
 
 
   /**
-   * \defgroup set_pose_goal Setting a pose target (goal)
+   * \name Setting a pose target (goal)
    */
   /**@{*/
 
@@ -316,7 +316,7 @@ public:
   /**@}*/
 
   /**
-   * \defgroup plan_and_exec Planning a path from the start position to the Target (goal) position, and executing that plan.
+   * \name Planning a path from the start position to the Target (goal) position, and executing that plan.
    */
   /**@{*/
 
@@ -360,7 +360,7 @@ public:
   /**@}*/
 
   /**
-   * \defgroup high_level High level actions that trigger a sequence of plans and actions.
+   * \name High level actions that trigger a sequence of plans and actions.
    */
   /**@{*/
 
@@ -413,7 +413,7 @@ public:
   /**@}*/
 
   /**
-   * \defgroup query_robot_state Query current robot state
+   * \name Query current robot state
    */
   /**@{*/
 
@@ -448,7 +448,7 @@ public:
   /**@}*/
 
   /**
-   * \defgroup named_joint_goals Manage named joint configurations
+   * \name Manage named joint configurations
    */
   /**@{*/
 
@@ -470,7 +470,7 @@ public:
   /**@}*/
 
   /**
-   * \defgroup move_group_interface_constraints_management Manage planning constraints
+   * \name Manage planning constraints
    */
   /**@{*/
 

--- a/planning_interface/planning_scene_interface/include/moveit/planning_scene_interface/planning_scene_interface.h
+++ b/planning_interface/planning_scene_interface/include/moveit/planning_scene_interface/planning_scene_interface.h
@@ -51,7 +51,7 @@ public:
   ~PlanningSceneInterface();
 
   /**
-   * \defgroup move_group_interface_world_management Manage the world
+   * \name Manage the world
    */
   /**@{*/
 


### PR DESCRIPTION
\defgroup was used to describe the groups of functions, but that is supposed to
group classes and files into modules.  The grouping of functions was correct in
the code and the \defgroup tags just needed to be changed to \name tags, which then
group the functions nicely within the same page.
