### PR TITLE
Fix wrong cloud offset

### DIFF
--- a/perception/point_containment_filter/src/shape_mask.cpp
+++ b/perception/point_containment_filter/src/shape_mask.cpp
@@ -140,7 +140,7 @@ void point_containment_filter::ShapeMask::maskContainment(const pcl::PointCloud<
     for (int i = 0 ; i < (int)np ; ++i)
     {
       Eigen::Vector3d pt = Eigen::Vector3d(data_in.points[i].x, data_in.points[i].y, data_in.points[i].z);
-      double d = (sensor_origin - pt).norm();
+      double d = pt.norm();
       int out = OUTSIDE;
       if (d < min_sensor_dist || d > max_sensor_dist)
         out = CLIP;


### PR DESCRIPTION
For filtering points with sensor_range, distance between sensor_origin and a point was used for limiting range.
But, the point was not converted to the fixed frame, it still being on the sensor frame.
So, distance should be calculated at the sensor frame.
