### PR TITLE
Added ability to set a random <collision free> start/goal position

### DIFF
--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -209,12 +209,12 @@ void MotionPlanningFrame::fillStateSelectionOptions()
   const robot_model::JointModelGroup *jmg = kmodel->getJointModelGroup(group);
   if (jmg)
   {
-    ui_->start_state_selection->addItem(QString("<random no collision>"));
+    ui_->start_state_selection->addItem(QString("<random valid>"));
     ui_->start_state_selection->addItem(QString("<random>"));
     ui_->start_state_selection->addItem(QString("<current>"));
     ui_->start_state_selection->addItem(QString("<same as goal>"));
 
-    ui_->goal_state_selection->addItem(QString("<random no collision>"));
+    ui_->goal_state_selection->addItem(QString("<random valid>"));
     ui_->goal_state_selection->addItem(QString("<random>"));
     ui_->goal_state_selection->addItem(QString("<current>"));
     ui_->goal_state_selection->addItem(QString("<same as start>"));
@@ -231,7 +231,7 @@ void MotionPlanningFrame::fillStateSelectionOptions()
       }
     }
     ui_->start_state_selection->setCurrentIndex(2); // default to 'current'
-    ui_->goal_state_selection->setCurrentIndex(0); // default to 'random no collision'
+    ui_->goal_state_selection->setCurrentIndex(0); // default to 'random valid'
   }
 }
 

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -209,10 +209,12 @@ void MotionPlanningFrame::fillStateSelectionOptions()
   const robot_model::JointModelGroup *jmg = kmodel->getJointModelGroup(group);
   if (jmg)
   {
+    ui_->start_state_selection->addItem(QString("<random no collision>"));
     ui_->start_state_selection->addItem(QString("<random>"));
     ui_->start_state_selection->addItem(QString("<current>"));
     ui_->start_state_selection->addItem(QString("<same as goal>"));
 
+    ui_->goal_state_selection->addItem(QString("<random no collision>"));
     ui_->goal_state_selection->addItem(QString("<random>"));
     ui_->goal_state_selection->addItem(QString("<current>"));
     ui_->goal_state_selection->addItem(QString("<same as start>"));

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -230,8 +230,8 @@ void MotionPlanningFrame::fillStateSelectionOptions()
         ui_->goal_state_selection->addItem(QString::fromStdString(known_states[i]));
       }
     }
-    ui_->start_state_selection->setCurrentIndex(1);
-    ui_->goal_state_selection->setCurrentIndex(0);
+    ui_->start_state_selection->setCurrentIndex(2); // default to 'current'
+    ui_->goal_state_selection->setCurrentIndex(0); // default to 'random no collision'
   }
 }
 

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -160,24 +160,24 @@ void MotionPlanningFrame::updateQueryStateHelper(robot_state::RobotState &state,
       configureWorkspace();
 
       // Loop until a collision free state is found
-      int max_iteration = 100; // prevent loop for going forever
-      while (max_iteration > 0)
+      static const int MAX_ATTEMPTS = 100;
+      int attempt_count = 0; // prevent loop for going forever
+      while (attempt_count < MAX_ATTEMPTS)
       {
         // Generate random state
         if (const robot_model::JointModelGroup *jmg = state.getJointModelGroup(planning_display_->getCurrentPlanningGroup()))
           state.setToRandomPositions(jmg);
 
         // Test for collision
-        if (!planning_display_->getPlanningSceneRO()->isStateColliding(state, "", true)) // verbose
+        if (!planning_display_->getPlanningSceneRO()->isStateColliding(state, "", false)) 
         {
-          ROS_INFO_STREAM_NAMED("temp","no collision!");
           break;
         }
         else
         {
-          ROS_ERROR_STREAM_NAMED("temp","THERE IS COLLISION");
+          ROS_WARN("Unable to find a random collision free configuration after %d attempts", MAX_ATTEMPTS);
         }
-        max_iteration --;
+        attempt_count ++;
       }
     }
     else

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -170,11 +170,12 @@ void MotionPlanningFrame::updateQueryStateHelper(robot_state::RobotState &state,
           // Generate random state
           state.setToRandomPositions(jmg);
 
+          state.update(); // prevent dirty transforms
+
           // Test for collision
-          if (!planning_display_->getPlanningSceneRO()->isStateColliding(state, "", false))
-          {
+          if (planning_display_->getPlanningSceneRO()->isStateValid(state, "", false))
             break;
-          }
+
           attempt_count ++;
         }
         // Explain if no valid rand state found

--- a/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -302,6 +302,9 @@
                 <property name="frameShadow">
                  <enum>QFrame::Raised</enum>
                 </property>
+                <property name="currentIndex">
+                 <number>1</number>
+                </property>
                 <widget class="QWidget" name="query_stackedwidgetPage2">
                  <property name="geometry">
                   <rect>
@@ -357,7 +360,7 @@
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>109</width>
+                   <width>218</width>
                    <height>78</height>
                   </rect>
                  </property>


### PR DESCRIPTION
Simply added a new option in the drop down box of the Rviz Plugin "Planning" tab that allows you to set the start/goal position randomly and **collision-free**. It attempts to find a collision-free configuration 100 times before giving up. 
