### PR TITLE
computeCartesianPath now accepts path constraints

### DIFF
--- a/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -576,6 +576,17 @@ public:
   double computeCartesianPath(const std::vector<geometry_msgs::Pose> &waypoints, double eef_step, double jump_threshold,
                               moveit_msgs::RobotTrajectory &trajectory,  bool avoid_collisions = true);
 
+  /** \brief Compute a Cartesian path that follows specified waypoints with a step size of at most \e eef_step meters
+      between end effector configurations of consecutive points in the result \e trajectory. The reference frame for the
+      waypoints is that specified by setPoseReferenceFrame(). No more than \e jump_threshold
+      is allowed as change in distance in the configuration space of the robot (this is to prevent 'jumps' in IK solutions).
+      Kinematic constraints for the path given by \e path_constraints will be met for every point along the trajectory.
+      Constraints are checked (collision and kinematic) if \e avoid_collisions is set to true. If constraints cannot be met, the function fails.
+      Return a value that is between 0.0 and 1.0 indicating the fraction of the path achieved as described by the waypoints.
+      Return -1.0 in case of error. */
+  double computeCartesianPath(const std::vector<geometry_msgs::Pose> &waypoints, double step, double jump_threshold,
+                              moveit_msgs::RobotTrajectory &msg, bool avoid_collisions, moveit_msgs::Constraints &path_constraints);
+
   /** \brief Stop any trajectory execution, if one is active */
   void stop();
 

--- a/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -585,8 +585,7 @@ public:
       Return a value that is between 0.0 and 1.0 indicating the fraction of the path achieved as described by the waypoints.
       Return -1.0 in case of error. */
   double computeCartesianPath(const std::vector<geometry_msgs::Pose> &waypoints, double step, double jump_threshold,
-                              moveit_msgs::RobotTrajectory &msg, bool avoid_collisions, const moveit_msgs::Constraints &path_constraints);
-
+                              moveit_msgs::RobotTrajectory &msg, const moveit_msgs::Constraints &path_constraints, bool avoid_collisions = true);
   /** \brief Stop any trajectory execution, if one is active */
   void stop();
 

--- a/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -585,7 +585,7 @@ public:
       Return a value that is between 0.0 and 1.0 indicating the fraction of the path achieved as described by the waypoints.
       Return -1.0 in case of error. */
   double computeCartesianPath(const std::vector<geometry_msgs::Pose> &waypoints, double step, double jump_threshold,
-                              moveit_msgs::RobotTrajectory &msg, bool avoid_collisions, moveit_msgs::Constraints &path_constraints);
+                              moveit_msgs::RobotTrajectory &msg, bool avoid_collisions, const moveit_msgs::Constraints &path_constraints);
 
   /** \brief Stop any trajectory execution, if one is active */
   void stop();

--- a/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -580,7 +580,7 @@ public:
       between end effector configurations of consecutive points in the result \e trajectory. The reference frame for the
       waypoints is that specified by setPoseReferenceFrame(). No more than \e jump_threshold
       is allowed as change in distance in the configuration space of the robot (this is to prevent 'jumps' in IK solutions).
-      Kinematic constraints for the path given by \e path_constraints will be met for every point along the trajectory.
+      Kinematic constraints for the path given by \e path_constraints will be met for every point along the trajectory, if they are not met, a partial solution will be returned.
       Constraints are checked (collision and kinematic) if \e avoid_collisions is set to true. If constraints cannot be met, the function fails.
       Return a value that is between 0.0 and 1.0 indicating the fraction of the path achieved as described by the waypoints.
       Return -1.0 in case of error. */

--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -632,7 +632,7 @@ public:
   }
 
   double computeCartesianPath(const std::vector<geometry_msgs::Pose> &waypoints, double step, double jump_threshold,
-                              moveit_msgs::RobotTrajectory &msg, bool avoid_collisions)
+                              moveit_msgs::RobotTrajectory &msg, bool avoid_collisions, moveit_msgs::Constraints &path_constraints)
   {
     moveit_msgs::GetCartesianPath::Request req;
     moveit_msgs::GetCartesianPath::Response res;
@@ -646,6 +646,7 @@ public:
     req.max_step = step;
     req.jump_threshold = jump_threshold;
     req.avoid_collisions = avoid_collisions;
+    req.path_constraints = path_constraints;
 
     if (cartesian_path_service_.call(req, res))
     {
@@ -1102,7 +1103,14 @@ bool moveit::planning_interface::MoveGroup::place(const std::string &object, con
 double moveit::planning_interface::MoveGroup::computeCartesianPath(const std::vector<geometry_msgs::Pose> &waypoints, double eef_step, double jump_threshold,
                                                                    moveit_msgs::RobotTrajectory &trajectory, bool avoid_collisions)
 {
-  return impl_->computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory, avoid_collisions);
+  moveit_msgs::Constraints path_constraints;
+  return impl_->computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory, avoid_collisions, path_constraints);
+}
+
+double moveit::planning_interface::MoveGroup::computeCartesianPath(const std::vector<geometry_msgs::Pose> &waypoints, double eef_step, double jump_threshold,
+                                                                   moveit_msgs::RobotTrajectory &trajectory, bool avoid_collisions, moveit_msgs::Constraints &path_constraints)
+{
+  return impl_->computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory, avoid_collisions, path_constraints);
 }
 
 void moveit::planning_interface::MoveGroup::stop()

