### PR TITLE
Fix collision display benchmark gui

### DIFF
--- a/benchmarks_gui/include/main_window.h
+++ b/benchmarks_gui/include/main_window.h
@@ -217,7 +217,13 @@ private:
   void switchGoalPoseMarkerSelection(const std::string &marker_name);
   typedef std::pair<visualization_msgs::InteractiveMarker, boost::shared_ptr<rviz::InteractiveMarker> > MsgMarkerPair;
 
-  bool isStateColliding(robot_state::RobotState& robot_state, const std::string& group_name);
+  /** @brief Return true if any links of the given @a group_name are
+   * in collision with objects in the world (not including the rest of the
+   * robot).
+   *
+   * This function helps display collision state for a disconnected
+   * end-effector which is used to show goal poses. */
+  bool isGroupCollidingWithWorld(robot_state::RobotState& robot_state, const std::string& group_name);
 
   void checkIfGoalInCollision(const std::string & goal_name);
   void checkIfGoalReachable(const std::string &goal_name, bool update_if_reachable = false);

--- a/benchmarks_gui/include/main_window.h
+++ b/benchmarks_gui/include/main_window.h
@@ -217,6 +217,8 @@ private:
   void switchGoalPoseMarkerSelection(const std::string &marker_name);
   typedef std::pair<visualization_msgs::InteractiveMarker, boost::shared_ptr<rviz::InteractiveMarker> > MsgMarkerPair;
 
+  bool isStateColliding(robot_state::RobotState& robot_state, const std::string& group_name);
+
   void checkIfGoalInCollision(const std::string & goal_name);
   void checkIfGoalReachable(const std::string &goal_name, bool update_if_reachable = false);
   void computeLoadBenchmarkResults(const std::string &file);

--- a/benchmarks_gui/src/tab_states_and_goals.cpp
+++ b/benchmarks_gui/src/tab_states_and_goals.cpp
@@ -701,11 +701,8 @@ void MainWindow::checkIfGoalReachable(const std::string &goal_name, bool update_
   setStatusFromBackground(STATUS_INFO, "");
 }
 
-bool MainWindow::isStateColliding(robot_state::RobotState& robot_state, const std::string& group_name)
+bool MainWindow::isGroupCollidingWithWorld(robot_state::RobotState& robot_state, const std::string& group_name)
 {
-  // Want to do what you'd think this function would do:
-  // scene_display_->getPlanningSceneRO()->isStateColliding(robot_state, group_name);
-
   collision_detection::AllowedCollisionMatrix acm( scene_display_->getPlanningSceneRO()->getAllowedCollisionMatrix() );
   // get link names in group_name
   const std::vector<std::string>& group_link_names =
@@ -753,7 +750,7 @@ void MainWindow::checkIfGoalInCollision(const std::string & goal_name)
 
   robot_state::RobotState ks(scene_display_->getPlanningSceneRO()->getCurrentState());
   ks.updateStateWithLinkAt(eef.parent_link, marker_pose_eigen);
-  bool in_collision = isStateColliding(ks, eef.eef_group);
+  bool in_collision = isGroupCollidingWithWorld(ks, eef.eef_group);
 
   if ( in_collision )
   {


### PR DESCRIPTION
In benchmark GUI, when you move a goal pose marker around, the end-effector meshes in the middle are supposed to change color to yellow when they are in collision with something and back to normal when they are not.  Prior to this change, that collision detection did not work at all if the end-effector did not have any active joints.  Because of the collision-checking function it was using, it only checked collisions for links downstream from active joints in the given group.  So if it was the PR2 hand, it would have worked to check collisions with the fingers, but not with the palm.  With a fixed tool, it never showed any collisions.
