### PR TITLE
Fixed one crash bug and fixed goal-selection bug #339

### DIFF
--- a/benchmarks_gui/include/main_window.h
+++ b/benchmarks_gui/include/main_window.h
@@ -189,6 +189,7 @@ private:
   EigenSTL::map_string_Affine3d goals_initial_pose_;
   EigenSTL::map_string_Affine3d goals_dragging_initial_pose_;
   bool goal_pose_dragging_;
+  Eigen::Affine3d drag_initial_pose_;
 
   typedef std::map<std::string, GripperMarkerPtr> GoalPoseMap;
   typedef std::pair<std::string, GripperMarkerPtr> GoalPosePair;


### PR DESCRIPTION
Fixed bug #339: selecting a goal pose in the 3D view when another exists moves the other point.

It seems the original author did not realize that when a "click" event happens, there will also be a "mouse down" event which happens first.  The "mouse down" event code was only concerned with the start of a drag, so caused trouble in the case of a click.
