### PR TITLE
Fix planning scene display initial state

### DIFF
--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -92,6 +92,9 @@ public:
   /// The name of the topic used by default for receiving full planning scenes or planning scene diffs
   static const std::string DEFAULT_PLANNING_SCENE_TOPIC; // "/planning_scene"
   
+  /// The name of the service used by default for requesting full planning scene state
+  static const std::string DEFAULT_PLANNING_SCENE_SERVICE; // "/get_planning_scene"
+  
   /// The name of the topic used by default for publishing the monitored planning scene (this is without "/" in the name, so the topic is prefixed by the node name)
   static const std::string MONITORED_PLANNING_SCENE_TOPIC; // "monitored_planning_scene"
 
@@ -289,6 +292,14 @@ public:
    */
   void startSceneMonitor(const std::string &scene_topic = DEFAULT_PLANNING_SCENE_TOPIC);
 
+  /** @brief Request planning scene state using a service call
+   *  @param service_name The name of the service to use for requesting the
+   *     planning scene.  This must be a service of type
+   *     moveit_msgs::GetPlanningScene and is usually called
+   *     "/get_planning_scene".
+   */
+  bool requestPlanningSceneState(const std::string &service_name = DEFAULT_PLANNING_SCENE_SERVICE);
+
   /** @brief Stop the scene monitor*/
   void stopSceneMonitor();
 
@@ -344,9 +355,6 @@ protected:
 
   /** @brief Configure the default padding*/
   void configureDefaultPadding();
-
-  /** @brief Callback for a new planning scene msg*/
-  void newPlanningSceneCallback(const moveit_msgs::PlanningSceneConstPtr &scene);
 
   /** @brief Callback for a new collision object msg*/
   void collisionObjectCallback(const moveit_msgs::CollisionObjectConstPtr &obj);
@@ -460,6 +468,12 @@ private:
 
   // called by state_update_timer_ when a state update it pending
   void stateUpdateTimerCallback(const ros::WallTimerEvent& event);
+
+  // Callback for a new planning scene msg
+  void newPlanningSceneCallback(const moveit_msgs::PlanningSceneConstPtr &scene);
+
+  // Called to update the planning scene with a new message.
+  void newPlanningSceneMessage(const moveit_msgs::PlanningScene& scene);
 
 
   // Lock for state_update_pending_ and dt_state_update_

--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -443,6 +443,8 @@ protected:
   CollisionBodyShapeHandles collision_body_shape_handles_;
   mutable boost::recursive_mutex shape_handles_lock_;
 
+  /// lock access to update_callbacks_
+  boost::recursive_mutex update_lock_;
   std::vector<boost::function<void(SceneUpdateType)> > update_callbacks_; /// List of callbacks to trigger when updates are received
   ros::Time last_update_time_; /// Last time the state was updated
 