--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -1103,12 +1103,12 @@ bool moveit::planning_interface::MoveGroup::place(const std::string &object, con
 double moveit::planning_interface::MoveGroup::computeCartesianPath(const std::vector<geometry_msgs::Pose> &waypoints, double eef_step, double jump_threshold,
                                                                    moveit_msgs::RobotTrajectory &trajectory, bool avoid_collisions)
 {
-  moveit_msgs::Constraints path_constraints;
+  const moveit_msgs::Constraints path_constraints;
   return impl_->computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory, avoid_collisions, path_constraints);
 }
 
 double moveit::planning_interface::MoveGroup::computeCartesianPath(const std::vector<geometry_msgs::Pose> &waypoints, double eef_step, double jump_threshold,
-                                                                   moveit_msgs::RobotTrajectory &trajectory, bool avoid_collisions, moveit_msgs::Constraints &path_constraints)
+                                                                   moveit_msgs::RobotTrajectory &trajectory, bool avoid_collisions, const moveit_msgs::Constraints &path_constraints)
 {
   return impl_->computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory, avoid_collisions, path_constraints);
 }

--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -632,7 +632,7 @@ public:
   }
 
   double computeCartesianPath(const std::vector<geometry_msgs::Pose> &waypoints, double step, double jump_threshold,
-                              moveit_msgs::RobotTrajectory &msg, bool avoid_collisions, const moveit_msgs::Constraints &path_constraints)
+                              moveit_msgs::RobotTrajectory &msg, const moveit_msgs::Constraints &path_constraints, bool avoid_collisions)
   {
     moveit_msgs::GetCartesianPath::Request req;
     moveit_msgs::GetCartesianPath::Response res;
@@ -1104,13 +1104,13 @@ double moveit::planning_interface::MoveGroup::computeCartesianPath(const std::ve
                                                                    moveit_msgs::RobotTrajectory &trajectory, bool avoid_collisions)
 {
   const moveit_msgs::Constraints path_constraints;
-  return impl_->computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory, avoid_collisions, path_constraints);
+  return impl_->computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory, path_constraints, avoid_collisions);
 }
 
 double moveit::planning_interface::MoveGroup::computeCartesianPath(const std::vector<geometry_msgs::Pose> &waypoints, double eef_step, double jump_threshold,
-                                                                   moveit_msgs::RobotTrajectory &trajectory, bool avoid_collisions, const moveit_msgs::Constraints &path_constraints)
+                                                                   moveit_msgs::RobotTrajectory &trajectory, const moveit_msgs::Constraints &path_constraints, bool avoid_collisions)
 {
-  return impl_->computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory, avoid_collisions, path_constraints);
+  return impl_->computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory, path_constraints, avoid_collisions);
 }
 
 void moveit::planning_interface::MoveGroup::stop()

--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -632,7 +632,7 @@ public:
   }
 
   double computeCartesianPath(const std::vector<geometry_msgs::Pose> &waypoints, double step, double jump_threshold,
-                              moveit_msgs::RobotTrajectory &msg, bool avoid_collisions, moveit_msgs::Constraints &path_constraints)
+                              moveit_msgs::RobotTrajectory &msg, bool avoid_collisions, const moveit_msgs::Constraints &path_constraints)
   {
     moveit_msgs::GetCartesianPath::Request req;
     moveit_msgs::GetCartesianPath::Response res;


### PR DESCRIPTION
GetCartesianPath service accepts path constraints but they were not exposed in move_group_interface. They will only be checked if 'avoid_collisions' is set to true. Perhaps 'avoid_collisions' would be better named as 'enforce_constraints'? 
