### PR TITLE
Why such a long default duration?

### DIFF
--- a/manipulation/pick_place/src/pick_place.cpp
+++ b/manipulation/pick_place/src/pick_place.cpp
@@ -46,7 +46,7 @@ namespace pick_place
 
 const std::string PickPlace::DISPLAY_PATH_TOPIC = planning_pipeline::PlanningPipeline::DISPLAY_PATH_TOPIC;
 const std::string PickPlace::DISPLAY_GRASP_TOPIC = "display_grasp_markers";
-const double PickPlace::DEFAULT_GRASP_POSTURE_COMPLETION_DURATION = 7.0; // seconds
+const double PickPlace::DEFAULT_GRASP_POSTURE_COMPLETION_DURATION = 1.0; // seconds
 
 // functionality specific to pick-only is in pick.cpp;
 // functionality specific to place-only is in place.cpp;


### PR DESCRIPTION
I've noticed that when asking for a pick plan my gripper time_to_start times get this time added which makes the closing of the gripper very slow.
As I don't fully understand the need of this value (there is one most probably) I propose lowering it.
