### PR TITLE
Re-ordered movegroup's initialization, so capabilities start after monitors.

### DIFF
--- a/move_group/src/move_group.cpp
+++ b/move_group/src/move_group.cpp
@@ -170,13 +170,13 @@ int main(int argc, char **argv)
     else
       ROS_INFO("MoveGroup debug mode is OFF");
 
-    move_group::MoveGroupExe mge(planning_scene_monitor, debug);
-
     printf(MOVEIT_CONSOLE_COLOR_CYAN "Starting context monitors...\n" MOVEIT_CONSOLE_COLOR_RESET);
     planning_scene_monitor->startSceneMonitor();
     planning_scene_monitor->startWorldGeometryMonitor();
     planning_scene_monitor->startStateMonitor();
     printf(MOVEIT_CONSOLE_COLOR_CYAN "Context monitors started.\n" MOVEIT_CONSOLE_COLOR_RESET);
+
+    move_group::MoveGroupExe mge(planning_scene_monitor, debug);
 
     planning_scene_monitor->publishDebugInformation(debug);
 


### PR DESCRIPTION
This is intended to fix #378.

Capabilities starting after monitors means that a client which waits on a capability to become ready (via SimpleActionClient::waitForServer() for instance) can be sure that the rest of move_group is already initialized and thus ready to be used.

In a long-running system this is not really an issue, but for tests which start up a new instance of move_group each time, this is a big problem.

I don't know much about the other capabilities for move_group, so I don't know if this will cause trouble for them.  I do know it makes my own particular capability and its client work nicely though.