--- a/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -392,6 +392,9 @@ bool planning_scene_monitor::PlanningSceneMonitor::updatesScene(const planning_s
 
 void planning_scene_monitor::PlanningSceneMonitor::triggerSceneUpdateEvent(SceneUpdateType update_type)
 {
+  // do not modify update functions while we are calling them
+  boost::recursive_mutex::scoped_lock lock(update_lock_);
+
   for (std::size_t i = 0 ; i < update_callbacks_.size() ; ++i)
     update_callbacks_[i](update_type);
   new_scene_update_ = (SceneUpdateType) ((int)new_scene_update_ | (int)update_type);
@@ -1026,12 +1029,14 @@ void planning_scene_monitor::PlanningSceneMonitor::updateSceneWithCurrentState()
 
 void planning_scene_monitor::PlanningSceneMonitor::addUpdateCallback(const boost::function<void(SceneUpdateType)> &fn)
 {
+  boost::recursive_mutex::scoped_lock lock(update_lock_);
   if (fn)
     update_callbacks_.push_back(fn);
 }
 
 void planning_scene_monitor::PlanningSceneMonitor::clearUpdateCallbacks()
 {
+  boost::recursive_mutex::scoped_lock lock(update_lock_);
   update_callbacks_.clear();
 }
 

--- a/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -403,7 +403,6 @@ void planning_scene_monitor::PlanningSceneMonitor::triggerSceneUpdateEvent(Scene
   new_scene_update_condition_.notify_all();
 }
 
-// requestPlanningSceneState("/get_planning_scene");
 bool planning_scene_monitor::PlanningSceneMonitor::requestPlanningSceneState(const std::string& service_name)
 {
   ros::ServiceClient client = nh_.serviceClient<moveit_msgs::GetPlanningScene>(service_name);
@@ -422,12 +421,7 @@ bool planning_scene_monitor::PlanningSceneMonitor::requestPlanningSceneState(con
 
   if (client.call(srv))
   {
-    ROS_INFO("Got planning scene service response from %s -- applying...  is_diff=%d",
-      service_name.c_str(), srv.response.scene.is_diff?1:0);
-
     newPlanningSceneMessage(srv.response.scene);
-
-    ROS_INFO("Got planning scene service response from %s -- DONE applying.",service_name.c_str());
   }
   else
   {
@@ -446,7 +440,6 @@ void planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneCallback(cons
 
 void planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneMessage(const moveit_msgs::PlanningScene& scene)
 {
-  ROS_INFO("   newPlanningSceneCallback() isdiff=%d",scene.is_diff);
   if (scene_)
   {
     SceneUpdateType upd = UPDATE_SCENE;

--- a/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -68,7 +68,6 @@ PlanningSceneDisplay::PlanningSceneDisplay(bool listen_to_planning_scene, bool s
   current_scene_time_(0.0f),
   planning_scene_needs_render_(true)
 {
-  ROS_ERROR("ENTER PlanningSceneDisplay::PlanningSceneDisplay()");
   robot_description_property_ =
     new rviz::StringProperty( "Robot Description", "robot_description", "The name of the ROS parameter where the URDF for the robot is loaded",
                               this,
@@ -162,7 +161,6 @@ PlanningSceneDisplay::PlanningSceneDisplay(bool listen_to_planning_scene, bool s
     robot_alpha_property_ = NULL;
     attached_body_color_property_ = NULL;
   }
-  ROS_ERROR("EXIT  PlanningSceneDisplay::PlanningSceneDisplay()");
 }
 
 // ******************************************************************************************
@@ -359,13 +357,11 @@ void PlanningSceneDisplay::changedRobotSceneAlpha()
 
 void PlanningSceneDisplay::changedPlanningSceneTopic()
 {
-  ROS_ERROR("ENTER changedPlanningSceneTopic()");
   if (planning_scene_monitor_ && planning_scene_topic_property_)
   {
     planning_scene_monitor_->startSceneMonitor(planning_scene_topic_property_->getStdString());
     planning_scene_monitor_->requestPlanningSceneState();
   }
-  ROS_ERROR("EXIT  changedPlanningSceneTopic()");
 }
 
 void PlanningSceneDisplay::changedSceneDisplayTime()
@@ -558,7 +554,6 @@ void PlanningSceneDisplay::onSceneMonitorReceivedUpdate(planning_scene_monitor::
 
 void PlanningSceneDisplay::onEnable()
 {
-  ROS_ERROR("ENTER PlanningSceneDisplay::onEnable()");
   Display::onEnable();
 
   addBackgroundJob(boost::bind(&PlanningSceneDisplay::loadRobotModel, this), "loadRobotModel");
@@ -573,10 +568,6 @@ void PlanningSceneDisplay::onEnable()
     planning_scene_render_->getGeometryNode()->setVisible(scene_enabled_property_->getBool());
 
   calculateOffsetPosition();
-
-  
-
-  ROS_ERROR("EXIT  PlanningSceneDisplay::onEnable()");
 }
 
 // ******************************************************************************************

--- a/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -68,6 +68,7 @@ PlanningSceneDisplay::PlanningSceneDisplay(bool listen_to_planning_scene, bool s
   current_scene_time_(0.0f),
   planning_scene_needs_render_(true)
 {
+  ROS_ERROR("ENTER PlanningSceneDisplay::PlanningSceneDisplay()");
   robot_description_property_ =
     new rviz::StringProperty( "Robot Description", "robot_description", "The name of the ROS parameter where the URDF for the robot is loaded",
                               this,
@@ -161,6 +162,7 @@ PlanningSceneDisplay::PlanningSceneDisplay(bool listen_to_planning_scene, bool s
     robot_alpha_property_ = NULL;
     attached_body_color_property_ = NULL;
   }
+  ROS_ERROR("EXIT  PlanningSceneDisplay::PlanningSceneDisplay()");
 }
 
 // ******************************************************************************************
@@ -357,8 +359,13 @@ void PlanningSceneDisplay::changedRobotSceneAlpha()
 
 void PlanningSceneDisplay::changedPlanningSceneTopic()
 {
+  ROS_ERROR("ENTER changedPlanningSceneTopic()");
   if (planning_scene_monitor_ && planning_scene_topic_property_)
+  {
     planning_scene_monitor_->startSceneMonitor(planning_scene_topic_property_->getStdString());
+    planning_scene_monitor_->requestPlanningSceneState();
+  }
+  ROS_ERROR("EXIT  changedPlanningSceneTopic()");
 }
 
 void PlanningSceneDisplay::changedSceneDisplayTime()
@@ -516,8 +523,7 @@ void PlanningSceneDisplay::loadRobotModel()
 
 void PlanningSceneDisplay::onRobotModelLoaded()
 {
-  if (planning_scene_topic_property_)
-    planning_scene_monitor_->startSceneMonitor(planning_scene_topic_property_->getStdString());
+  changedPlanningSceneTopic();
   planning_scene_render_.reset(new PlanningSceneRender(planning_scene_node_, context_, planning_scene_robot_));
   planning_scene_render_->getGeometryNode()->setVisible(scene_enabled_property_->getBool());
 
@@ -552,6 +558,7 @@ void PlanningSceneDisplay::onSceneMonitorReceivedUpdate(planning_scene_monitor::
 
 void PlanningSceneDisplay::onEnable()
 {
+  ROS_ERROR("ENTER PlanningSceneDisplay::onEnable()");
   Display::onEnable();
 
   addBackgroundJob(boost::bind(&PlanningSceneDisplay::loadRobotModel, this), "loadRobotModel");
@@ -566,6 +573,10 @@ void PlanningSceneDisplay::onEnable()
     planning_scene_render_->getGeometryNode()->setVisible(scene_enabled_property_->getBool());
 
   calculateOffsetPosition();
+
+  
+
+  ROS_ERROR("EXIT  PlanningSceneDisplay::onEnable()");
 }
 
 // ******************************************************************************************


### PR DESCRIPTION
When rviz starts after move_group, the planning scene diff messages sent by move_group do not give PlanningSceneDisplay the full state of the planning scene.  For example if the robot has not moved for a while then move_group may not be sending updates of the robot state and the state of the PlanningScene robot will be different from the actual state of the real robot (it will appear in the default position rather than the current position).

This change fixes the PlanningSceneDisplay so that when it starts up (robot model is loaded or planning scene monitor topic changes) it will query move_group for the current full PlanningScene state and use that to initialize the PlanningScene maintained by the PlanningSceneDisplay.

Fixes issue https://github.com/ros-planning/moveit_ros/issues/405
Replaces https://github.com/ros-planning/moveit_ros/pull/407 and adds to https://github.com/ros-planning/moveit_ros/pull/408
