### PR TITLE
Fix: Parse error at "BOOST_JOIN"

### DIFF
--- a/benchmarks_gui/include/benchmark_processing_thread.h
+++ b/benchmarks_gui/include/benchmark_processing_thread.h
@@ -4,7 +4,9 @@
 #include <QtCore/QThread>
 #include <QProgressDialog>
 
+#ifndef Q_MOC_RUN
 #include <moveit/benchmarks/benchmark_execution.h>
+#endif
 
 class BenchmarkProcessingThread : public QThread
 {

--- a/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -49,12 +49,12 @@
 #include <moveit/semantic_world/semantic_world.h>
 #include <interactive_markers/interactive_marker_server.h>
 #include <rviz/default_plugin/interactive_markers/interactive_marker.h>
-#endif
-
-
 #include <moveit_msgs/MotionPlanRequest.h>
 #include <actionlib/client/simple_action_client.h>
 #include <object_recognition_msgs/ObjectRecognitionAction.h>
+#endif
+
+
 #include <std_msgs/Bool.h>
 #include <map>
 #include <string>


### PR DESCRIPTION
See: https://bugreports.qt-project.org/browse/QTBUG-22829

This was tested on Arch Linux (Qt 4.8.5, Boost 1.55) while packaging for hydro.
