### PR TITLE
Set link padding

### DIFF
--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -401,6 +401,10 @@ protected:
   double                                default_robot_padd_;
   /// default robot scaling
   double                                default_robot_scale_;
+  /// default unpadded-robot padding
+  double                                default_robot_unpadded_padd_;
+  /// default unpadded-robot scaling
+  double                                default_robot_unpadded_scale_;
   /// default object padding
   double                                default_object_padd_;
   /// default attached padding

--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -409,6 +409,15 @@ protected:
   double                                default_object_padd_;
   /// default attached padding
   double                                default_attached_padd_;
+  /// default robot link padding
+  std::map<std::string, double>         default_robot_link_padd_;
+  /// default robot link scale
+  std::map<std::string, double>         default_robot_link_scale_;
+  /// default unpadded robot link padding
+  std::map<std::string, double>         default_robot_link_unpadded_padd_;
+  /// default unpadded robot link scale
+  std::map<std::string, double>         default_robot_link_unpadded_scale_;
+
 
   // variables for planning scene publishing
   ros::Publisher                        planning_scene_publisher_;

--- a/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -180,6 +180,8 @@ void planning_scene_monitor::PlanningSceneMonitor::initialize(const planning_sce
 
         scene_->getCollisionRobotNonConst()->setPadding(default_robot_padd_);
         scene_->getCollisionRobotNonConst()->setScale(default_robot_scale_);
+        scene_->getCollisionRobotUnpaddedNonConst()->setPadding(default_robot_unpadded_padd_);
+        scene_->getCollisionRobotUnpaddedNonConst()->setScale(default_robot_unpadded_scale_);
         scene_->propogateRobotPadding();
       }
       catch (moveit::ConstructException &e)
@@ -1080,12 +1082,16 @@ void planning_scene_monitor::PlanningSceneMonitor::configureDefaultPadding()
   {
     default_robot_padd_ = 0.0;
     default_robot_scale_ = 1.0;
+    default_robot_unpadded_padd_ = 0.0;
+    default_robot_unpadded_scale_ = 1.0;
     default_object_padd_ = 0.0;
     default_attached_padd_ = 0.0;
     return;
   }
   nh_.param(robot_description_ + "_planning/default_robot_padding", default_robot_padd_, 0.0);
   nh_.param(robot_description_ + "_planning/default_robot_scale", default_robot_scale_, 1.0);
+  nh_.param(robot_description_ + "_planning/default_robot_unpadded_padding", default_robot_unpadded_padd_, 0.0);
+  nh_.param(robot_description_ + "_planning/default_robot_unpadded_scale", default_robot_unpadded_scale_, 1.0);
   nh_.param(robot_description_ + "_planning/default_object_padding", default_object_padd_, 0.0);
   nh_.param(robot_description_ + "_planning/default_attached_padding", default_attached_padd_, 0.0);
 }

--- a/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -180,8 +180,20 @@ void planning_scene_monitor::PlanningSceneMonitor::initialize(const planning_sce
 
         scene_->getCollisionRobotNonConst()->setPadding(default_robot_padd_);
         scene_->getCollisionRobotNonConst()->setScale(default_robot_scale_);
+        for(std::map<std::string, double>::iterator it=default_robot_link_padd_.begin(); it != default_robot_link_padd_.end(); it++) {
+            scene_->getCollisionRobotNonConst()->setLinkPadding(it->first, it->second);
+        }
+        for(std::map<std::string, double>::iterator it=default_robot_link_scale_.begin(); it != default_robot_link_scale_.end(); it++) {
+            scene_->getCollisionRobotNonConst()->setLinkScale(it->first, it->second);
+        }
         scene_->getCollisionRobotUnpaddedNonConst()->setPadding(default_robot_unpadded_padd_);
         scene_->getCollisionRobotUnpaddedNonConst()->setScale(default_robot_unpadded_scale_);
+        for(std::map<std::string, double>::iterator it=default_robot_link_unpadded_padd_.begin(); it != default_robot_link_unpadded_padd_.end(); it++) {
+            scene_->getCollisionRobotUnpaddedNonConst()->setLinkPadding(it->first, it->second);
+        }
+        for(std::map<std::string, double>::iterator it=default_robot_link_unpadded_scale_.begin(); it != default_robot_link_unpadded_scale_.end(); it++) {
+            scene_->getCollisionRobotUnpaddedNonConst()->setLinkScale(it->first, it->second);
+        }
         scene_->propogateRobotPadding();
       }
       catch (moveit::ConstructException &e)
@@ -1094,4 +1106,8 @@ void planning_scene_monitor::PlanningSceneMonitor::configureDefaultPadding()
   nh_.param(robot_description_ + "_planning/default_robot_unpadded_scale", default_robot_unpadded_scale_, 1.0);
   nh_.param(robot_description_ + "_planning/default_object_padding", default_object_padd_, 0.0);
   nh_.param(robot_description_ + "_planning/default_attached_padding", default_attached_padd_, 0.0);
+  nh_.param(robot_description_ + "_planning/default_robot_link_padding", default_robot_link_padd_, std::map<std::string, double>());
+  nh_.param(robot_description_ + "_planning/default_robot_link_scale", default_robot_link_padd_, std::map<std::string, double>());
+  nh_.param(robot_description_ + "_planning/default_robot_link_unpadded_padding", default_robot_link_unpadded_padd_, std::map<std::string, double>());
+  nh_.param(robot_description_ + "_planning/default_robot_link_unpadded_scale", default_robot_link_unpadded_padd_, std::map<std::string, double>());
 }


### PR DESCRIPTION
this is patch for https://github.com/ros-planning/moveit_ros/issues/402, add following 4 values

```
  /// default robot link padding                                                                                                                        
  std::map<std::string, double>         default_robot_link_padd_;
  /// default robot link scale                                                                                                                          
  std::map<std::string, double>         default_robot_link_scale_;
  /// default unpadded robot link padding                                                                                                               
  std::map<std::string, double>         default_robot_link_unpadded_padd_;
  /// default unpadded robot link scale                                                                                                                 
  std::map<std::string, double>         default_robot_link_unpadded_scale_;
```

please check #341, it explains the reason we need unpadded robot.
