### PR TITLE
add clear_octomap service

### DIFF
--- a/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
+++ b/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
@@ -46,6 +46,7 @@
 #include <moveit/point_containment_filter/shape_mask.h>
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
+#include <std_srvs/Empty.h>
 
 namespace occupancy_map_monitor
 {
@@ -73,6 +74,7 @@ private:
 
   bool getShapeTransform(ShapeHandle h, Eigen::Affine3d &transform) const;
   void cloudMsgCallback(const sensor_msgs::PointCloud2::ConstPtr &cloud_msg);
+  bool clearOctomap(std_srvs::EmptyRequest &req, std_srvs::EmptyResponse &res);
   void stopHelper();
 
   ros::NodeHandle root_nh_;
@@ -87,6 +89,7 @@ private:
   unsigned int point_subsample_;
   std::string filtered_cloud_topic_;
   ros::Publisher filtered_cloud_publisher_;
+  ros::ServiceServer clear_octomap_server_;
 
   message_filters::Subscriber<sensor_msgs::PointCloud2> *point_cloud_subscriber_;
   tf::MessageFilter<sensor_msgs::PointCloud2> *point_cloud_filter_;

--- a/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -110,6 +110,8 @@ void PointCloudOctomapUpdater::start()
     point_cloud_subscriber_->registerCallback(boost::bind(&PointCloudOctomapUpdater::cloudMsgCallback, this, _1));
     ROS_INFO("Listening to '%s'", point_cloud_topic_.c_str());
   }
+  clear_octomap_server_ =
+    private_nh_.advertiseService("clear_octomap", &PointCloudOctomapUpdater::clearOctomap, this);
 }
 
 void PointCloudOctomapUpdater::stopHelper()
@@ -156,7 +158,16 @@ bool PointCloudOctomapUpdater::getShapeTransform(ShapeHandle h, Eigen::Affine3d 
 void PointCloudOctomapUpdater::updateMask(const pcl::PointCloud<pcl::PointXYZ> &cloud, const Eigen::Vector3d &sensor_origin, std::vector<int> &mask)
 {
 }
+bool PointCloudOctomapUpdater::clearOctomap(std_srvs::EmptyRequest &req, std_srvs::EmptyResponse &reset)
+{
+  tree_->lockWrite();
+  // clear map
+  tree_->clear();
+  tree_->unlockWrite();
+  tree_->triggerUpdateCallback();
 
+  return true;
+}
 void PointCloudOctomapUpdater::cloudMsgCallback(const sensor_msgs::PointCloud2::ConstPtr &cloud_msg)
 {
   ROS_DEBUG("Received a new point cloud message");


### PR DESCRIPTION
I added a service to force clearing octomap.
It needs to clear un-updated point when sensor see wrong points such as noise.
