### PR TITLE
Potential fix for current robot state incorrect

### DIFF
--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -179,6 +179,7 @@ private:
   ros::Subscriber                              joint_state_subscriber_;
   ros::Time                                    current_state_time_;
   ros::Time                                    last_tf_update_;
+  bool                                         first_update_;
   
   mutable boost::mutex                         state_update_lock_;
   std::vector< JointStateUpdateCallback >      update_callbacks_;

--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -179,7 +179,6 @@ private:
   ros::Subscriber                              joint_state_subscriber_;
   ros::Time                                    current_state_time_;
   ros::Time                                    last_tf_update_;
-  bool                                         first_update_;
   
   mutable boost::mutex                         state_update_lock_;
   std::vector< JointStateUpdateCallback >      update_callbacks_;

--- a/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -44,6 +44,7 @@ planning_scene_monitor::CurrentStateMonitor::CurrentStateMonitor(const robot_mod
   , robot_state_(robot_model)
   , state_monitor_started_(false)
   , error_(std::numeric_limits<float>::epsilon())
+  , first_update_(true)
 {
   robot_state_.setToDefaultValues();
 }
@@ -338,7 +339,13 @@ void planning_scene_monitor::CurrentStateMonitor::jointStateCallback(const senso
             robot_state_.setJointPositions(jm, &b.max_position_);
       }
     }
-    
+
+    if(first_update_)
+    {
+      update = true;
+      first_update_ = false;
+    }
+      
     // read root transform, if needed
     if (tf_ && (robot_model_->getRootJoint()->getType() == robot_model::JointModel::PLANAR ||
                 robot_model_->getRootJoint()->getType() == robot_model::JointModel::FLOATING))
@@ -381,5 +388,7 @@ void planning_scene_monitor::CurrentStateMonitor::jointStateCallback(const senso
   // callbacks, if needed
   if (update)
     for (std::size_t i = 0 ; i < update_callbacks_.size() ; ++i)
+    {
       update_callbacks_[i](joint_state);
+    }
 }

--- a/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -44,7 +44,6 @@ planning_scene_monitor::CurrentStateMonitor::CurrentStateMonitor(const robot_mod
   , robot_state_(robot_model)
   , state_monitor_started_(false)
   , error_(std::numeric_limits<float>::epsilon())
-  , first_update_(true)
 {
   robot_state_.setToDefaultValues();
 }
@@ -340,12 +339,6 @@ void planning_scene_monitor::CurrentStateMonitor::jointStateCallback(const senso
       }
     }
 
-    if(first_update_)
-    {
-      update = true;
-      first_update_ = false;
-    }
-      
     // read root transform, if needed
     if (tf_ && (robot_model_->getRootJoint()->getType() == robot_model::JointModel::PLANAR ||
                 robot_model_->getRootJoint()->getType() == robot_model::JointModel::FLOATING))

--- a/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -279,7 +279,7 @@ void planning_scene_monitor::PlanningSceneMonitor::startPublishingPlanningScene(
   publish_update_types_ = update_type;
   if (!publish_planning_scene_ && scene_)
   {
-    planning_scene_publisher_ = nh_.advertise<moveit_msgs::PlanningScene>(planning_scene_topic, 100, false);
+    planning_scene_publisher_ = nh_.advertise<moveit_msgs::PlanningScene>(planning_scene_topic, 100, true);
     ROS_INFO("Publishing maintained planning scene on '%s'", planning_scene_topic.c_str());
     monitorDiffs(true);
     publish_planning_scene_.reset(new boost::thread(boost::bind(&PlanningSceneMonitor::scenePublishingThread, this)));

--- a/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -888,11 +888,11 @@ void planning_scene_monitor::PlanningSceneMonitor::onStateUpdate(const sensor_ms
 {
   const ros::WallTime &n = ros::WallTime::now();
   const double t = (n - last_state_update_).toSec();
-  if (t >= dt_state_update_ && dt_state_update_ > std::numeric_limits<double>::epsilon())
-  {
+  //  if (t >= dt_state_update_ && dt_state_update_ > std::numeric_limits<double>::epsilon())
+  //  {
     last_state_update_ = n;
     updateSceneWithCurrentState();
-  }
+    //  }
 }
 
 void planning_scene_monitor::PlanningSceneMonitor::octomapUpdateCallback()


### PR DESCRIPTION
updates should always happen here (they are throttled in current state monitor anyway). 

This should fix #405 - the issue was the following:

(1) current_state_monitor will not pass updates on if none of the joints have changed values. industrial simulator publishes updates at 10 Hz. 
(2) planning_scene_monitor will not process a state update if they are not spaced apart by at least dt_state_update_ which defaults to 0.1s. So, the last state update never gets processed when being used with industrial robot simulator. 
(3) Changing the dt_state_update is not right either since planning_scene_monitor can still miss some updates

Solution is to not use dt_state_update but do an update in planning_scene_monitor everytime current_state_monitor updates - note that this could potentially cause issues if current_state updates come in too fast. 
