### PR TITLE
Fixed an occasional crash bug in rviz plugin caused by gui calls in non-gui thread.

### DIFF
--- a/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -139,6 +139,9 @@ class MotionPlanningDisplay : public PlanningSceneDisplay
   void setStatusTextColor(const QColor &color);
   void resetStatusTextColor();
 
+Q_SIGNALS:
+  void timeToShowNewTrail();
+
 private Q_SLOTS:
 
   // ******************************************************************************************


### PR DESCRIPTION
It's not clear to me when exactly this happens, but it was happening enough to me that I fixed it.

The code looks like it should be OK, because the subscription is done via "update_nh_", which should use the default global callback-queue.  However, I tried printing out the thread ID in the callback function and the GUI code, and sometimes the message callback happened in a different thread.

The fix was easy, just use a signal/slot call instead of a direct method call.
