### PR TITLE
Improve RobotInteraction thread safety

### DIFF
--- a/robot_interaction/CMakeLists.txt
+++ b/robot_interaction/CMakeLists.txt
@@ -35,6 +35,8 @@ link_directories(${orocos_kdl_LIBRARY_DIRS})
 
 add_library(${MOVEIT_LIB_NAME}
   src/interactive_marker_helpers.cpp
+  src/kinematic_options.cpp
+  src/kinematic_options_map.cpp
   src/interaction_handler.cpp
   src/robot_interaction.cpp)
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/robot_interaction/CMakeLists.txt
+++ b/robot_interaction/CMakeLists.txt
@@ -37,9 +37,16 @@ add_library(${MOVEIT_LIB_NAME}
   src/interactive_marker_helpers.cpp
   src/kinematic_options.cpp
   src/kinematic_options_map.cpp
+  src/locked_robot_state.cpp
   src/interaction_handler.cpp
   src/robot_interaction.cpp)
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+catkin_add_gtest(locked_robot_state_test test/locked_robot_state_test.cpp)
+target_link_libraries(locked_robot_state_test
+  ${MOVEIT_LIB_NAME}
+  ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES})
 
 install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION lib)
 install(DIRECTORY include/ DESTINATION include)

--- a/robot_interaction/include/moveit/robot_interaction/interaction.h
+++ b/robot_interaction/include/moveit/robot_interaction/interaction.h
@@ -113,8 +113,8 @@ typedef boost::function<bool(
 ///           is somehow invalid or erronious (e.g. in collision).  true if
 ///           everything worked well.
 typedef boost::function<bool(
-	  robot_state::RobotState& state,
-	  const visualization_msgs::InteractiveMarkerFeedbackConstPtr & feedback)>
+    robot_state::RobotState& state,
+    const visualization_msgs::InteractiveMarkerFeedbackConstPtr & feedback)>
                                                 ProcessFeedbackFn;
 
 /// Type of function for updating marker pose for new state.

--- a/robot_interaction/include/moveit/robot_interaction/interaction.h
+++ b/robot_interaction/include/moveit/robot_interaction/interaction.h
@@ -1,0 +1,186 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, SRI International
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Acorn Pooley */
+
+#ifndef MOVEIT_ROBOT_INTERACTION_INTERACTION_
+#define MOVEIT_ROBOT_INTERACTION_INTERACTION_
+
+#include <visualization_msgs/InteractiveMarkerFeedback.h>
+#include <visualization_msgs/InteractiveMarker.h>
+#include <interactive_markers/menu_handler.h>
+#include <moveit/robot_state/robot_state.h>
+#include <boost/function.hpp>
+#include <boost/thread.hpp>
+#include <tf/tf.h>
+
+namespace moveit
+{
+namespace core
+{
+class RobotState;
+}
+}
+
+namespace robot_interaction
+{
+
+namespace InteractionStyle
+{
+  /// The different types of interaction that can be constructed for an end
+  /// effector This is a bitmask so OR together the parts you want.
+  enum InteractionStyle
+  {
+    POSITION_ARROWS = 1,      // arrows to change position
+    ORIENTATION_CIRCLES = 2,  // circles to change orientation
+    POSITION_SPHERE = 4,      // sphere: drag to change position
+    ORIENTATION_SPHERE = 8,   // sphere: drag to change orientation
+    POSITION_EEF = 16,        // drag end effector to change position
+    ORIENTATION_EEF = 32,     // drag end effector to change orientation
+    FIXED = 64,               // keep arrow and circle axis fixed
+
+    POSITION = POSITION_ARROWS |
+               POSITION_SPHERE |
+               POSITION_EEF,
+    ORIENTATION = ORIENTATION_CIRCLES |
+                  ORIENTATION_SPHERE |
+                  ORIENTATION_EEF,
+    SIX_DOF = POSITION |
+           ORIENTATION,
+    SIX_DOF_SPHERE = POSITION_SPHERE |
+                  ORIENTATION_SPHERE,
+    POSITION_NOSPHERE = POSITION_ARROWS |
+                        POSITION_EEF,
+    ORIENTATION_NOSPHERE = ORIENTATION_CIRCLES |
+                           ORIENTATION_EEF,
+    SIX_DOF_NOSPHERE = POSITION_NOSPHERE |
+                    ORIENTATION_NOSPHERE
+  };
+}
+
+/// Type of function for constructing markers.
+/// This callback sets up the marker used for an interaction.
+typedef boost::function<bool(
+          const robot_state::RobotState&,
+          visualization_msgs::InteractiveMarker&)>
+                                                InteractiveMarkerConstructorFn;
+
+/// Type of function for processing marker feedback.
+/// This callback function handles feedback for an Interaction's marker.
+/// Callback should update the robot state that was passed in according to
+/// the new position of the marker. Return true if the update was successful.
+/// Return false if the state was not successfully updated.
+typedef boost::function<bool(
+          robot_state::RobotState&,
+          const visualization_msgs::InteractiveMarkerFeedbackConstPtr &)>
+                                                ProcessFeedbackFn;
+
+/// Type of function for updating marker pose for new state.
+/// This callback is called when the robot state has changed.
+/// Callback should calculate a new
+/// pose for the marker based on the passed in robot state.
+/// Return true if the pose was modified, false if no update is needed (i.e. if
+/// the pose did not change).
+typedef boost::function<bool(
+          const robot_state::RobotState&,
+          geometry_msgs::Pose&)>
+                                                InteractiveMarkerUpdateFn;
+
+/// Representation of a generic interaction.
+/// Displays one interactive marker.
+struct GenericInteraction
+{
+  // Callback to construct interactive marker.
+  // See comment on typedef above.
+  InteractiveMarkerConstructorFn construct_marker;
+
+  // Callback to handle interactive marker feedback messages.
+  // See comment on typedef above.
+  ProcessFeedbackFn process_feedback;
+
+  // Callback to update marker pose when RobotState changes.
+  // See comment on typedef above.
+  InteractiveMarkerUpdateFn update_pose;
+
+  // Suffix added to name of markers.
+  // Automatically generated.
+  std::string marker_name_suffix;
+};
+
+/// Representation of an interaction via an end-effector
+/// Displays one marker for manipulating the EEF position.
+class EndEffectorInteraction
+{
+public:
+  /// The name of the group that sustains the end-effector (usually an arm)
+  std::string parent_group;
+
+  /// The name of the link in the parent group that connects to the end-effector
+  std::string parent_link;
+
+  /// The name of the group that defines the group joints
+  std::string eef_group;
+
+  /// Which degrees of freedom to enable for the end-effector
+  InteractionStyle::InteractionStyle interaction;
+
+  /// The size of the end effector group (diameter of enclosing sphere)
+  double size;
+
+};
+
+/// Representation of a joint interaction.
+/// Displays one marker for manipulating the joint.
+class JointInteraction
+{
+public:
+  /// The link in the robot model this joint is a parent of
+  std::string connecting_link;
+
+  /// The name of the frame that is a parent of this joint
+  std::string parent_frame;
+
+  /// The name of the joint
+  std::string joint_name;
+
+  /// The type of joint disguised as the number of DOF it has.  3=PLANAR in X/Y; 6=FLOATING
+  unsigned int dof;
+
+  /// The size of the connecting link  (diameter of enclosing sphere)
+  double size;
+};
+
+}
+
+#endif

--- a/robot_interaction/include/moveit/robot_interaction/interaction.h
+++ b/robot_interaction/include/moveit/robot_interaction/interaction.h
@@ -91,27 +91,41 @@ namespace InteractionStyle
 
 /// Type of function for constructing markers.
 /// This callback sets up the marker used for an interaction.
+/// @param state the current state of the robot
+/// @param marker the function should fill this in with an InteractiveMarker
+///          that will be used to control the interaction.
+///  @returns true if the function succeeds, false if the function was not able
+///          to fill in \e marker.
 typedef boost::function<bool(
-          const robot_state::RobotState&,
-          visualization_msgs::InteractiveMarker&)>
+          const robot_state::RobotState& state,
+          visualization_msgs::InteractiveMarker& marker)>
                                                 InteractiveMarkerConstructorFn;
 
 /// Type of function for processing marker feedback.
 /// This callback function handles feedback for an Interaction's marker.
 /// Callback should update the robot state that was passed in according to
-/// the new position of the marker. Return true if the update was successful.
-/// Return false if the state was not successfully updated.
+/// the new position of the marker.
+///
+/// @param state the current state of the robot
+/// @param marker the function should fill this in with an InteractiveMarker
+///          that will be used to control the interaction.
+/// @returns false if the state was not successfully updated or the new state
+///           is somehow invalid or erronious (e.g. in collision).  true if
+///           everything worked well.
 typedef boost::function<bool(
-          robot_state::RobotState&,
-          const visualization_msgs::InteractiveMarkerFeedbackConstPtr &)>
+	  robot_state::RobotState& state,
+	  const visualization_msgs::InteractiveMarkerFeedbackConstPtr & feedback)>
                                                 ProcessFeedbackFn;
 
 /// Type of function for updating marker pose for new state.
 /// This callback is called when the robot state has changed.
 /// Callback should calculate a new
 /// pose for the marker based on the passed in robot state.
-/// Return true if the pose was modified, false if no update is needed (i.e. if
-/// the pose did not change).
+/// @param state the new state of the robot
+/// @param pose the function should fill this in with the new pose of the
+///              marker, given the new state of the robot.
+/// @returns true if the pose was modified, false if no update is needed (i.e.
+///              if the pose did not change).
 typedef boost::function<bool(
           const robot_state::RobotState&,
           geometry_msgs::Pose&)>
@@ -140,9 +154,8 @@ struct GenericInteraction
 
 /// Representation of an interaction via an end-effector
 /// Displays one marker for manipulating the EEF position.
-class EndEffectorInteraction
+struct EndEffectorInteraction
 {
-public:
   /// The name of the group that sustains the end-effector (usually an arm)
   std::string parent_group;
 
@@ -162,9 +175,8 @@ public:
 
 /// Representation of a joint interaction.
 /// Displays one marker for manipulating the joint.
-class JointInteraction
+struct JointInteraction
 {
-public:
   /// The link in the robot model this joint is a parent of
   std::string connecting_link;
 

--- a/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
+++ b/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
@@ -346,7 +346,7 @@ public:
   const kinematics::KinematicsQueryOptions& getKinematicsQueryOptions() const;
   void setKinematicsQueryOptions(const kinematics::KinematicsQueryOptions &opt);
   void setKinematicsQueryOptionsForGroup(const std::string& group_name, 
-           kinematics::KinematicsQueryOptions &options);
+           const kinematics::KinematicsQueryOptions &options);
 };
 
 

--- a/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
+++ b/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
@@ -62,11 +62,11 @@ class GenericInteraction;
 
 
 /// Function type for notifying client of RobotState changes.
-//
-/// This callback function is called by the InteractionHandler::handle* functions,
-/// when changes are made to the internal robot state the handler maintains.
-/// The handler passes its own pointer as argument to the callback, as well
-/// as a boolean flag that indicates whether the error state changed --
+///
+/// This callback function is called by the InteractionHandler::handle*
+/// functions, when changes are made to the internal robot state the handler
+/// maintains.  The handler passes its own pointer as argument to the callback,
+/// as well as a boolean flag that indicates whether the error state changed --
 /// whether updates to the robot state performed in the
 /// InteractionHandler::handle* functions have switched from failing to
 /// succeeding or the other way around.
@@ -80,7 +80,8 @@ typedef boost::function<void(InteractionHandler*, bool)> InteractionHandlerCallb
 /// various joints in one group of one RobotState.
 /// The group being controlled is maintained by the RobotInteraction object
 /// that contains this InteractionHandler object.
-/// All InteractionHandler objects in the same RobotInteraction are controlling the same group.
+/// All InteractionHandler objects in the same RobotInteraction are controlling
+/// the same group.
 class InteractionHandler : public LockedRobotState
 {
 public:
@@ -126,33 +127,30 @@ public:
   void setControlsVisible(bool visible);
   bool getControlsVisible() const;
 
-  /** \brief Set the offset for drawing the interactive marker controls for an end-effector,
-   *         expressed in the frame of the end-effector parent.
-   * @param  The target end-effector.
-   * @param  The desired pose offset. */
+  /** \brief Set the offset from EEF to its marker.
+   * @param eef The target end-effector.
+   * @param m The pose of the marker in the frame of the end-effector parent. */
   void setPoseOffset(const EndEffectorInteraction& eef, const geometry_msgs::Pose& m);
 
-  /** \brief Set the offset for drawing the interactive marker controls for a joint,
-   *         expressed in the frame of the joint parent.
-   * @param  The target joint.
-   * @param  The desired pose offset. */
-  void setPoseOffset(const JointInteraction& eef, const geometry_msgs::Pose& m);
+  /** \brief Set the offset from a joint to its marker.
+   * @param j The target joint.
+   * @param m The pose of the marker in the frame of the joint parent. */
+  void setPoseOffset(const JointInteraction& j, const geometry_msgs::Pose& m);
 
-  /** \brief Get the offset for the interactive marker controls for an end-effector,
-   *         expressed in the frame of the end-effector parent.
+  /** \brief Get the offset from EEF to its marker.
    * @param  The target end-effector.
    * @param  The pose offset (only valid if return value is true).
-   * @return True if an offset was found for the given end-effector, false otherwise. */
+   * @return True if an offset was found for the given end-effector. */
   bool getPoseOffset(const EndEffectorInteraction& eef, geometry_msgs::Pose& m);
 
-  /** \brief Get the offset for the interactive marker controls for a joint,
-   *         expressed in the frame of the joint parent.
-   * @param  The target joint.
-   * @param  The pose offset (only valid if return value is true).
-   * @return True if an offset was found for the given joint, false otherwise. */
+  /** \brief Get the offset from a joint to its marker.
+   * @param vj The joint.
+   * @param m The pose offset (only valid if return value is true).
+   * @return True if an offset was found for the given joint. */
   bool getPoseOffset(const JointInteraction& vj, geometry_msgs::Pose& m);
 
-  /** \brief Clear the interactive marker pose offset for the given end-effector.
+  /** \brief Clear the interactive marker pose offset for the given
+   * end-effector.
    * @param  The target end-effector. */
   void clearPoseOffset(const EndEffectorInteraction& eef);
 
@@ -166,7 +164,8 @@ public:
   /** \brief Set the menu handler that defines menus and callbacks for all
    *         interactive markers drawn by this interaction handler.
    * @param  A menu handler. */
-  void setMenuHandler(const boost::shared_ptr<interactive_markers::MenuHandler>& mh);
+  void setMenuHandler(
+        const boost::shared_ptr<interactive_markers::MenuHandler>& mh);
 
 
   /** \brief Get the menu handler that defines menus and callbacks for all
@@ -179,17 +178,22 @@ public:
 
   /** \brief Get the last interactive_marker command pose for an end-effector.
    * @param The end-effector in question.
-   * @param A PoseStamped message containing the last (offset-removed) pose commanded for the end-effector.
+   * @param A PoseStamped message containing the last (offset-removed) pose
+   *           commanded for the end-effector.
    * @return True if a pose for that end-effector was found, false otherwise. */
-  bool getLastEndEffectorMarkerPose(const EndEffectorInteraction& eef, geometry_msgs::PoseStamped& pose);
+  bool getLastEndEffectorMarkerPose(const EndEffectorInteraction& eef, 
+                                    geometry_msgs::PoseStamped& pose);
 
   /** \brief Get the last interactive_marker command pose for a joint.
    * @param The joint in question.
-   * @param A PoseStamped message containing the last (offset-removed) pose commanded for the joint.
+   * @param A PoseStamped message containing the last (offset-removed) pose
+   *           commanded for the joint.
    * @return True if a pose for that joint was found, false otherwise. */
-  bool getLastJointMarkerPose(const JointInteraction& vj, geometry_msgs::PoseStamped& pose);
+  bool getLastJointMarkerPose(const JointInteraction& vj, 
+                              geometry_msgs::PoseStamped& pose);
 
-  /** \brief Clear the last interactive_marker command pose for the given end-effector.
+  /** \brief Clear the last interactive_marker command pose for the given
+   * end-effector.
    * @param  The target end-effector. */
   void clearLastEndEffectorMarkerPose(const EndEffectorInteraction& eef);
 
@@ -197,28 +201,34 @@ public:
    * @param  The target joint. */
   void clearLastJointMarkerPose(const JointInteraction& vj);
 
-  /** \brief Clear the last interactive_marker command poses for all end-effectors and joints. */
+  /** \brief Clear the last interactive_marker command poses for all
+   * end-effectors and joints. */
   void clearLastMarkerPoses();
 
   /** \brief Update the internal state maintained by the handler using
    * information from the received feedback message. */
-  virtual void handleEndEffector(const EndEffectorInteraction &eef,
-                                 const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback);
+  virtual void handleEndEffector(
+        const EndEffectorInteraction &eef,
+        const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback);
 
   /** \brief Update the internal state maintained by the handler using
    * information from the received feedback message. */
-  virtual void handleJoint(const JointInteraction &vj,
-                           const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback);
+  virtual void handleJoint(
+        const JointInteraction &vj,
+        const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback);
 
   /** \brief Update the internal state maintained by the handler using
    * information from the received feedback message. */
-  virtual void handleGeneric(const GenericInteraction &g,
-                             const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback);
+  virtual void handleGeneric(
+        const GenericInteraction &g,
+        const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback);
 
-  /** \brief Check if the marker corresponding to this end-effector leads to an invalid state */
+  /** \brief Check if the marker corresponding to this end-effector leads to an
+   * invalid state */
   virtual bool inError(const EndEffectorInteraction& eef) const;
 
-  /** \brief Check if the marker corresponding to this joint leads to an invalid state */
+  /** \brief Check if the marker corresponding to this joint leads to an
+   * invalid state */
   virtual bool inError(const JointInteraction& vj) const;
 
   /** \brief Check if the generic marker to an invalid state */
@@ -235,9 +245,10 @@ public:
 
 protected:
 
-  bool transformFeedbackPose(const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback,
-                             const geometry_msgs::Pose &offset,
-                             geometry_msgs::PoseStamped &tpose);
+  bool transformFeedbackPose(
+        const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback,
+        const geometry_msgs::Pose &offset,
+        geometry_msgs::PoseStamped &tpose);
 
   const std::string name_;
   const std::string planning_frame_;
@@ -249,10 +260,11 @@ private:
 
   // Update RobotState using a generic interaction feedback message.
   // YOU MUST LOCK state_lock_ BEFORE CALLING THIS.
-  void updateStateGeneric(robot_state::RobotState* state,
-                          const GenericInteraction* g,
-                          const visualization_msgs::InteractiveMarkerFeedbackConstPtr *feedback,
-                          StateChangeCallbackFn *callback);
+  void updateStateGeneric(
+        robot_state::RobotState* state,
+        const GenericInteraction* g,
+        const visualization_msgs::InteractiveMarkerFeedbackConstPtr *feedback,
+        StateChangeCallbackFn *callback);
 
   // Update RobotState for a new pose of an eef.
   // YOU MUST LOCK state_lock_ BEFORE CALLING THIS.
@@ -296,7 +308,8 @@ private:
   std::map<std::string, geometry_msgs::PoseStamped> pose_map_;
 
   // The RobotInteraction we are associated with.
-  // This is never safe to use because the RobotInteraction could be deleted at any time.
+  // This is never safe to use because the RobotInteraction could be deleted at
+  // any time.
   // Therefore it is stored as a void* to discourage its use.
   // This is only used inside setKinematicOptions() with the state_lock_ held.
   // That function should only be called from RobotInteraction methods.
@@ -307,7 +320,8 @@ private:
   boost::mutex offset_map_lock_;
 
   // per group options for doing kinematics.
-  // PROTECTED BY state_lock_ - The POINTER is protected by state_lock_.  The CONTENTS is protected internally.
+  // PROTECTED BY state_lock_ - The POINTER is protected by state_lock_.  The
+  // CONTENTS is protected internally.
   KinematicOptionsMapPtr kinematic_options_map_;
 
   // A set of Interactions for which the pose is invalid.
@@ -317,16 +331,20 @@ private:
   // For adding menus (and associated callbacks) to all the
   // end-effector and virtual-joint interactive markers
   //
-  // PROTECTED BY state_lock_ - The POINTER is protected by state_lock_.  The CONTENTS is not.
+  // PROTECTED BY state_lock_ - The POINTER is protected by state_lock_.  The
+  // CONTENTS is not.
   boost::shared_ptr<interactive_markers::MenuHandler> menu_handler_;
 
   // Called when the RobotState maintained by the handler changes. 
   // The caller may, for example, redraw the robot at the new state.
   // handler is the handler that changed.
-  // error_state_changed is true if an end effector's error state may have changed.
+  // error_state_changed is true if an end effector's error state may have
+  // changed.
   //
-  // PROTECTED BY state_lock_ - the function pointer is protected, but the call is made without any lock held.
-  boost::function<void(InteractionHandler* handler, bool error_state_changed)> update_callback_;
+  // PROTECTED BY state_lock_ - the function pointer is protected, but the call
+  // is made without any lock held.
+  boost::function<void(InteractionHandler* handler,
+                       bool error_state_changed)> update_callback_;
 
   // PROTECTED BY state_lock_
   bool display_meshes_;
@@ -339,8 +357,10 @@ private:
 
 public:
   // DEPRECATED FUNCTIONS.
-  // DO NOT USE THESE.  Instead access the KinematicOptions by calling RobotInteraction::getKinematicOptionsMap()
-  void setGroupStateValidityCallback(const robot_state::GroupStateValidityCallbackFn &callback);
+  // DO NOT USE THESE.  Instead access the KinematicOptions by calling
+  // RobotInteraction::getKinematicOptionsMap()
+  void setGroupStateValidityCallback(
+        const robot_state::GroupStateValidityCallbackFn &callback);
   void setIKTimeout(double timeout);
   void setIKAttempts(unsigned int attempts);
   const kinematics::KinematicsQueryOptions& getKinematicsQueryOptions() const;

--- a/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
+++ b/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
@@ -181,7 +181,7 @@ public:
    * @param A PoseStamped message containing the last (offset-removed) pose
    *           commanded for the end-effector.
    * @return True if a pose for that end-effector was found, false otherwise. */
-  bool getLastEndEffectorMarkerPose(const EndEffectorInteraction& eef, 
+  bool getLastEndEffectorMarkerPose(const EndEffectorInteraction& eef,
                                     geometry_msgs::PoseStamped& pose);
 
   /** \brief Get the last interactive_marker command pose for a joint.
@@ -189,7 +189,7 @@ public:
    * @param A PoseStamped message containing the last (offset-removed) pose
    *           commanded for the joint.
    * @return True if a pose for that joint was found, false otherwise. */
-  bool getLastJointMarkerPose(const JointInteraction& vj, 
+  bool getLastJointMarkerPose(const JointInteraction& vj,
                               geometry_msgs::PoseStamped& pose);
 
   /** \brief Clear the last interactive_marker command pose for the given
@@ -335,7 +335,7 @@ private:
   // CONTENTS is not.
   boost::shared_ptr<interactive_markers::MenuHandler> menu_handler_;
 
-  // Called when the RobotState maintained by the handler changes. 
+  // Called when the RobotState maintained by the handler changes.
   // The caller may, for example, redraw the robot at the new state.
   // handler is the handler that changed.
   // error_state_changed is true if an end effector's error state may have
@@ -365,7 +365,7 @@ public:
   void setIKAttempts(unsigned int attempts);
   const kinematics::KinematicsQueryOptions& getKinematicsQueryOptions() const;
   void setKinematicsQueryOptions(const kinematics::KinematicsQueryOptions &opt);
-  void setKinematicsQueryOptionsForGroup(const std::string& group_name, 
+  void setKinematicsQueryOptionsForGroup(const std::string& group_name,
            const kinematics::KinematicsQueryOptions &options);
 };
 

--- a/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
+++ b/robot_interaction/include/moveit/robot_interaction/interaction_handler.h
@@ -42,6 +42,20 @@
 namespace robot_interaction
 {
 
+
+/// Function type for notifying client of RobotState changes.
+//
+/// This callback function is called by the InteractionHandler::handle* functions,
+/// when changes are made to the internal robot state the handler maintains.
+/// The handler passes its own pointer as argument to the callback, as well
+/// as a boolean flag that indicates whether the error state changed --
+/// whether updates to the robot state performed in the
+/// InteractionHandler::handle* functions have switched from failing to
+/// succeeding or the other way around.
+typedef boost::function<void(InteractionHandler*, bool)> InteractionHandlerCallbackFn;
+
+
+
 /// Manage interactive markers to control a RobotState.
 ///
 /// Each instance maintains one or more interactive markers to control
@@ -49,7 +63,7 @@ namespace robot_interaction
 /// The group being controlled is maintained by the RobotInteraction object
 /// that contains this InteractionHandler object.
 /// All InteractionHandler objects in the same RobotInteraction are controlling the same group.
-class RobotInteraction::InteractionHandler
+class InteractionHandler
 {
 public:
 
@@ -162,35 +176,35 @@ return false;
    *         expressed in the frame of the end-effector parent.
    * @param  The target end-effector.
    * @param  The desired pose offset. */
-  void setPoseOffset(const RobotInteraction::EndEffector& eef, const geometry_msgs::Pose& m);
+  void setPoseOffset(const EndEffectorInteraction& eef, const geometry_msgs::Pose& m);
 
   /** \brief Set the offset for drawing the interactive marker controls for a joint,
    *         expressed in the frame of the joint parent.
    * @param  The target joint.
    * @param  The desired pose offset. */
-  void setPoseOffset(const RobotInteraction::Joint& eef, const geometry_msgs::Pose& m);
+  void setPoseOffset(const JointInteraction& eef, const geometry_msgs::Pose& m);
 
   /** \brief Get the offset for the interactive marker controls for an end-effector,
    *         expressed in the frame of the end-effector parent.
    * @param  The target end-effector.
    * @param  The pose offset (only valid if return value is true).
    * @return True if an offset was found for the given end-effector, false otherwise. */
-  bool getPoseOffset(const RobotInteraction::EndEffector& eef, geometry_msgs::Pose& m);
+  bool getPoseOffset(const EndEffectorInteraction& eef, geometry_msgs::Pose& m);
 
   /** \brief Get the offset for the interactive marker controls for a joint,
    *         expressed in the frame of the joint parent.
    * @param  The target joint.
    * @param  The pose offset (only valid if return value is true).
    * @return True if an offset was found for the given joint, false otherwise. */
-  bool getPoseOffset(const RobotInteraction::Joint& vj, geometry_msgs::Pose& m);
+  bool getPoseOffset(const JointInteraction& vj, geometry_msgs::Pose& m);
 
   /** \brief Clear the interactive marker pose offset for the given end-effector.
    * @param  The target end-effector. */
-  void clearPoseOffset(const RobotInteraction::EndEffector& eef);
+  void clearPoseOffset(const EndEffectorInteraction& eef);
 
   /** \brief Clear the interactive marker pose offset for the given joint.
    * @param  The target joint. */
-  void clearPoseOffset(const RobotInteraction::Joint& vj);
+  void clearPoseOffset(const JointInteraction& vj);
 
   /** \brief Clear the pose offset for all end-effectors and virtual joints. */
   void clearPoseOffsets();
@@ -213,48 +227,48 @@ return false;
    * @param The end-effector in question.
    * @param A PoseStamped message containing the last (offset-removed) pose commanded for the end-effector.
    * @return True if a pose for that end-effector was found, false otherwise. */
-  bool getLastEndEffectorMarkerPose(const RobotInteraction::EndEffector& eef, geometry_msgs::PoseStamped& pose);
+  bool getLastEndEffectorMarkerPose(const EndEffectorInteraction& eef, geometry_msgs::PoseStamped& pose);
 
   /** \brief Get the last interactive_marker command pose for a joint.
    * @param The joint in question.
    * @param A PoseStamped message containing the last (offset-removed) pose commanded for the joint.
    * @return True if a pose for that joint was found, false otherwise. */
-  bool getLastJointMarkerPose(const RobotInteraction::Joint& vj, geometry_msgs::PoseStamped& pose);
+  bool getLastJointMarkerPose(const JointInteraction& vj, geometry_msgs::PoseStamped& pose);
 
   /** \brief Clear the last interactive_marker command pose for the given end-effector.
    * @param  The target end-effector. */
-  void clearLastEndEffectorMarkerPose(const RobotInteraction::EndEffector& eef);
+  void clearLastEndEffectorMarkerPose(const EndEffectorInteraction& eef);
 
   /** \brief Clear the last interactive_marker command pose for the given joint.
    * @param  The target joint. */
-  void clearLastJointMarkerPose(const RobotInteraction::Joint& vj);
+  void clearLastJointMarkerPose(const JointInteraction& vj);
 
   /** \brief Clear the last interactive_marker command poses for all end-effectors and joints. */
   void clearLastMarkerPoses();
 
   /** \brief Update the internal state maintained by the handler using
    * information from the received feedback message. */
-  virtual void handleEndEffector(const RobotInteraction::EndEffector &eef,
+  virtual void handleEndEffector(const EndEffectorInteraction &eef,
                                  const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback);
 
   /** \brief Update the internal state maintained by the handler using
    * information from the received feedback message. */
-  virtual void handleJoint(const RobotInteraction::Joint &vj,
+  virtual void handleJoint(const JointInteraction &vj,
                            const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback);
 
   /** \brief Update the internal state maintained by the handler using
    * information from the received feedback message. */
-  virtual void handleGeneric(const RobotInteraction::Generic &g,
+  virtual void handleGeneric(const GenericInteraction &g,
                              const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback);
 
   /** \brief Check if the marker corresponding to this end-effector leads to an invalid state */
-  virtual bool inError(const RobotInteraction::EndEffector& eef) const;
+  virtual bool inError(const EndEffectorInteraction& eef) const;
 
   /** \brief Check if the marker corresponding to this joint leads to an invalid state */
-  virtual bool inError(const RobotInteraction::Joint& vj) const;
+  virtual bool inError(const JointInteraction& vj) const;
 
   /** \brief Check if the generic marker to an invalid state */
-  virtual bool inError(const RobotInteraction::Generic& g) const;
+  virtual bool inError(const GenericInteraction& g) const;
 
   /** \brief Clear any error settings. This makes the markers appear as if the state is no longer invalid. */
   void clearError(void);
@@ -324,6 +338,9 @@ private:
 
   void setup();
 };
+
+typedef boost::shared_ptr<InteractionHandler> InteractionHandlerPtr;
+typedef boost::shared_ptr<const InteractionHandler> InteractionHandlerConstPtr;
 
 }
 

--- a/robot_interaction/include/moveit/robot_interaction/kinematic_options.h
+++ b/robot_interaction/include/moveit/robot_interaction/kinematic_options.h
@@ -75,11 +75,10 @@ struct KinematicOptions
   /// @param tip link that will be posed
   /// @param pose desired pose of tip link
   /// @param result true if IK succeeded.
-  void setStateFromIK(robot_state::RobotState* state,
-                      const std::string* group,
-                      const std::string* tip,
-                      const geometry_msgs::Pose* pose,
-                      bool* result) const;
+  bool setStateFromIK(robot_state::RobotState& state,
+                      const std::string& group,
+                      const std::string& tip,
+                      const geometry_msgs::Pose& pose) const;
 
   /// Copy a subset of source to this.
   /// For each bit set in fields the corresponding member is copied from

--- a/robot_interaction/include/moveit/robot_interaction/kinematic_options.h
+++ b/robot_interaction/include/moveit/robot_interaction/kinematic_options.h
@@ -49,7 +49,6 @@ namespace robot_interaction
 // functions and no destructor.
 struct KinematicOptions
 {
-public: 
   /// Constructor - set all options to reasonable default values
   KinematicOptions();
 

--- a/robot_interaction/include/moveit/robot_interaction/kinematic_options.h
+++ b/robot_interaction/include/moveit/robot_interaction/kinematic_options.h
@@ -1,0 +1,80 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, SRI International
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Acorn Pooley */
+
+#ifndef MOVEIT_ROBOT_INTERACTION_KINEMATIC_OPTIONS_
+#define MOVEIT_ROBOT_INTERACTION_KINEMATIC_OPTIONS_
+
+#include <moveit/kinematics_base/kinematics_base.h>
+#include <moveit/robot_state/robot_state.h>
+
+namespace robot_interaction
+{
+
+// Options for inverse kinematics calculations.
+struct KinematicOptions
+{
+public: 
+  /// Constructor - set all options to reasonable default values
+  KinematicOptions();
+
+  /// Set \e state using inverse kinematics
+  /// @param state the state to set
+  /// @param group name of group whose joints can move
+  /// @param tip link that will be posed
+  /// @param pose desired pose of tip link
+  /// @param result true if IK succeeded.
+  void setStateFromIK(robot_state::RobotState* state,
+                      const std::string* group,
+                      const std::string* tip,
+                      const geometry_msgs::Pose* pose,
+                      bool* result) const;
+
+  /// max time an IK attempt can take before we give up.
+  double timeout_seconds_;
+
+  /// how many attempts before we give up.
+  unsigned int max_attempts_;
+
+  /// other options
+  kinematics::KinematicsQueryOptions options_;
+
+  /// This is called to determine if the state is valid
+  robot_state::GroupStateValidityCallbackFn state_validity_callback_;
+};
+
+}
+
+#endif

--- a/robot_interaction/include/moveit/robot_interaction/kinematic_options.h
+++ b/robot_interaction/include/moveit/robot_interaction/kinematic_options.h
@@ -44,11 +44,31 @@ namespace robot_interaction
 {
 
 // Options for inverse kinematics calculations.
+//
+// This is intended to be lightweight and passable by value.  No virtual
+// functions and no destructor.
 struct KinematicOptions
 {
 public: 
   /// Constructor - set all options to reasonable default values
   KinematicOptions();
+
+  /// Bits corresponding to each member.
+  /// NOTE: when adding fields to this structure also add the field to this
+  /// enum and to the setOptions() method.
+  enum OptionBitmask
+  {
+    TIMEOUT                     = 0x00000001, // timeout_seconds_
+    MAX_ATTEMPTS                = 0x00000002, // max_attempts_
+    STATE_VALIDITY_CALLBACK     = 0x00000004, // state_validity_callback_
+    LOCK_REDUNDANT_JOINTS       = 0x00000008, // options_.lock_redundant_joints
+    RETURN_APPROXIMATE_SOLUTION = 0x00000010, // options_.return_approximate_solution
+
+    ALL_QUERY_OPTIONS           = LOCK_REDUNDANT_JOINTS |
+                                  RETURN_APPROXIMATE_SOLUTION,
+    ALL                         = 0x7fffffff
+  };
+
 
   /// Set \e state using inverse kinematics
   /// @param state the state to set
@@ -62,17 +82,23 @@ public:
                       const geometry_msgs::Pose* pose,
                       bool* result) const;
 
+  /// Copy a subset of source to this.
+  /// For each bit set in fields the corresponding member is copied from
+  /// source to this.
+  void setOptions(const KinematicOptions& source,
+                  OptionBitmask fields = ALL);
+
   /// max time an IK attempt can take before we give up.
   double timeout_seconds_;
 
   /// how many attempts before we give up.
   unsigned int max_attempts_;
 
-  /// other options
-  kinematics::KinematicsQueryOptions options_;
-
   /// This is called to determine if the state is valid
   robot_state::GroupStateValidityCallbackFn state_validity_callback_;
+
+  /// other options
+  kinematics::KinematicsQueryOptions options_;
 };
 
 }

--- a/robot_interaction/include/moveit/robot_interaction/kinematic_options_map.h
+++ b/robot_interaction/include/moveit/robot_interaction/kinematic_options_map.h
@@ -46,7 +46,7 @@ namespace robot_interaction
 
 // Maintains a set of KinematicOptions with a key/value mapping and a default
 // value.
-struct KinematicOptionsMap
+class KinematicOptionsMap
 {
 public: 
   /// Constructor - set all options to reasonable default values.

--- a/robot_interaction/include/moveit/robot_interaction/kinematic_options_map.h
+++ b/robot_interaction/include/moveit/robot_interaction/kinematic_options_map.h
@@ -48,7 +48,7 @@ namespace robot_interaction
 // value.
 class KinematicOptionsMap
 {
-public: 
+public:
   /// Constructor - set all options to reasonable default values.
   KinematicOptionsMap();
 
@@ -103,8 +103,8 @@ private:
   KinematicOptions defaults_;
 
   typedef std::map<std::string, KinematicOptions> M_options;
-  
-  // per key kinematic options.  
+
+  // per key kinematic options.
   // If key is not here, defaults are used.
   // PROTECTED BY lock_
   M_options options_;

--- a/robot_interaction/include/moveit/robot_interaction/kinematic_options_map.h
+++ b/robot_interaction/include/moveit/robot_interaction/kinematic_options_map.h
@@ -65,12 +65,11 @@ public:
   /// @param tip link that will be posed
   /// @param pose desired pose of tip link
   /// @param result true if IK succeeded.
-  void setStateFromIK(robot_state::RobotState* state,
-                      const std::string* key,
-                      const std::string* group,
-                      const std::string* tip,
-                      const geometry_msgs::Pose* pose,
-                      bool* result) const;
+  bool setStateFromIK(robot_state::RobotState& state,
+                      const std::string& key,
+                      const std::string& group,
+                      const std::string& tip,
+                      const geometry_msgs::Pose& pose) const;
 
   /// Get the options to use for a particular key.
   /// To get the default values pass key = KinematicOptionsMap::DEFAULT

--- a/robot_interaction/include/moveit/robot_interaction/kinematic_options_map.h
+++ b/robot_interaction/include/moveit/robot_interaction/kinematic_options_map.h
@@ -39,6 +39,7 @@
 
 #include <moveit/robot_interaction/kinematic_options.h>
 #include <boost/thread.hpp>
+#include <boost/function.hpp>
 
 namespace robot_interaction
 {
@@ -50,6 +51,12 @@ struct KinematicOptionsMap
 public: 
   /// Constructor - set all options to reasonable default values.
   KinematicOptionsMap();
+
+  /// When used as \e key this means the default value
+  static const std::string DEFAULT;
+
+  /// When used as \e key this means set ALL keys (including default)
+  static const std::string ALL;
 
   /// Set \e state using inverse kinematics.
   /// @param state the state to set
@@ -66,25 +73,27 @@ public:
                       bool* result) const;
 
   /// Get the options to use for a particular key.
+  /// To get the default values pass key = KinematicOptionsMap::DEFAULT
   KinematicOptions getOptions(const std::string& key) const;
 
-  // Set the options to be used for a particular key.
-  void setOptions(const std::string& key,
-                       const KinematicOptions& options);
+  /// Set some of the options to be used for a particular key.
+  ///
+  /// @param key set the options for this key.
+  ///         To set the default options use key = KinematicOptionsMap::DEFAULT
+  ///         To set ALL options use key = KinematicOptionsMap::ALL
+  ///
+  /// @param options the new value for the options.
+  ///
+  /// @fields which options to set for the key.
+  void setOptions(
+          const std::string& key,
+          const KinematicOptions& options,
+          KinematicOptions::OptionBitmask fields = KinematicOptions::ALL);
 
-  /// Get the options to use by default (for unknown keys).
-  KinematicOptions getDefaultOptions() const;
-
-  // Set the options to be used by default.
-  void setDefaultOptions(const KinematicOptions& options);
-
-  // Clear all the key-specific options.
-  // Does not affect the default values.
-  // After this all keys will return default options.
-  void clear();
-
-  /// get a list of all keys which have non-default values.
-  void getKeys(std::vector<std::string>& keys) const;
+  /// Merge all options from \e other into \e this.
+  /// Values in \e other (including defaults_) take precedence over values in \e
+  /// this.
+  void merge(const KinematicOptionsMap& other);
 
 private:
   // this protects all members.

--- a/robot_interaction/include/moveit/robot_interaction/kinematic_options_map.h
+++ b/robot_interaction/include/moveit/robot_interaction/kinematic_options_map.h
@@ -1,0 +1,107 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, SRI International
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Acorn Pooley */
+
+#ifndef MOVEIT_ROBOT_INTERACTION_KINEMATIC_OPTIONS_MAP_
+#define MOVEIT_ROBOT_INTERACTION_KINEMATIC_OPTIONS_MAP_
+
+#include <moveit/robot_interaction/kinematic_options.h>
+#include <boost/thread.hpp>
+
+namespace robot_interaction
+{
+
+// Maintains a set of KinematicOptions with a key/value mapping and a default
+// value.
+struct KinematicOptionsMap
+{
+public: 
+  /// Constructor - set all options to reasonable default values.
+  KinematicOptionsMap();
+
+  /// Set \e state using inverse kinematics.
+  /// @param state the state to set
+  /// @param key used to lookup the options to use
+  /// @param group name of group whose joints can move
+  /// @param tip link that will be posed
+  /// @param pose desired pose of tip link
+  /// @param result true if IK succeeded.
+  void setStateFromIK(robot_state::RobotState* state,
+                      const std::string* key,
+                      const std::string* group,
+                      const std::string* tip,
+                      const geometry_msgs::Pose* pose,
+                      bool* result) const;
+
+  /// Get the options to use for a particular key.
+  KinematicOptions getOptions(const std::string& key) const;
+
+  // Set the options to be used for a particular key.
+  void setOptions(const std::string& key,
+                       const KinematicOptions& options);
+
+  /// Get the options to use by default (for unknown keys).
+  KinematicOptions getDefaultOptions() const;
+
+  // Set the options to be used by default.
+  void setDefaultOptions(const KinematicOptions& options);
+
+  // Clear all the key-specific options.
+  // Does not affect the default values.
+  // After this all keys will return default options.
+  void clear();
+
+  /// get a list of all keys which have non-default values.
+  void getKeys(std::vector<std::string>& keys) const;
+
+private:
+  // this protects all members.
+  mutable boost::mutex lock_;
+
+  // default kinematic options.
+  // PROTECTED BY lock_
+  KinematicOptions defaults_;
+
+  typedef std::map<std::string, KinematicOptions> M_options;
+  
+  // per key kinematic options.  
+  // If key is not here, defaults are used.
+  // PROTECTED BY lock_
+  M_options options_;
+};
+
+}
+
+#endif

--- a/robot_interaction/include/moveit/robot_interaction/locked_robot_state.h
+++ b/robot_interaction/include/moveit/robot_interaction/locked_robot_state.h
@@ -96,10 +96,12 @@ protected:
   // TODO: is this needed?
   virtual void robotStateChanged();
 
-private:
+protected:
   // this locks all accesses to the state_ member.
+  // The lock can also be used by subclasses to lock additional fields.
   mutable boost::mutex state_lock_;
 
+private:
   // The state maintained by this class.
   // When a modify function is being called this is NULL.
   // PROTECTED BY state_lock_

--- a/robot_interaction/include/moveit/robot_interaction/locked_robot_state.h
+++ b/robot_interaction/include/moveit/robot_interaction/locked_robot_state.h
@@ -1,0 +1,114 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2008, Willow Garage, Inc.
+ *  Copyright (c) 2014, SRI International
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Ioan Sucan, Acorn Pooley */
+
+#ifndef MOVEIT_ROBOT_INTERACTION_LOCKED_ROBOT_STATE_
+#define MOVEIT_ROBOT_INTERACTION_LOCKED_ROBOT_STATE_
+
+#include <moveit/robot_state/robot_state.h>
+#include <boost/function.hpp>
+#include <boost/thread.hpp>
+
+namespace robot_interaction
+{
+
+/// Maintain a RobotState in a multithreaded environment.
+//
+// Only allow one thread to modify the RobotState at a time.
+//
+// Allow any thread access to the RobotState when it is not being modified.  If
+// a (const) reference to the robot state is held when the RobotState needs to
+// be modified, a copy is made and the copy is modified.  Any externally held
+// references will be out of date but still valid.
+//
+// The RobotState can only be modified by passing a callback function which
+// does the modification.
+class LockedRobotState
+{
+public:
+  LockedRobotState(const robot_state::RobotStatePtr& state);
+  LockedRobotState(const robot_state::RobotState& state);
+  LockedRobotState(const robot_model::RobotModelPtr& model);
+
+  virtual ~LockedRobotState();
+
+  /// get read-only access to the state.
+  //
+  // This state may go stale, meaning the maintained state has been updated,
+  // but it will never be modified while the caller is holding a reference to
+  // it.
+  //
+  // The transforms in the returned state will always be up to date.
+  robot_state::RobotStateConstPtr getState() const;
+
+  /// Set the state to the new value.
+  void setState(const robot_state::RobotState& state);
+
+  // This is a function that can modify the maintained state.
+  typedef boost::function<void (robot_state::RobotState*)> ModifyStateFunction;
+  
+  // Modify the state.
+  //
+  // This modifies the state by calling \e modify on it.
+  // The \e modify function is passed a reference to the state which it can
+  // modify.  No threads will be given access to the state while the \e modify
+  // function is running.
+  void modifyState(ModifyStateFunction modify);
+
+protected:
+  // This is called when the internally maintained state has changed.
+  // This is called with state_lock_ unlocked.
+  // Default definition does nothing.  Override to get notification of state
+  // change.
+  // TODO: is this needed?
+  virtual void robotStateChanged();
+
+private:
+  // this locks all accesses to the state_ member.
+  mutable boost::mutex state_lock_;
+
+  // The state maintained by this class.
+  // When a modify function is being called this is NULL.
+  // PROTECTED BY state_lock_
+  robot_state::RobotStatePtr state_;
+};
+
+typedef boost::shared_ptr<LockedRobotState> LockedRobotStatePtr;
+typedef boost::shared_ptr<const LockedRobotState> LockedRobotStateConstPtr;
+
+}
+
+#endif

--- a/robot_interaction/include/moveit/robot_interaction/locked_robot_state.h
+++ b/robot_interaction/include/moveit/robot_interaction/locked_robot_state.h
@@ -59,7 +59,6 @@ namespace robot_interaction
 class LockedRobotState
 {
 public:
-  LockedRobotState(const robot_state::RobotStatePtr& state);
   LockedRobotState(const robot_state::RobotState& state);
   LockedRobotState(const robot_model::RobotModelPtr& model);
 
@@ -86,7 +85,7 @@ public:
   // The \e modify function is passed a reference to the state which it can
   // modify.  No threads will be given access to the state while the \e modify
   // function is running.
-  void modifyState(ModifyStateFunction modify);
+  void modifyState(const ModifyStateFunction& modify);
 
 protected:
   // This is called when the internally maintained state has changed.

--- a/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
+++ b/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
@@ -95,25 +95,25 @@ public:
     return topic_;
   }
 
-  // add an interactive marker.
-  // construct - a callback to construct the marker.  See comment on
-  //              InteractiveMarkerConstructorFn above.
-  // update - Called when the robot state changes.  Updates the marker pose.
-  //              Optional.  See comment on InteractiveMarkerUpdateFn above.
-  // process - called when the marker moves.  Updates the robot state.  See
-  //              comment on ProcessFeedbackFn above.
+  /// add an interactive marker.
+  /// construct - a callback to construct the marker.  See comment on
+  ///              InteractiveMarkerConstructorFn above.
+  /// update - Called when the robot state changes.  Updates the marker pose.
+  ///              Optional.  See comment on InteractiveMarkerUpdateFn above.
+  /// process - called when the marker moves.  Updates the robot state.  See
+  ///              comment on ProcessFeedbackFn above.
   void addActiveComponent(
         const InteractiveMarkerConstructorFn &construct,
         const ProcessFeedbackFn &process,
         const InteractiveMarkerUpdateFn &update = InteractiveMarkerUpdateFn(),
         const std::string &name = "");
 
-  // Adds an interactive marker for:
-  //  - each end effector in the group that can be controller by IK
-  //  - each floating joint
-  //  - each planar joint
-  // If no end effector exists in the robot then adds an interactive marker for
-  // the last link in the chain.
+  /// Adds an interactive marker for:
+  ///  - each end effector in the group that can be controller by IK
+  ///  - each floating joint
+  ///  - each planar joint
+  /// If no end effector exists in the robot then adds an interactive marker for
+  /// the last link in the chain.
   void decideActiveComponents(const std::string &group);
   void decideActiveComponents(const std::string &group,
                               InteractionStyle::InteractionStyle style);
@@ -174,24 +174,24 @@ private:
   // the links in this group
   double computeGroupMarkerSize(const std::string &group);
   void computeMarkerPose(
-        const ::robot_interaction::InteractionHandlerPtr &handler, 
-        const EndEffectorInteraction &eef, 
+        const ::robot_interaction::InteractionHandlerPtr &handler,
+        const EndEffectorInteraction &eef,
         const robot_state::RobotState &robot_state,
-        geometry_msgs::Pose &pose, 
+        geometry_msgs::Pose &pose,
         geometry_msgs::Pose &control_to_eef_tf) const;
 
   void addEndEffectorMarkers(
-        const ::robot_interaction::InteractionHandlerPtr &handler, 
-        const EndEffectorInteraction& eef, 
-        visualization_msgs::InteractiveMarker& im, 
-        bool position = true, 
+        const ::robot_interaction::InteractionHandlerPtr &handler,
+        const EndEffectorInteraction& eef,
+        visualization_msgs::InteractiveMarker& im,
+        bool position = true,
         bool orientation = true);
   void addEndEffectorMarkers(
-        const ::robot_interaction::InteractionHandlerPtr &handler, 
-        const EndEffectorInteraction& eef, 
-        const geometry_msgs::Pose& offset, 
-        visualization_msgs::InteractiveMarker& im, 
-        bool position = true, 
+        const ::robot_interaction::InteractionHandlerPtr &handler,
+        const EndEffectorInteraction& eef,
+        const geometry_msgs::Pose& offset,
+        visualization_msgs::InteractiveMarker& im,
+        bool position = true,
         bool orientation = true);
   void processInteractiveMarkerFeedback(
         const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback);

--- a/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
+++ b/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
@@ -42,7 +42,6 @@
 #include <interactive_markers/menu_handler.h>
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/robot_interaction/interaction.h>
-#include <moveit/robot_interaction/kinematic_options_map.h>
 #include <boost/function.hpp>
 #include <boost/thread.hpp>
 #include <tf/tf.h>
@@ -57,6 +56,9 @@ namespace robot_interaction
 
 class InteractionHandler;
 typedef boost::shared_ptr<InteractionHandler> InteractionHandlerPtr;
+
+class KinematicOptionsMap;
+typedef boost::shared_ptr<KinematicOptionsMap> KinematicOptionsMapPtr;
 
 
 // Manage interactive markers for controlling a robot state.
@@ -82,7 +84,8 @@ public:
   static const std::string INTERACTIVE_MARKER_TOPIC;
 
 
-  RobotInteraction(const robot_model::RobotModelConstPtr &kmodel, const std::string &ns = "");
+  RobotInteraction(const robot_model::RobotModelConstPtr &kmodel,
+                   const std::string &ns = "");
   virtual ~RobotInteraction();
 
   const std::string& getServerTopic(void) const
@@ -134,12 +137,17 @@ public:
     return active_vj_;
   }
 
+  const robot_model::RobotModelConstPtr& getRobotModel() const { robot_model_; }
+
   // Get the kinematic options map.
   // Use this to set kinematic options (defaults or per-group).
-  KinematicOptionsMap& getKinematicOptionsMap() { return kinematic_options_map_; }
+  KinematicOptionsMapPtr getKinematicOptionsMap() { return kinematic_options_map_; }
 
-  static bool updateState(robot_state::RobotState &state, const EndEffectorInteraction &eef, const geometry_msgs::Pose &pose,
-                          unsigned int attempts, double ik_timeout,
+  static bool updateState(robot_state::RobotState &state,
+                          const EndEffectorInteraction &eef,
+                          const geometry_msgs::Pose &pose,
+                          unsigned int attempts,
+                          double ik_timeout,
                           const robot_state::GroupStateValidityCallbackFn &validity_callback = robot_state::GroupStateValidityCallbackFn(),
                           const kinematics::KinematicsQueryOptions &kinematics_query_options = kinematics::KinematicsQueryOptions());
 
@@ -189,7 +197,7 @@ private:
 
   // options for doing IK
   // Locking is done internally
-  KinematicOptionsMap kinematic_options_map_;
+  KinematicOptionsMapPtr kinematic_options_map_;
 
 public:
   // DEPRECATED.  This is included for backwards compatibility.

--- a/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
+++ b/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
@@ -112,13 +112,6 @@ public:
   void decideActiveComponents(const std::string &group);
   void decideActiveComponents(const std::string &group, InteractionStyle::InteractionStyle style);
 
-  /// called by decideActiveComponents(); add markers for end effectors
-  void decideActiveEndEffectors(const std::string &group);
-  void decideActiveEndEffectors(const std::string &group, InteractionStyle::InteractionStyle style);
-
-  /// called by decideActiveComponents(); add markers for planar and floating joints
-  void decideActiveJoints(const std::string &group);
-
   // remove all interactive markers.
   void clear();
 
@@ -139,7 +132,7 @@ public:
     return active_vj_;
   }
 
-  const robot_model::RobotModelConstPtr& getRobotModel() const { robot_model_; }
+  const robot_model::RobotModelConstPtr& getRobotModel() const { return robot_model_; }
 
   // Get the kinematic options map.
   // Use this to set kinematic options (defaults or per-group).
@@ -155,6 +148,12 @@ public:
 
 
 private:
+  /// called by decideActiveComponents(); add markers for end effectors
+  void decideActiveEndEffectors(const std::string &group);
+  void decideActiveEndEffectors(const std::string &group, InteractionStyle::InteractionStyle style);
+
+  /// called by decideActiveComponents(); add markers for planar and floating joints
+  void decideActiveJoints(const std::string &group);
 
   // return the diameter of the sphere that certainly can enclose the AABB of the links in this group
   double computeGroupMarkerSize(const std::string &group);

--- a/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
+++ b/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
@@ -39,12 +39,12 @@
 
 #include <visualization_msgs/InteractiveMarkerFeedback.h>
 #include <visualization_msgs/InteractiveMarker.h>
-#include <interactive_markers/menu_handler.h>
+//#include <interactive_markers/menu_handler.h>
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/robot_interaction/interaction.h>
 #include <boost/function.hpp>
 #include <boost/thread.hpp>
-#include <tf/tf.h>
+//#include <tf/tf.h>
 
 namespace interactive_markers
 {
@@ -152,7 +152,9 @@ public:
                           const kinematics::KinematicsQueryOptions &kinematics_query_options = kinematics::KinematicsQueryOptions());
 
 
+#if 0
   static bool updateState(robot_state::RobotState &state, const JointInteraction &vj, const geometry_msgs::Pose &pose);
+#endif
 
 private:
 
@@ -235,6 +237,6 @@ typedef boost::shared_ptr<const RobotInteraction> RobotInteractionConstPtr;
 
 }
 
-#include <moveit/robot_interaction/interaction_handler.h>
+//#include <moveit/robot_interaction/interaction_handler.h>
 
 #endif

--- a/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
+++ b/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
@@ -96,28 +96,38 @@ public:
   }
 
   // add an interactive marker.
-  // construct - a callback to construct the marker.  See comment on InteractiveMarkerConstructorFn above.
-  // update - Called when the robot state changes.  Updates the marker pose.  Optional.  See comment on InteractiveMarkerUpdateFn above.
-  // process - called when the marker moves.  Updates the robot state.  See comment on ProcessFeedbackFn above.
-  void addActiveComponent(const InteractiveMarkerConstructorFn &construct,
-                          const ProcessFeedbackFn &process,
-                          const InteractiveMarkerUpdateFn &update = InteractiveMarkerUpdateFn(),
-                          const std::string &name = "");
+  // construct - a callback to construct the marker.  See comment on
+  //              InteractiveMarkerConstructorFn above.
+  // update - Called when the robot state changes.  Updates the marker pose.
+  //              Optional.  See comment on InteractiveMarkerUpdateFn above.
+  // process - called when the marker moves.  Updates the robot state.  See
+  //              comment on ProcessFeedbackFn above.
+  void addActiveComponent(
+        const InteractiveMarkerConstructorFn &construct,
+        const ProcessFeedbackFn &process,
+        const InteractiveMarkerUpdateFn &update = InteractiveMarkerUpdateFn(),
+        const std::string &name = "");
 
   // Adds an interactive marker for:
   //  - each end effector in the group that can be controller by IK
   //  - each floating joint
   //  - each planar joint
-  // If no end effector exists in the robot then adds an interactive marker for the last link in the chain.
+  // If no end effector exists in the robot then adds an interactive marker for
+  // the last link in the chain.
   void decideActiveComponents(const std::string &group);
-  void decideActiveComponents(const std::string &group, InteractionStyle::InteractionStyle style);
+  void decideActiveComponents(const std::string &group,
+                              InteractionStyle::InteractionStyle style);
 
   // remove all interactive markers.
   void clear();
 
-  void addInteractiveMarkers(const ::robot_interaction::InteractionHandlerPtr &handler, const double marker_scale = 0.0);
-  void updateInteractiveMarkers(const ::robot_interaction::InteractionHandlerPtr &handler);
-  bool showingMarkers(const ::robot_interaction::InteractionHandlerPtr &handler);
+  void addInteractiveMarkers(
+        const ::robot_interaction::InteractionHandlerPtr &handler,
+        const double marker_scale = 0.0);
+  void updateInteractiveMarkers(
+        const ::robot_interaction::InteractionHandlerPtr &handler);
+  bool showingMarkers(
+        const ::robot_interaction::InteractionHandlerPtr &handler);
 
   void publishInteractiveMarkers();
   void clearInteractiveMarkers();
@@ -138,31 +148,53 @@ public:
   // Use this to set kinematic options (defaults or per-group).
   KinematicOptionsMapPtr getKinematicOptionsMap() { return kinematic_options_map_; }
 
-  static bool updateState(robot_state::RobotState &state,
-                          const EndEffectorInteraction &eef,
-                          const geometry_msgs::Pose &pose,
-                          unsigned int attempts,
-                          double ik_timeout,
-                          const robot_state::GroupStateValidityCallbackFn &validity_callback = robot_state::GroupStateValidityCallbackFn(),
-                          const kinematics::KinematicsQueryOptions &kinematics_query_options = kinematics::KinematicsQueryOptions());
+  static bool updateState(
+            robot_state::RobotState &state,
+            const EndEffectorInteraction &eef,
+            const geometry_msgs::Pose &pose,
+            unsigned int attempts,
+            double ik_timeout,
+            const robot_state::GroupStateValidityCallbackFn &validity_callback =
+                                robot_state::GroupStateValidityCallbackFn(),
+            const kinematics::KinematicsQueryOptions &kinematics_query_options =
+                                kinematics::KinematicsQueryOptions());
 
 
 private:
-  /// called by decideActiveComponents(); add markers for end effectors
+  // called by decideActiveComponents(); add markers for end effectors
   void decideActiveEndEffectors(const std::string &group);
-  void decideActiveEndEffectors(const std::string &group, InteractionStyle::InteractionStyle style);
+  void decideActiveEndEffectors(const std::string &group,
+                                InteractionStyle::InteractionStyle style);
 
-  /// called by decideActiveComponents(); add markers for planar and floating joints
+  // called by decideActiveComponents(); add markers for planar and floating
+  // joints
   void decideActiveJoints(const std::string &group);
 
-  // return the diameter of the sphere that certainly can enclose the AABB of the links in this group
+  // return the diameter of the sphere that certainly can enclose the AABB of
+  // the links in this group
   double computeGroupMarkerSize(const std::string &group);
-  void computeMarkerPose(const ::robot_interaction::InteractionHandlerPtr &handler, const EndEffectorInteraction &eef, const robot_state::RobotState &robot_state,
-                         geometry_msgs::Pose &pose, geometry_msgs::Pose &control_to_eef_tf) const;
+  void computeMarkerPose(
+        const ::robot_interaction::InteractionHandlerPtr &handler, 
+        const EndEffectorInteraction &eef, 
+        const robot_state::RobotState &robot_state,
+        geometry_msgs::Pose &pose, 
+        geometry_msgs::Pose &control_to_eef_tf) const;
 
-  void addEndEffectorMarkers(const ::robot_interaction::InteractionHandlerPtr &handler, const EndEffectorInteraction& eef, visualization_msgs::InteractiveMarker& im, bool position = true, bool orientation = true);
-  void addEndEffectorMarkers(const ::robot_interaction::InteractionHandlerPtr &handler, const EndEffectorInteraction& eef, const geometry_msgs::Pose& offset, visualization_msgs::InteractiveMarker& im, bool position = true, bool orientation = true);
-  void processInteractiveMarkerFeedback(const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback);
+  void addEndEffectorMarkers(
+        const ::robot_interaction::InteractionHandlerPtr &handler, 
+        const EndEffectorInteraction& eef, 
+        visualization_msgs::InteractiveMarker& im, 
+        bool position = true, 
+        bool orientation = true);
+  void addEndEffectorMarkers(
+        const ::robot_interaction::InteractionHandlerPtr &handler, 
+        const EndEffectorInteraction& eef, 
+        const geometry_msgs::Pose& offset, 
+        visualization_msgs::InteractiveMarker& im, 
+        bool position = true, 
+        bool orientation = true);
+  void processInteractiveMarkerFeedback(
+        const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback);
   void processingThread();
   void clearInteractiveMarkersUnsafe();
 
@@ -200,11 +232,11 @@ private:
 
 public:
   // DEPRECATED.  This is included for backwards compatibility.
-  // These classes/enums used to be subclasses of RobotInteraction.  This allows
-  // client code to continue to work as if they are.
+  // These classes/enums used to be subclasses of RobotInteraction.  This
+  // allows client code to continue to work as if they are.
 
-  /// The different types of interaction that can be constructed for an end effector
-  /// DEPRECATED.  See robot_interaction::InteractionStyle::InteractionStyle in interaction.h
+  /// DEPRECATED. Instead use
+  /// robot_interaction::InteractionStyle::InteractionStyle in interaction.h
   enum EndEffectorInteractionStyle
   {
     EEF_POSITION_ARROWS = InteractionStyle::POSITION_ARROWS,
@@ -223,9 +255,11 @@ public:
     EEF_6DOF_NOSPHERE = InteractionStyle::SIX_DOF_NOSPHERE
   };
   // DEPRECATED.  Use InteractionStyle::InteractionStyle version.
-  void decideActiveComponents(const std::string &group, EndEffectorInteractionStyle style);
+  void decideActiveComponents(const std::string &group,
+                              EndEffectorInteractionStyle style);
   // DEPRECATED.  Use InteractionStyle::InteractionStyle version.
-  void decideActiveEndEffectors(const std::string &group, EndEffectorInteractionStyle style);
+  void decideActiveEndEffectors(const std::string &group,
+                                EndEffectorInteractionStyle style);
 };
 
 typedef boost::shared_ptr<RobotInteraction> RobotInteractionPtr;
@@ -233,7 +267,5 @@ typedef boost::shared_ptr<const RobotInteraction> RobotInteractionConstPtr;
 
 
 }
-
-//#include <moveit/robot_interaction/interaction_handler.h>
 
 #endif

--- a/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
+++ b/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
@@ -39,12 +39,14 @@
 
 #include <visualization_msgs/InteractiveMarkerFeedback.h>
 #include <visualization_msgs/InteractiveMarker.h>
-//#include <interactive_markers/menu_handler.h>
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/robot_interaction/interaction.h>
 #include <boost/function.hpp>
 #include <boost/thread.hpp>
-//#include <tf/tf.h>
+
+// This is needed for legacy code that includes robot_interaction.h but not
+// interaction_handler.h
+#include <moveit/robot_interaction/interaction_handler.h>
 
 namespace interactive_markers
 {

--- a/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
+++ b/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
@@ -152,10 +152,6 @@ public:
                           const kinematics::KinematicsQueryOptions &kinematics_query_options = kinematics::KinematicsQueryOptions());
 
 
-#if 0
-  static bool updateState(robot_state::RobotState &state, const JointInteraction &vj, const geometry_msgs::Pose &pose);
-#endif
-
 private:
 
   // return the diameter of the sphere that certainly can enclose the AABB of the links in this group

--- a/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
+++ b/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
@@ -41,8 +41,8 @@
 #include <visualization_msgs/InteractiveMarker.h>
 #include <interactive_markers/menu_handler.h>
 #include <moveit/robot_state/robot_state.h>
-#include <moveit/macros/class_forward.h>
 #include <moveit/robot_interaction/interaction.h>
+#include <moveit/robot_interaction/kinematic_options_map.h>
 #include <boost/function.hpp>
 #include <boost/thread.hpp>
 #include <tf/tf.h>
@@ -134,6 +134,10 @@ public:
     return active_vj_;
   }
 
+  // Get the kinematic options map.
+  // Use this to set kinematic options (defaults or per-group).
+  KinematicOptionsMap& getKinematicOptionsMap() { return kinematic_options_map_; }
+
   static bool updateState(robot_state::RobotState &state, const EndEffectorInteraction &eef, const geometry_msgs::Pose &pose,
                           unsigned int attempts, double ik_timeout,
                           const robot_state::GroupStateValidityCallbackFn &validity_callback = robot_state::GroupStateValidityCallbackFn(),
@@ -183,6 +187,10 @@ private:
   interactive_markers::InteractiveMarkerServer *int_marker_server_;
   std::string topic_;
 
+  // options for doing IK
+  // Locking is done internally
+  KinematicOptionsMap kinematic_options_map_;
+
 public:
   // DEPRECATED.  This is included for backwards compatibility.
   // These classes/enums used to be subclasses of RobotInteraction.  This allows
@@ -213,7 +221,9 @@ public:
   void decideActiveEndEffectors(const std::string &group, EndEffectorInteractionStyle style);
 };
 
-MOVEIT_CLASS_FORWARD(RobotInteraction);
+typedef boost::shared_ptr<RobotInteraction> RobotInteractionPtr;
+typedef boost::shared_ptr<const RobotInteraction> RobotInteractionConstPtr;
+
 
 }
 

--- a/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
+++ b/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
@@ -95,7 +95,11 @@ public:
     return topic_;
   }
 
-  /// add an interactive marker.
+  /// add an interaction.
+  /// An interaction is a marker that can be used to manipulate the robot
+  /// state. 
+  /// This function does not add any markers.  To add markers for all
+  /// active interactions call addInteractiveMarkers().
   /// construct - a callback to construct the marker.  See comment on
   ///              InteractiveMarkerConstructorFn above.
   /// update - Called when the robot state changes.  Updates the marker pose.
@@ -108,57 +112,57 @@ public:
         const InteractiveMarkerUpdateFn &update = InteractiveMarkerUpdateFn(),
         const std::string &name = "");
 
-  /// Adds an interactive marker for:
+  /// Adds an interaction for:
   ///  - each end effector in the group that can be controller by IK
   ///  - each floating joint
   ///  - each planar joint
-  /// If no end effector exists in the robot then adds an interactive marker for
+  /// If no end effector exists in the robot then adds an interaction for
   /// the last link in the chain.
+  /// This function does not add any markers.  To add markers for all
+  /// active interactions call addInteractiveMarkers().
   void decideActiveComponents(const std::string &group);
   void decideActiveComponents(const std::string &group,
                               InteractionStyle::InteractionStyle style);
 
-  // remove all interactive markers.
+  /// remove all interactions.
+  /// Also removes all markers.
   void clear();
 
+  /// Add interactive markers for all active interactions.
+  /// This adds markers just to the one handler.  If there are multiple handlers
+  /// call this for each handler for which you want markers.
+  /// The markers are not actually added until you call
+  /// publishInteractiveMarkers().
   void addInteractiveMarkers(
         const ::robot_interaction::InteractionHandlerPtr &handler,
         const double marker_scale = 0.0);
+
+  // Update pose of all interactive markers to match the handler's RobotState.
+  // Call this when the handler's RobotState changes.
   void updateInteractiveMarkers(
         const ::robot_interaction::InteractionHandlerPtr &handler);
+
+  // True if markers are being shown for this handler.
   bool showingMarkers(
         const ::robot_interaction::InteractionHandlerPtr &handler);
 
+  // Display all markers that have been added.
+  // This is needed after calls to addInteractiveMarkers() to publish the
+  // resulting markers so they get displayed.  This call is not needed after
+  // calling updateInteractiveMarkers() which publishes the results itself.
   void publishInteractiveMarkers();
+
+  // Clear all interactive markers.
+  // This removes all interactive markers but does not affect which
+  // interactions are active.  After this a call to publishInteractiveMarkers()
+  // is needed to actually remove the markers from the display.
   void clearInteractiveMarkers();
-
-  const std::vector<EndEffectorInteraction>& getActiveEndEffectors() const
-  {
-    return active_eef_;
-  }
-
-  const std::vector<JointInteraction>& getActiveJoints() const
-  {
-    return active_vj_;
-  }
 
   const robot_model::RobotModelConstPtr& getRobotModel() const { return robot_model_; }
 
   // Get the kinematic options map.
   // Use this to set kinematic options (defaults or per-group).
   KinematicOptionsMapPtr getKinematicOptionsMap() { return kinematic_options_map_; }
-
-  static bool updateState(
-            robot_state::RobotState &state,
-            const EndEffectorInteraction &eef,
-            const geometry_msgs::Pose &pose,
-            unsigned int attempts,
-            double ik_timeout,
-            const robot_state::GroupStateValidityCallbackFn &validity_callback =
-                                robot_state::GroupStateValidityCallbackFn(),
-            const kinematics::KinematicsQueryOptions &kinematics_query_options =
-                                kinematics::KinematicsQueryOptions());
-
 
 private:
   // called by decideActiveComponents(); add markers for end effectors
@@ -260,6 +264,27 @@ public:
   // DEPRECATED.  Use InteractionStyle::InteractionStyle version.
   void decideActiveEndEffectors(const std::string &group,
                                 EndEffectorInteractionStyle style);
+  // DEPRECATED
+  const std::vector<EndEffectorInteraction>& getActiveEndEffectors() const
+  {
+    return active_eef_;
+  }
+  // DEPRECATED
+  const std::vector<JointInteraction>& getActiveJoints() const
+  {
+    return active_vj_;
+  }
+  // DEPRECATED
+  static bool updateState(
+            robot_state::RobotState &state,
+            const EndEffectorInteraction &eef,
+            const geometry_msgs::Pose &pose,
+            unsigned int attempts,
+            double ik_timeout,
+            const robot_state::GroupStateValidityCallbackFn &validity_callback =
+                                robot_state::GroupStateValidityCallbackFn(),
+            const kinematics::KinematicsQueryOptions &kinematics_query_options =
+                                kinematics::KinematicsQueryOptions());
 };
 
 typedef boost::shared_ptr<RobotInteraction> RobotInteractionPtr;

--- a/robot_interaction/src/interaction_handler.cpp
+++ b/robot_interaction/src/interaction_handler.cpp
@@ -48,7 +48,6 @@
 #include <boost/math/constants/constants.hpp>
 #include <algorithm>
 #include <limits>
-#include <stdexcept>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -584,7 +583,7 @@ void InteractionHandler::setKinematicsQueryOptions(
 
 void InteractionHandler::setKinematicsQueryOptionsForGroup(
       const std::string& group_name, 
-      kinematics::KinematicsQueryOptions &opt)
+      const kinematics::KinematicsQueryOptions &opt)
 {
   KinematicOptions delta;
   delta.options_ = opt;

--- a/robot_interaction/src/interaction_handler.cpp
+++ b/robot_interaction/src/interaction_handler.cpp
@@ -360,12 +360,10 @@ void InteractionHandler::updateStateEndEffector(
   // access kinematic_options_map_.
   KinematicOptions kinematic_options = kinematic_options_map_->getOptions(eef->parent_group);
 
-  bool ok;
-  kinematic_options.setStateFromIK(state,
-                                   &eef->parent_group,
-                                   &eef->parent_link,
-                                   pose,
-                                   &ok);
+  bool ok = kinematic_options.setStateFromIK(*state,
+                                             eef->parent_group,
+                                             eef->parent_link,
+                                             *pose);
   bool error_state_changed = setErrorState(eef->parent_group, !ok);
   if (update_callback_)
     *callback = boost::bind(update_callback_,

--- a/robot_interaction/src/interaction_handler.cpp
+++ b/robot_interaction/src/interaction_handler.cpp
@@ -584,7 +584,7 @@ void InteractionHandler::setKinematicsQueryOptions(
 }
 
 void InteractionHandler::setKinematicsQueryOptionsForGroup(
-      const std::string& group_name, 
+      const std::string& group_name,
       const kinematics::KinematicsQueryOptions &opt)
 {
   KinematicOptions delta;

--- a/robot_interaction/src/interaction_handler.cpp
+++ b/robot_interaction/src/interaction_handler.cpp
@@ -484,12 +484,16 @@ bool InteractionHandler::transformFeedbackPose(const visualization_msgs::Interac
       }
       catch (tf::TransformException& e)
       {
-        ROS_ERROR("Error transforming from frame '%s' to frame '%s'", tpose.header.frame_id.c_str(), planning_frame_.c_str());
+        ROS_ERROR("Error transforming from frame '%s' to frame '%s'",
+          tpose.header.frame_id.c_str(),
+          planning_frame_.c_str());
         return false;
       }
     else
     {
-      ROS_ERROR("Cannot transform from frame '%s' to frame '%s' (no TF instance provided)", tpose.header.frame_id.c_str(), planning_frame_.c_str());
+      ROS_ERROR("Cannot transform from frame '%s' to frame '%s' (no TF instance provided)",
+          tpose.header.frame_id.c_str(),
+          planning_frame_.c_str());
       return false;
     }
   }

--- a/robot_interaction/src/interaction_handler.cpp
+++ b/robot_interaction/src/interaction_handler.cpp
@@ -54,7 +54,7 @@
 namespace robot_interaction
 {
 
-RobotInteraction::InteractionHandler::InteractionHandler(const std::string &name,
+InteractionHandler::InteractionHandler(const std::string &name,
                                                          const robot_state::RobotState &kstate,
                                                          const boost::shared_ptr<tf::Transformer> &tf) :
   name_(name),
@@ -66,7 +66,7 @@ RobotInteraction::InteractionHandler::InteractionHandler(const std::string &name
   setup();
 }
 
-RobotInteraction::InteractionHandler::InteractionHandler(const std::string &name,
+InteractionHandler::InteractionHandler(const std::string &name,
                                                          const robot_model::RobotModelConstPtr &robot_model,
                                                          const boost::shared_ptr<tf::Transformer> &tf) :
   name_(name),
@@ -78,7 +78,7 @@ RobotInteraction::InteractionHandler::InteractionHandler(const std::string &name
   setup();
 }
 
-void RobotInteraction::InteractionHandler::setup()
+void InteractionHandler::setup()
 {
   std::replace(name_.begin(), name_.end(), '_', '-'); // we use _ as a special char in marker name
   ik_timeout_ = 0.0; // so that the default IK timeout is used in setFromIK()
@@ -86,37 +86,37 @@ void RobotInteraction::InteractionHandler::setup()
   planning_frame_ = kstate_->getRobotModel()->getModelFrame();
 }
 
-void RobotInteraction::InteractionHandler::setPoseOffset(const RobotInteraction::EndEffector& eef, const geometry_msgs::Pose& m)
+void InteractionHandler::setPoseOffset(const EndEffectorInteraction& eef, const geometry_msgs::Pose& m)
 {
   boost::mutex::scoped_lock slock(offset_map_lock_);
   offset_map_[eef.eef_group] = m;
 }
 
-void RobotInteraction::InteractionHandler::setPoseOffset(const RobotInteraction::Joint& vj, const geometry_msgs::Pose& m)
+void InteractionHandler::setPoseOffset(const JointInteraction& vj, const geometry_msgs::Pose& m)
 {
   boost::mutex::scoped_lock slock(offset_map_lock_);
   offset_map_[vj.joint_name] = m;
 }
 
-void RobotInteraction::InteractionHandler::clearPoseOffset(const RobotInteraction::EndEffector& eef)
+void InteractionHandler::clearPoseOffset(const EndEffectorInteraction& eef)
 {
   boost::mutex::scoped_lock slock(offset_map_lock_);
   offset_map_.erase(eef.eef_group);
 }
 
-void RobotInteraction::InteractionHandler::clearPoseOffset(const RobotInteraction::Joint& vj)
+void InteractionHandler::clearPoseOffset(const JointInteraction& vj)
 {
   boost::mutex::scoped_lock slock(offset_map_lock_);
   offset_map_.erase(vj.joint_name);
 }
 
-void RobotInteraction::InteractionHandler::clearPoseOffsets()
+void InteractionHandler::clearPoseOffsets()
 {
   boost::mutex::scoped_lock slock(offset_map_lock_);
   offset_map_.clear();
 }
 
-bool RobotInteraction::InteractionHandler::getPoseOffset(const RobotInteraction::EndEffector& eef, geometry_msgs::Pose& m)
+bool InteractionHandler::getPoseOffset(const EndEffectorInteraction& eef, geometry_msgs::Pose& m)
 {
   boost::mutex::scoped_lock slock(offset_map_lock_);
   std::map<std::string, geometry_msgs::Pose>::iterator it = offset_map_.find(eef.eef_group);
@@ -128,7 +128,7 @@ bool RobotInteraction::InteractionHandler::getPoseOffset(const RobotInteraction:
   return false;
 }
 
-bool RobotInteraction::InteractionHandler::getPoseOffset(const RobotInteraction::Joint& vj, geometry_msgs::Pose& m)
+bool InteractionHandler::getPoseOffset(const JointInteraction& vj, geometry_msgs::Pose& m)
 {
   boost::mutex::scoped_lock slock(offset_map_lock_);
   std::map<std::string, geometry_msgs::Pose>::iterator it = offset_map_.find(vj.joint_name);
@@ -140,7 +140,7 @@ bool RobotInteraction::InteractionHandler::getPoseOffset(const RobotInteraction:
   return false;
 }
 
-bool RobotInteraction::InteractionHandler::getLastEndEffectorMarkerPose(const RobotInteraction::EndEffector& eef, geometry_msgs::PoseStamped& ps)
+bool InteractionHandler::getLastEndEffectorMarkerPose(const EndEffectorInteraction& eef, geometry_msgs::PoseStamped& ps)
 {
   boost::mutex::scoped_lock slock(pose_map_lock_);
   std::map<std::string, geometry_msgs::PoseStamped>::iterator it = pose_map_.find(eef.eef_group);
@@ -152,7 +152,7 @@ bool RobotInteraction::InteractionHandler::getLastEndEffectorMarkerPose(const Ro
   return false;
 }
 
-bool RobotInteraction::InteractionHandler::getLastJointMarkerPose(const RobotInteraction::Joint& vj, geometry_msgs::PoseStamped& ps)
+bool InteractionHandler::getLastJointMarkerPose(const JointInteraction& vj, geometry_msgs::PoseStamped& ps)
 {
   boost::mutex::scoped_lock slock(pose_map_lock_);
   std::map<std::string, geometry_msgs::PoseStamped>::iterator it = pose_map_.find(vj.joint_name);
@@ -164,40 +164,40 @@ bool RobotInteraction::InteractionHandler::getLastJointMarkerPose(const RobotInt
   return false;
 }
 
-void RobotInteraction::InteractionHandler::clearLastEndEffectorMarkerPose(const RobotInteraction::EndEffector& eef)
+void InteractionHandler::clearLastEndEffectorMarkerPose(const EndEffectorInteraction& eef)
 {
   boost::mutex::scoped_lock slock(pose_map_lock_);
   pose_map_.erase(eef.eef_group);
 }
 
-void RobotInteraction::InteractionHandler::clearLastJointMarkerPose(const RobotInteraction::Joint& vj)
+void InteractionHandler::clearLastJointMarkerPose(const JointInteraction& vj)
 {
   boost::mutex::scoped_lock slock(pose_map_lock_);
   pose_map_.erase(vj.joint_name);
 }
 
-void RobotInteraction::InteractionHandler::clearLastMarkerPoses()
+void InteractionHandler::clearLastMarkerPoses()
 {
   boost::mutex::scoped_lock slock(pose_map_lock_);
   pose_map_.clear();
 }
 
-void RobotInteraction::InteractionHandler::setMenuHandler(const boost::shared_ptr<interactive_markers::MenuHandler>& mh)
+void InteractionHandler::setMenuHandler(const boost::shared_ptr<interactive_markers::MenuHandler>& mh)
 {
   menu_handler_ = mh;
 }
 
-const boost::shared_ptr<interactive_markers::MenuHandler>& RobotInteraction::InteractionHandler::getMenuHandler()
+const boost::shared_ptr<interactive_markers::MenuHandler>& InteractionHandler::getMenuHandler()
 {
   return menu_handler_;
 }
 
-void RobotInteraction::InteractionHandler::clearMenuHandler()
+void InteractionHandler::clearMenuHandler()
 {
   menu_handler_.reset();
 }
 
-robot_state::RobotStateConstPtr RobotInteraction::InteractionHandler::getState() const
+robot_state::RobotStateConstPtr InteractionHandler::getState() const
 {
   boost::unique_lock<boost::mutex> ulock(state_lock_);
   while (!kstate_)
@@ -206,7 +206,7 @@ robot_state::RobotStateConstPtr RobotInteraction::InteractionHandler::getState()
   return kstate_;
 }
 
-void RobotInteraction::InteractionHandler::setState(const robot_state::RobotState& kstate)
+void InteractionHandler::setState(const robot_state::RobotState& kstate)
 {
   boost::unique_lock<boost::mutex> ulock(state_lock_);
   while (!kstate_)
@@ -217,7 +217,7 @@ void RobotInteraction::InteractionHandler::setState(const robot_state::RobotStat
     kstate_.reset(new robot_state::RobotState(kstate));
 }
 
-robot_state::RobotStatePtr RobotInteraction::InteractionHandler::getUniqueStateAccess()
+robot_state::RobotStatePtr InteractionHandler::getUniqueStateAccess()
 {
   robot_state::RobotStatePtr result;
   {
@@ -236,7 +236,7 @@ robot_state::RobotStatePtr RobotInteraction::InteractionHandler::getUniqueStateA
   return result;
 }
 
-void RobotInteraction::InteractionHandler::setStateToAccess(robot_state::RobotStatePtr &state)
+void InteractionHandler::setStateToAccess(robot_state::RobotStatePtr &state)
 {
   boost::unique_lock<boost::mutex> ulock(state_lock_);
   if (state != kstate_)
@@ -244,7 +244,7 @@ void RobotInteraction::InteractionHandler::setStateToAccess(robot_state::RobotSt
   state_available_condition_.notify_all();
 }
 
-void RobotInteraction::InteractionHandler::handleGeneric(const RobotInteraction::Generic &g, const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback)
+void InteractionHandler::handleGeneric(const GenericInteraction &g, const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback)
 {
   if (g.process_feedback)
   {
@@ -269,7 +269,7 @@ void RobotInteraction::InteractionHandler::handleGeneric(const RobotInteraction:
   }
 }
 
-void RobotInteraction::InteractionHandler::handleEndEffector(const robot_interaction::RobotInteraction::EndEffector &eef,
+void InteractionHandler::handleEndEffector(const EndEffectorInteraction &eef,
                                                              const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback)
 {
   if (feedback->event_type != visualization_msgs::InteractiveMarkerFeedback::POSE_UPDATE)
@@ -313,7 +313,7 @@ void RobotInteraction::InteractionHandler::handleEndEffector(const robot_interac
     update_callback_(this, error_state_changed);
 }
 
-void RobotInteraction::InteractionHandler::handleJoint(const robot_interaction::RobotInteraction::Joint &vj,
+void InteractionHandler::handleJoint(const JointInteraction &vj,
                                                        const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback)
 {
   if (feedback->event_type != visualization_msgs::InteractiveMarkerFeedback::POSE_UPDATE)
@@ -352,27 +352,27 @@ void RobotInteraction::InteractionHandler::handleJoint(const robot_interaction::
     update_callback_(this, false);
 }
 
-bool RobotInteraction::InteractionHandler::inError(const robot_interaction::RobotInteraction::EndEffector& eef) const
+bool InteractionHandler::inError(const EndEffectorInteraction& eef) const
 {
   return error_state_.find(eef.parent_group) != error_state_.end();
 }
 
-bool RobotInteraction::InteractionHandler::inError(const robot_interaction::RobotInteraction::Generic& g) const
+bool InteractionHandler::inError(const GenericInteraction& g) const
 {
   return error_state_.find(g.marker_name_suffix) != error_state_.end();
 }
 
-bool RobotInteraction::InteractionHandler::inError(const robot_interaction::RobotInteraction::Joint& vj) const
+bool InteractionHandler::inError(const JointInteraction& vj) const
 {
   return false;
 }
 
-void RobotInteraction::InteractionHandler::clearError(void)
+void InteractionHandler::clearError(void)
 {
   error_state_.clear();
 }
 
-bool RobotInteraction::InteractionHandler::transformFeedbackPose(const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback,
+bool InteractionHandler::transformFeedbackPose(const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback,
                                                                  const geometry_msgs::Pose &offset,
                                                                  geometry_msgs::PoseStamped &tpose)
 {

--- a/robot_interaction/src/kinematic_options.cpp
+++ b/robot_interaction/src/kinematic_options.cpp
@@ -1,0 +1,62 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, SRI International
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Acorn Pooley */
+
+#include <moveit/robot_interaction/kinematic_options.h>
+
+robot_interaction::KinematicOptions::KinematicOptions()
+: timeout_seconds_(0.0) // 0.0 = use default timeout
+, max_attempts_(0)      // 0 = use default max attempts
+{ }
+
+// This is intended to be called as a ModifyStateFunction to modify the state
+// maintained by a LockedRobotState in place.
+void robot_interaction::KinematicOptions::setStateFromIK(
+      robot_state::RobotState* state,
+      const std::string* group,
+      const std::string* tip,
+      const geometry_msgs::Pose* pose,
+      bool* result) const
+{
+  const robot_model::JointModelGroup *jmg = state->getJointModelGroup(*group);
+  *result = state->setFromIK(jmg,
+                            *pose,
+                            *tip,
+                            max_attempts_,
+                            timeout_seconds_,
+                            state_validity_callback_,
+                            options_);
+}
+

--- a/robot_interaction/src/kinematic_options.cpp
+++ b/robot_interaction/src/kinematic_options.cpp
@@ -36,6 +36,7 @@
 
 #include <moveit/robot_interaction/kinematic_options.h>
 #include <boost/static_assert.hpp>
+#include <ros/console.h>
 
 robot_interaction::KinematicOptions::KinematicOptions()
 : timeout_seconds_(0.0) // 0.0 = use default timeout

--- a/robot_interaction/src/kinematic_options.cpp
+++ b/robot_interaction/src/kinematic_options.cpp
@@ -91,7 +91,7 @@ void robot_interaction::KinematicOptions::setOptions(
   #define QO_FIELDS(F) \
     F(bool, lock_redundant_joints, LOCK_REDUNDANT_JOINTS) \
     F(bool, return_approximate_solution, RETURN_APPROXIMATE_SOLUTION)
-  
+
 
   // This structure should be identical to kinematics::KinematicsQueryOptions
   // This is only used in the BOOST_STATIC_ASSERT below.
@@ -120,7 +120,7 @@ void robot_interaction::KinematicOptions::setOptions(
   BOOST_STATIC_ASSERT(sizeof(KinematicOptions) ==
                       sizeof(DummyKinematicOptions));
 
-  
+
   // copy fields from other to this if its bit is set in fields
   #define F(type,member,enumval) \
           if (fields & KinematicOptions::enumval) \

--- a/robot_interaction/src/kinematic_options.cpp
+++ b/robot_interaction/src/kinematic_options.cpp
@@ -52,6 +52,12 @@ void robot_interaction::KinematicOptions::setStateFromIK(
       bool* result) const
 {
   const robot_model::JointModelGroup *jmg = state->getJointModelGroup(*group);
+  if (!jmg)
+  {
+    ROS_ERROR("No getJointModelGroup('%s') found",group->c_str());
+    *result = false;
+    return;
+  }
   *result = state->setFromIK(jmg,
                             *pose,
                             *tip,

--- a/robot_interaction/src/kinematic_options.cpp
+++ b/robot_interaction/src/kinematic_options.cpp
@@ -45,28 +45,27 @@ robot_interaction::KinematicOptions::KinematicOptions()
 
 // This is intended to be called as a ModifyStateFunction to modify the state
 // maintained by a LockedRobotState in place.
-void robot_interaction::KinematicOptions::setStateFromIK(
-      robot_state::RobotState* state,
-      const std::string* group,
-      const std::string* tip,
-      const geometry_msgs::Pose* pose,
-      bool* result) const
+bool robot_interaction::KinematicOptions::setStateFromIK(
+      robot_state::RobotState& state,
+      const std::string& group,
+      const std::string& tip,
+      const geometry_msgs::Pose& pose) const
 {
-  const robot_model::JointModelGroup *jmg = state->getJointModelGroup(*group);
+  const robot_model::JointModelGroup *jmg = state.getJointModelGroup(group);
   if (!jmg)
   {
-    ROS_ERROR("No getJointModelGroup('%s') found",group->c_str());
-    *result = false;
-    return;
+    ROS_ERROR("No getJointModelGroup('%s') found",group.c_str());
+    return false;
   }
-  *result = state->setFromIK(jmg,
-                            *pose,
-                            *tip,
+  bool result = state.setFromIK(jmg,
+                            pose,
+                            tip,
                             max_attempts_,
                             timeout_seconds_,
                             state_validity_callback_,
                             options_);
-  state->update();
+  state.update();
+  return result;
 }
 
 

--- a/robot_interaction/src/kinematic_options_map.cpp
+++ b/robot_interaction/src/kinematic_options_map.cpp
@@ -1,0 +1,109 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, SRI International
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Acorn Pooley */
+
+#include <moveit/robot_interaction/kinematic_options_map.h>
+
+robot_interaction::KinematicOptionsMap::KinematicOptionsMap()
+{}
+
+robot_interaction::KinematicOptions
+robot_interaction::KinematicOptionsMap::getOptions(
+      const std::string& key) const
+{
+  boost::mutex::scoped_lock lock(lock_);
+  M_options::const_iterator it = options_.find(key);
+  if (it == options_.end())
+    return defaults_;
+  return it->second;
+}
+
+void robot_interaction::KinematicOptionsMap::setOptions(
+      const std::string& key,
+      const KinematicOptions& options)
+{
+  boost::mutex::scoped_lock lock(lock_);
+  options_[key] = options;
+}
+
+robot_interaction::KinematicOptions
+robot_interaction::KinematicOptionsMap::getDefaultOptions() const
+{
+  boost::mutex::scoped_lock lock(lock_);
+  return defaults_;
+}
+
+void robot_interaction::KinematicOptionsMap::setDefaultOptions(
+      const KinematicOptions& options)
+{
+  boost::mutex::scoped_lock lock(lock_);
+  defaults_ = options;
+}
+
+void robot_interaction::KinematicOptionsMap::clear()
+{
+  boost::mutex::scoped_lock lock(lock_);
+  options_.clear();
+}
+
+void robot_interaction::KinematicOptionsMap::getKeys(
+      std::vector<std::string>& keys) const
+{
+  boost::mutex::scoped_lock lock(lock_);
+  keys.clear();
+  keys.reserve(options_.size());
+  for (M_options::const_iterator it = options_.begin() ;
+       it != options_.end() ;
+       ++it)
+  {
+    keys.push_back(it->first);
+  }
+}
+
+// This is intended to be called as a ModifyStateFunction to modify the state
+// maintained by a LockedRobotState in place.
+void robot_interaction::KinematicOptionsMap::setStateFromIK(
+      robot_state::RobotState* state,
+      const std::string* key,
+      const std::string* group,
+      const std::string* tip,
+      const geometry_msgs::Pose* pose,
+      bool* result) const
+{
+  // copy options so lock is not needed during IK solve.
+  KinematicOptions options = getOptions(*key);
+  options.setStateFromIK(state, group, tip, pose, result);
+}
+

--- a/robot_interaction/src/kinematic_options_map.cpp
+++ b/robot_interaction/src/kinematic_options_map.cpp
@@ -119,7 +119,7 @@ void robot_interaction::KinematicOptionsMap::merge(
   if (&other == this)
     return;
 
-  // need to lock in consistent order to avoid deadlock. 
+  // need to lock in consistent order to avoid deadlock.
   // Lock the one with lower address first.
   boost::mutex *m1 = &lock_;
   boost::mutex *m2 = &other.lock_;

--- a/robot_interaction/src/kinematic_options_map.cpp
+++ b/robot_interaction/src/kinematic_options_map.cpp
@@ -139,16 +139,15 @@ void robot_interaction::KinematicOptionsMap::merge(
 
 // This is intended to be called as a ModifyStateFunction to modify the state
 // maintained by a LockedRobotState in place.
-void robot_interaction::KinematicOptionsMap::setStateFromIK(
-      robot_state::RobotState* state,
-      const std::string* key,
-      const std::string* group,
-      const std::string* tip,
-      const geometry_msgs::Pose* pose,
-      bool* result) const
+bool robot_interaction::KinematicOptionsMap::setStateFromIK(
+      robot_state::RobotState& state,
+      const std::string& key,
+      const std::string& group,
+      const std::string& tip,
+      const geometry_msgs::Pose& pose) const
 {
   // copy options so lock is not needed during IK solve.
-  KinematicOptions options = getOptions(*key);
-  options.setStateFromIK(state, group, tip, pose, result);
+  KinematicOptions options = getOptions(key);
+  return options.setStateFromIK(state, group, tip, pose);
 }
 

--- a/robot_interaction/src/kinematic_options_map.cpp
+++ b/robot_interaction/src/kinematic_options_map.cpp
@@ -119,7 +119,7 @@ void robot_interaction::KinematicOptionsMap::merge(
   if (&other == this)
     return;
 
-  // need to lock in consitent order to avoid deadlock. 
+  // need to lock in consistent order to avoid deadlock. 
   // Lock the one with lower address first.
   boost::mutex *m1 = &lock_;
   boost::mutex *m2 = &other.lock_;

--- a/robot_interaction/src/locked_robot_state.cpp
+++ b/robot_interaction/src/locked_robot_state.cpp
@@ -39,13 +39,6 @@
 #include <moveit/robot_interaction/locked_robot_state.h>
 
 robot_interaction::LockedRobotState::LockedRobotState(
-      const robot_state::RobotStatePtr& state)
-: state_(state)
-{
-  state_->update();
-}
-
-robot_interaction::LockedRobotState::LockedRobotState(
       const robot_state::RobotState& state)
 : state_(new robot_state::RobotState(state))
 {
@@ -90,7 +83,7 @@ void robot_interaction::LockedRobotState::setState(
 }
 
 void robot_interaction::LockedRobotState::modifyState(
-      ModifyStateFunction modify)
+      const ModifyStateFunction& modify)
 {
   {
     boost::mutex::scoped_lock lock(state_lock_);

--- a/robot_interaction/src/locked_robot_state.cpp
+++ b/robot_interaction/src/locked_robot_state.cpp
@@ -1,0 +1,110 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012-2013, Willow Garage, Inc.
+ *  Copyright (c) 2013, Ioan A. Sucan
+ *  Copyright (c) 2014, SRI International
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Ioan Sucan, Acorn Pooley */
+
+#include <moveit/robot_interaction/locked_robot_state.h>
+
+robot_interaction::LockedRobotState::LockedRobotState(
+      const robot_state::RobotStatePtr& state)
+: state_(state)
+{
+  state_->update();
+}
+
+robot_interaction::LockedRobotState::LockedRobotState(
+      const robot_state::RobotState& state)
+: state_(new robot_state::RobotState(state))
+{
+  state_->update();
+}
+
+robot_interaction::LockedRobotState::LockedRobotState(
+      const robot_model::RobotModelPtr& model)
+: state_(new robot_state::RobotState(model))
+{
+  state_->setToDefaultValues();
+  state_->update();
+}
+
+robot_interaction::LockedRobotState::~LockedRobotState()
+{}
+
+
+robot_state::RobotStateConstPtr
+  robot_interaction::LockedRobotState::getState() const
+{
+  boost::unique_lock<boost::mutex> lock(state_lock_);
+  return state_;
+}
+
+void robot_interaction::LockedRobotState::setState(
+      const robot_state::RobotState& state)
+{
+  {
+    boost::unique_lock<boost::mutex> lock(state_lock_);
+
+    // If someone else has a reference to the state, then make a new copy.
+    // The old state is orphaned (does not change, but is now out of date).
+    if (state_.unique())
+      *state_ = state;
+    else
+      state_.reset(new robot_state::RobotState(state));
+
+    state_->update();
+  }
+  robotStateChanged();
+}
+
+void robot_interaction::LockedRobotState::modifyState(
+      ModifyStateFunction modify)
+{
+  {
+    boost::unique_lock<boost::mutex> lock(state_lock_);
+
+    // If someone else has a reference to the state, then make a copy.
+    // The old state is orphaned (does not change, but is now out of date).
+    if (!state_.unique())
+      state_.reset(new robot_state::RobotState(*state_));
+
+    modify(state_.get());
+    state_->update();
+  }
+  robotStateChanged();
+}
+
+void robot_interaction::LockedRobotState::robotStateChanged()
+{}

--- a/robot_interaction/src/locked_robot_state.cpp
+++ b/robot_interaction/src/locked_robot_state.cpp
@@ -67,7 +67,7 @@ robot_interaction::LockedRobotState::~LockedRobotState()
 robot_state::RobotStateConstPtr
   robot_interaction::LockedRobotState::getState() const
 {
-  boost::unique_lock<boost::mutex> lock(state_lock_);
+  boost::mutex::scoped_lock lock(state_lock_);
   return state_;
 }
 
@@ -75,7 +75,7 @@ void robot_interaction::LockedRobotState::setState(
       const robot_state::RobotState& state)
 {
   {
-    boost::unique_lock<boost::mutex> lock(state_lock_);
+    boost::mutex::scoped_lock lock(state_lock_);
 
     // If someone else has a reference to the state, then make a new copy.
     // The old state is orphaned (does not change, but is now out of date).
@@ -93,7 +93,7 @@ void robot_interaction::LockedRobotState::modifyState(
       ModifyStateFunction modify)
 {
   {
-    boost::unique_lock<boost::mutex> lock(state_lock_);
+    boost::mutex::scoped_lock lock(state_lock_);
 
     // If someone else has a reference to the state, then make a copy.
     // The old state is orphaned (does not change, but is now out of date).

--- a/robot_interaction/src/robot_interaction.cpp
+++ b/robot_interaction/src/robot_interaction.cpp
@@ -613,6 +613,7 @@ bool RobotInteraction::showingMarkers(const ::robot_interaction::InteractionHand
   return true;
 }
 
+#if 0
 bool RobotInteraction::updateState(robot_state::RobotState &state, const JointInteraction &vj, const geometry_msgs::Pose &pose)
 {
   Eigen::Quaterniond q;
@@ -640,6 +641,7 @@ bool RobotInteraction::updateState(robot_state::RobotState &state, const JointIn
   state.update();
   return true;
 }
+#endif
 
 // TODO: can we get rid of this?  Only used in moveit_ros/benchmarks_gui/src/tab_states_and_goals.cpp right now.
 bool RobotInteraction::updateState(robot_state::RobotState &state, const EndEffectorInteraction &eef, const geometry_msgs::Pose &pose,

--- a/robot_interaction/src/robot_interaction.cpp
+++ b/robot_interaction/src/robot_interaction.cpp
@@ -613,36 +613,6 @@ bool RobotInteraction::showingMarkers(const ::robot_interaction::InteractionHand
   return true;
 }
 
-#if 0
-bool RobotInteraction::updateState(robot_state::RobotState &state, const JointInteraction &vj, const geometry_msgs::Pose &pose)
-{
-  Eigen::Quaterniond q;
-  tf::quaternionMsgToEigen(pose.orientation, q);
-  std::map<std::string, double> vals;
-  if (vj.dof == 3)
-  {
-    vals[vj.joint_name + "/x"] = pose.position.x;
-    vals[vj.joint_name + "/y"] = pose.position.y;
-    Eigen::Vector3d xyz = q.matrix().eulerAngles(0, 1, 2);
-    vals[vj.joint_name + "/theta"] = xyz[2];
-  }
-  else
-    if (vj.dof == 6)
-    {
-      vals[vj.joint_name + "/trans_x"] = pose.position.x;
-      vals[vj.joint_name + "/trans_y"] = pose.position.y;
-      vals[vj.joint_name + "/trans_z"] = pose.position.z;
-      vals[vj.joint_name + "/rot_x"] = q.x();
-      vals[vj.joint_name + "/rot_y"] = q.y();
-      vals[vj.joint_name + "/rot_z"] = q.z();
-      vals[vj.joint_name + "/rot_w"] = q.w();
-    }
-  state.setVariablePositions(vals);
-  state.update();
-  return true;
-}
-#endif
-
 // TODO: can we get rid of this?  Only used in moveit_ros/benchmarks_gui/src/tab_states_and_goals.cpp right now.
 bool RobotInteraction::updateState(robot_state::RobotState &state, const EndEffectorInteraction &eef, const geometry_msgs::Pose &pose,
                                    unsigned int attempts, double ik_timeout,

--- a/robot_interaction/src/robot_interaction.cpp
+++ b/robot_interaction/src/robot_interaction.cpp
@@ -80,7 +80,12 @@ RobotInteraction::~RobotInteraction()
   delete int_marker_server_;
 }
 
-void RobotInteraction::decideActiveComponents(const std::string &group, EndEffectorInteractionStyle style)
+void RobotInteraction::decideActiveComponents(const std::string &group)
+{
+  decideActiveComponents(group, InteractionStyle::SIX_DOF);
+}
+
+void RobotInteraction::decideActiveComponents(const std::string &group, InteractionStyle::InteractionStyle style)
 {
   decideActiveEndEffectors(group, style);
   decideActiveJoints(group);
@@ -94,7 +99,7 @@ void RobotInteraction::addActiveComponent(const InteractiveMarkerConstructorFn &
                                           const std::string &name)
 {
   boost::unique_lock<boost::mutex> ulock(marker_access_lock_);
-  Generic g;
+  GenericInteraction g;
   g.construct_marker = construct;
   g.update_pose = update;
   g.process_feedback = process;
@@ -178,7 +183,7 @@ void RobotInteraction::decideActiveJoints(const std::string &group)
       {
         if (vj[i].type_ == "planar" || vj[i].type_ == "floating")
         {
-          Joint v;
+          JointInteraction v;
           v.connecting_link = vj[i].child_link_;
           v.parent_frame = vj[i].parent_frame_;
           if (!v.parent_frame.empty() && v.parent_frame[0] == '/')
@@ -202,7 +207,7 @@ void RobotInteraction::decideActiveJoints(const std::string &group)
     if ((joints[i]->getType() == robot_model::JointModel::PLANAR || joints[i]->getType() == robot_model::JointModel::FLOATING) &&
         used.find(joints[i]->getName()) == used.end())
     {
-      Joint v;
+      JointInteraction v;
       v.connecting_link = joints[i]->getChildLinkModel()->getName();
       if (joints[i]->getParentLinkModel())
         v.parent_frame = joints[i]->getParentLinkModel()->getName();
@@ -218,7 +223,12 @@ void RobotInteraction::decideActiveJoints(const std::string &group)
   }
 }
 
-void RobotInteraction::decideActiveEndEffectors(const std::string &group, EndEffectorInteractionStyle style)
+void RobotInteraction::decideActiveEndEffectors(const std::string &group)
+{
+  decideActiveEndEffectors(group, InteractionStyle::SIX_DOF);
+}
+
+void RobotInteraction::decideActiveEndEffectors(const std::string &group, InteractionStyle::InteractionStyle style)
 {
   boost::unique_lock<boost::mutex> ulock(marker_access_lock_);
 
@@ -247,7 +257,7 @@ void RobotInteraction::decideActiveEndEffectors(const std::string &group, EndEff
     if (eef.empty() && !jmg->getLinkModelNames().empty())
     {
       // No end effectors.  Use last link in group as the "end effector".
-      EndEffector ee;
+      EndEffectorInteraction ee;
       ee.parent_group = group;
       ee.parent_link = jmg->getLinkModelNames().back();
       ee.eef_group = group;
@@ -259,7 +269,7 @@ void RobotInteraction::decideActiveEndEffectors(const std::string &group, EndEff
         if ((jmg->hasLinkModel(eef[i].parent_link_) || jmg->getName() == eef[i].parent_group_) && jmg->canSetStateFromIK(eef[i].parent_link_))
         {
           // We found an end-effector whose parent is the group.
-          EndEffector ee;
+          EndEffectorInteraction ee;
           ee.parent_group = group;
           ee.parent_link = eef[i].parent_link_;
           ee.eef_group = eef[i].component_group_;
@@ -278,7 +288,7 @@ void RobotInteraction::decideActiveEndEffectors(const std::string &group, EndEff
           if ((it->first->hasLinkModel(eef[i].parent_link_) || jmg->getName() == eef[i].parent_group_) && it->first->canSetStateFromIK(eef[i].parent_link_))
           {
             // We found an end-effector whose parent is a subgroup of the group.  (May be more than one)
-            EndEffector ee;
+            EndEffectorInteraction ee;
             ee.parent_group = it->first->getName();
             ee.parent_link = eef[i].parent_link_;
             ee.eef_group = eef[i].component_group_;
@@ -321,20 +331,25 @@ void RobotInteraction::clearInteractiveMarkersUnsafe()
   int_marker_server_->clear();
 }
 
-void RobotInteraction::addEndEffectorMarkers(const InteractionHandlerPtr &handler, const RobotInteraction::EndEffector& eef,
-                                             visualization_msgs::InteractiveMarker& im,
-                                             bool position,
-                                             bool orientation)
+void RobotInteraction::addEndEffectorMarkers(
+      const ::robot_interaction::InteractionHandlerPtr &handler,
+      const EndEffectorInteraction& eef,
+      visualization_msgs::InteractiveMarker& im,
+      bool position,
+      bool orientation)
 {
   geometry_msgs::Pose pose;
   pose.orientation.w = 1;
   addEndEffectorMarkers(handler, eef, pose, im, position, orientation);
 }
 
-void RobotInteraction::addEndEffectorMarkers(const InteractionHandlerPtr &handler, const RobotInteraction::EndEffector& eef,
-                                             const geometry_msgs::Pose& im_to_eef, visualization_msgs::InteractiveMarker& im,
-                                             bool position,
-                                             bool orientation)
+void RobotInteraction::addEndEffectorMarkers(
+      const ::robot_interaction::InteractionHandlerPtr &handler,
+      const EndEffectorInteraction& eef,
+      const geometry_msgs::Pose& im_to_eef,
+      visualization_msgs::InteractiveMarker& im,
+      bool position,
+      bool orientation)
 {
   if (eef.parent_group == eef.eef_group || !robot_model_->hasLinkModel(eef.parent_link))
     return;
@@ -384,22 +399,29 @@ void RobotInteraction::addEndEffectorMarkers(const InteractionHandlerPtr &handle
   im.controls.push_back(m_control);
 }
 
-static inline std::string getMarkerName(const RobotInteraction::InteractionHandlerPtr &handler, const RobotInteraction::EndEffector &eef)
+static inline std::string getMarkerName(
+      const ::robot_interaction::InteractionHandlerPtr &handler,
+      const EndEffectorInteraction &eef)
 {
   return "EE:" + handler->getName() + "_" + eef.parent_link;
 }
 
-static inline std::string getMarkerName(const RobotInteraction::InteractionHandlerPtr &handler, const RobotInteraction::Joint &vj)
+static inline std::string getMarkerName(
+      const ::robot_interaction::InteractionHandlerPtr &handler, 
+      const JointInteraction &vj)
 {
   return "JJ:" + handler->getName() + "_" + vj.connecting_link;
 }
 
-static inline std::string getMarkerName(const RobotInteraction::InteractionHandlerPtr &handler, const RobotInteraction::Generic &g)
+static inline std::string getMarkerName(
+      const ::robot_interaction::InteractionHandlerPtr &handler, const GenericInteraction &g)
 {
   return "GG:" + handler->getName() + "_" + g.marker_name_suffix;
 }
 
-void RobotInteraction::addInteractiveMarkers(const InteractionHandlerPtr &handler, const double marker_scale)
+void RobotInteraction::addInteractiveMarkers(
+      const ::robot_interaction::InteractionHandlerPtr &handler,
+      const double marker_scale)
 {
   // If scale is left at default size of 0, scale will be based on end effector link size. a good value is between 0-1
   std::vector<visualization_msgs::InteractiveMarker> ims;
@@ -504,7 +526,7 @@ void RobotInteraction::addInteractiveMarkers(const InteractionHandlerPtr &handle
   }
 }
 
-void RobotInteraction::computeMarkerPose(const InteractionHandlerPtr &handler, const EndEffector &eef, const robot_state::RobotState &robot_state,
+void RobotInteraction::computeMarkerPose(const ::robot_interaction::InteractionHandlerPtr &handler, const EndEffectorInteraction &eef, const robot_state::RobotState &robot_state,
                                          geometry_msgs::Pose &pose, geometry_msgs::Pose &control_to_eef_tf) const
 {
   // Need to allow for control pose offsets
@@ -532,7 +554,7 @@ void RobotInteraction::computeMarkerPose(const InteractionHandlerPtr &handler, c
   tf::poseTFToMsg(tf_root_to_control, pose);
 }
 
-void RobotInteraction::updateInteractiveMarkers(const InteractionHandlerPtr &handler)
+void RobotInteraction::updateInteractiveMarkers(const ::robot_interaction::InteractionHandlerPtr &handler)
 {
   std::map<std::string, geometry_msgs::Pose> pose_updates;
   {
@@ -571,7 +593,7 @@ void RobotInteraction::publishInteractiveMarkers()
   int_marker_server_->applyChanges();
 }
 
-bool RobotInteraction::showingMarkers(const InteractionHandlerPtr &handler)
+bool RobotInteraction::showingMarkers(const ::robot_interaction::InteractionHandlerPtr &handler)
 {
   boost::unique_lock<boost::mutex> ulock(marker_access_lock_);
 
@@ -587,7 +609,7 @@ bool RobotInteraction::showingMarkers(const InteractionHandlerPtr &handler)
   return true;
 }
 
-bool RobotInteraction::updateState(robot_state::RobotState &state, const Joint &vj, const geometry_msgs::Pose &pose)
+bool RobotInteraction::updateState(robot_state::RobotState &state, const JointInteraction &vj, const geometry_msgs::Pose &pose)
 {
   Eigen::Quaterniond q;
   tf::quaternionMsgToEigen(pose.orientation, q);
@@ -615,7 +637,7 @@ bool RobotInteraction::updateState(robot_state::RobotState &state, const Joint &
   return true;
 }
 
-bool RobotInteraction::updateState(robot_state::RobotState &state, const EndEffector &eef, const geometry_msgs::Pose &pose,
+bool RobotInteraction::updateState(robot_state::RobotState &state, const EndEffectorInteraction &eef, const geometry_msgs::Pose &pose,
                                    unsigned int attempts, double ik_timeout,
                                    const robot_state::GroupStateValidityCallbackFn &validity_callback,
                                    const kinematics::KinematicsQueryOptions &kinematics_query_options)
@@ -681,7 +703,7 @@ void RobotInteraction::processingThread()
       }
       std::string marker_class = feedback->marker_name.substr(0, 2);
       std::string handler_name = feedback->marker_name.substr(3, u - 3); // skip the ":"
-      std::map<std::string, InteractionHandlerPtr>::const_iterator jt = handlers_.find(handler_name);
+      std::map<std::string, ::robot_interaction::InteractionHandlerPtr>::const_iterator jt = handlers_.find(handler_name);
       if (jt == handlers_.end())
       {
         ROS_ERROR("Interactive Marker Handler '%s' is not known.", handler_name.c_str());
@@ -694,8 +716,8 @@ void RobotInteraction::processingThread()
         if (marker_class == "EE")
         {
           // make a copy of the data, so we do not lose it while we are unlocked
-          EndEffector eef = active_eef_[it->second];
-          InteractionHandlerPtr ih = jt->second;
+          EndEffectorInteraction eef = active_eef_[it->second];
+          ::robot_interaction::InteractionHandlerPtr ih = jt->second;
           marker_access_lock_.unlock();
           try
           {
@@ -715,8 +737,8 @@ void RobotInteraction::processingThread()
           if (marker_class == "JJ")
           {
             // make a copy of the data, so we do not lose it while we are unlocked
-            Joint vj = active_vj_[it->second];
-            InteractionHandlerPtr ih = jt->second;
+            JointInteraction vj = active_vj_[it->second];
+            ::robot_interaction::InteractionHandlerPtr ih = jt->second;
             marker_access_lock_.unlock();
             try
             {
@@ -735,8 +757,8 @@ void RobotInteraction::processingThread()
           else
             if (marker_class == "GG")
             {
-              InteractionHandlerPtr ih = jt->second;
-              Generic g = active_generic_[it->second];
+              ::robot_interaction::InteractionHandlerPtr ih = jt->second;
+              GenericInteraction g = active_generic_[it->second];
               marker_access_lock_.unlock();
               try
               {
@@ -765,6 +787,18 @@ void RobotInteraction::processingThread()
       }
     }
   }
+}
+
+// DEPRECATED FUNCTIONALITY for backwards compatibility
+void RobotInteraction::decideActiveComponents(const std::string &group, EndEffectorInteractionStyle style)
+{
+  decideActiveComponents(group, (InteractionStyle::InteractionStyle)(int)style);
+}
+
+// DEPRECATED FUNCTIONALITY for backwards compatibility
+void RobotInteraction::decideActiveEndEffectors(const std::string &group, EndEffectorInteractionStyle style)
+{
+  decideActiveEndEffectors(group, (InteractionStyle::InteractionStyle)(int)style);
 }
 
 }

--- a/robot_interaction/src/robot_interaction.cpp
+++ b/robot_interaction/src/robot_interaction.cpp
@@ -211,7 +211,7 @@ void RobotInteraction::decideActiveJoints(const std::string &group)
   for (std::size_t i = 0 ; i < joints.size() ; ++i)
   {
     if ((joints[i]->getType() == robot_model::JointModel::PLANAR ||
-		 joints[i]->getType() == robot_model::JointModel::FLOATING) &&
+     joints[i]->getType() == robot_model::JointModel::FLOATING) &&
         used.find(joints[i]->getName()) == used.end())
     {
       JointInteraction v;
@@ -428,7 +428,7 @@ static inline std::string getMarkerName(
 }
 
 static inline std::string getMarkerName(
-      const ::robot_interaction::InteractionHandlerPtr &handler, 
+      const ::robot_interaction::InteractionHandlerPtr &handler,
       const JointInteraction &vj)
 {
   return "JJ:" + handler->getName() + "_" + vj.connecting_link;
@@ -563,10 +563,10 @@ void RobotInteraction::addInteractiveMarkers(
 }
 
 void RobotInteraction::computeMarkerPose(
-      const ::robot_interaction::InteractionHandlerPtr &handler, 
-      const EndEffectorInteraction &eef, 
+      const ::robot_interaction::InteractionHandlerPtr &handler,
+      const EndEffectorInteraction &eef,
       const robot_state::RobotState &robot_state,
-      geometry_msgs::Pose &pose, 
+      geometry_msgs::Pose &pose,
       geometry_msgs::Pose &control_to_eef_tf) const
 {
   // Need to allow for control pose offsets
@@ -654,10 +654,10 @@ bool RobotInteraction::showingMarkers(const ::robot_interaction::InteractionHand
 
 // TODO: can we get rid of this?  Only used in moveit_ros/benchmarks_gui/src/tab_states_and_goals.cpp right now.
 bool RobotInteraction::updateState(
-      robot_state::RobotState &state, 
-      const EndEffectorInteraction &eef, 
+      robot_state::RobotState &state,
+      const EndEffectorInteraction &eef,
       const geometry_msgs::Pose &pose,
-      unsigned int attempts, 
+      unsigned int attempts,
       double ik_timeout,
       const robot_state::GroupStateValidityCallbackFn &validity_callback,
       const kinematics::KinematicsQueryOptions &kinematics_query_options)

--- a/robot_interaction/test/locked_robot_state_test.cpp
+++ b/robot_interaction/test/locked_robot_state_test.cpp
@@ -1,0 +1,672 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Willow Garage, Inc.
+ *  Copyright (c) 2014, SRI International
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Acorn Pooley, Ioan Sucan */
+
+#include <gtest/gtest.h>
+#include <moveit/robot_interaction/locked_robot_state.h>
+#include <moveit/robot_model/robot_model.h>
+#include <moveit/robot_state/robot_state.h>
+#include <urdf_parser/urdf_parser.h>
+
+
+
+static const char *URDF_STR =
+  "<?xml version=\"1.0\" ?>"
+  "<robot name=\"one_robot\">"
+  "<link name=\"base_link\">"
+  "  <inertial>"
+  "    <mass value=\"2.81\"/>"
+  "    <origin rpy=\"0 0 0\" xyz=\"0.0 0.0 .0\"/>"
+  "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
+  "  </inertial>"
+  "  <collision name=\"my_collision\">"
+  "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
+  "    <geometry>"
+  "      <box size=\"1 2 1\" />"
+  "    </geometry>"
+  "  </collision>"
+  "  <visual>"
+  "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
+  "    <geometry>"
+  "      <box size=\"1 2 1\" />"
+  "    </geometry>"
+  "  </visual>"
+  "</link>"
+  "<joint name=\"joint_a\" type=\"continuous\">"
+  "   <axis xyz=\"0 0 1\"/>"
+  "   <parent link=\"base_link\"/>"
+  "   <child link=\"link_a\"/>"
+  "   <origin rpy=\" 0.0 0 0 \" xyz=\"0.0 0 0 \"/>"
+  "</joint>"
+  "<link name=\"link_a\">"
+  "  <inertial>"
+  "    <mass value=\"1.0\"/>"
+  "    <origin rpy=\"0 0 0\" xyz=\"0.0 0.0 .0\"/>"
+  "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
+  "  </inertial>"
+  "  <collision>"
+  "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
+  "    <geometry>"
+  "      <box size=\"1 2 1\" />"
+  "    </geometry>"
+  "  </collision>"
+  "  <visual>"
+  "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
+  "    <geometry>"
+  "      <box size=\"1 2 1\" />"
+  "    </geometry>"
+  "  </visual>"
+  "</link>"
+  "<joint name=\"joint_b\" type=\"fixed\">"
+  "  <parent link=\"link_a\"/>"
+  "  <child link=\"link_b\"/>"
+  "  <origin rpy=\" 0.0 -0.42 0 \" xyz=\"0.0 0.5 0 \"/>"
+  "</joint>"
+  "<link name=\"link_b\">"
+  "  <inertial>"
+  "    <mass value=\"1.0\"/>"
+  "    <origin rpy=\"0 0 0\" xyz=\"0.0 0.0 .0\"/>"
+  "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
+  "  </inertial>"
+  "  <collision>"
+  "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
+  "    <geometry>"
+  "      <box size=\"1 2 1\" />"
+  "    </geometry>"
+  "  </collision>"
+  "  <visual>"
+  "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
+  "    <geometry>"
+  "      <box size=\"1 2 1\" />"
+  "    </geometry>"
+  "  </visual>"
+  "</link>"
+  "  <joint name=\"joint_c\" type=\"prismatic\">"
+  "    <axis xyz=\"1 0 0\"/>"
+  "    <limit effort=\"100.0\" lower=\"0.0\" upper=\"0.09\" velocity=\"0.2\"/>"
+  "    <safety_controller k_position=\"20.0\" k_velocity=\"500.0\" soft_lower_limit=\"0.0\" soft_upper_limit=\"0.089\"/>"
+  "    <parent link=\"link_b\"/>"
+  "    <child link=\"link_c\"/>"
+  "    <origin rpy=\" 0.0 0.42 0.0 \" xyz=\"0.0 -0.1 0 \"/>"
+  "  </joint>"
+  "<link name=\"link_c\">"
+  "  <inertial>"
+  "    <mass value=\"1.0\"/>"
+  "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 .0\"/>"
+  "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
+  "  </inertial>"
+  "  <collision>"
+  "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
+  "    <geometry>"
+  "      <box size=\"1 2 1\" />"
+  "    </geometry>"
+  "  </collision>"
+  "  <visual>"
+  "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
+  "    <geometry>"
+  "      <box size=\"1 2 1\" />"
+  "    </geometry>"
+  "  </visual>"
+  "</link>"
+  "  <joint name=\"mim_f\" type=\"prismatic\">"
+  "    <axis xyz=\"1 0 0\"/>"
+  "    <limit effort=\"100.0\" lower=\"0.0\" upper=\"0.19\" velocity=\"0.2\"/>"
+  "    <parent link=\"link_c\"/>"
+  "    <child link=\"link_d\"/>"
+  "    <origin rpy=\" 0.0 0.1 0.0 \" xyz=\"0.1 0.1 0 \"/>"
+  "    <mimic joint=\"joint_f\" multiplier=\"1.5\" offset=\"0.1\"/>"
+  "  </joint>"
+  "  <joint name=\"joint_f\" type=\"prismatic\">"
+  "    <axis xyz=\"1 0 0\"/>"
+  "    <limit effort=\"100.0\" lower=\"0.0\" upper=\"0.19\" velocity=\"0.2\"/>"
+  "    <parent link=\"link_d\"/>"
+  "    <child link=\"link_e\"/>"
+  "    <origin rpy=\" 0.0 0.1 0.0 \" xyz=\"0.1 0.1 0 \"/>"
+  "  </joint>"
+  "<link name=\"link_d\">"
+  "  <collision>"
+  "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
+  "    <geometry>"
+  "      <box size=\"1 2 1\" />"
+  "    </geometry>"
+  "  </collision>"
+  "  <visual>"
+  "    <origin rpy=\"0 1 0\" xyz=\"0 0.1 0\"/>"
+  "    <geometry>"
+  "      <box size=\"1 2 1\" />"
+  "    </geometry>"
+  "  </visual>"
+  "</link>"
+  "<link name=\"link_e\">"
+  "  <collision>"
+  "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
+  "    <geometry>"
+  "      <box size=\"1 2 1\" />"
+  "    </geometry>"
+  "  </collision>"
+  "  <visual>"
+  "    <origin rpy=\"0 1 0\" xyz=\"0 0.1 0\"/>"
+  "    <geometry>"
+  "      <box size=\"1 2 1\" />"
+  "    </geometry>"
+  "  </visual>"
+  "</link>"
+  "</robot>";
+
+static const char *SRDF_STR =
+  "<?xml version=\"1.0\" ?>"
+  "<robot name=\"one_robot\">"
+  "<virtual_joint name=\"base_joint\" child_link=\"base_link\" parent_frame=\"odom_combined\" type=\"planar\"/>"
+  "<group name=\"base_from_joints\">"
+  "<joint name=\"base_joint\"/>"
+  "<joint name=\"joint_a\"/>"
+  "<joint name=\"joint_c\"/>"
+  "</group>"
+  "<group name=\"mim_joints\">"
+  "<joint name=\"joint_f\"/>"
+  "<joint name=\"mim_f\"/>"
+  "</group>"
+  "<group name=\"base_with_subgroups\">"
+  "<group name=\"base_from_base_to_tip\"/>"
+  "<joint name=\"joint_c\"/>"
+  "</group>"
+  "<group name=\"base_from_base_to_tip\">"
+  "<chain base_link=\"base_link\" tip_link=\"link_b\"/>"
+  "<joint name=\"base_joint\"/>"
+  "</group>"
+  "</robot>";
+
+// index of joints from URDF
+enum {
+  JOINT_A = 3,
+  JOINT_C = 4,
+  MIM_F   = 5,
+  JOINT_F = 6
+};
+
+static moveit::core::RobotModelPtr getModel()
+{
+  static moveit::core::RobotModelPtr model;
+  if (!model)
+  {
+    boost::shared_ptr<urdf::ModelInterface> urdf(urdf::parseURDF(URDF_STR));
+    boost::shared_ptr<srdf::Model> srdf(new srdf::Model());
+    srdf->initString(*urdf, SRDF_STR);
+    model.reset(new moveit::core::RobotModel(urdf, srdf));
+  }
+  return model;
+}
+
+// Test constructors and robot model loading
+TEST(LockedRobotState, load)
+{
+  moveit::core::RobotModelPtr model = getModel();
+
+  robot_interaction::LockedRobotState ls1(model);
+
+  moveit::core::RobotState state2(model);
+  state2.setToDefaultValues();
+  robot_interaction::LockedRobotState ls2(state2);
+  
+  moveit::core::RobotStatePtr state3(new moveit::core::RobotState(model));
+  state3->setToDefaultValues();
+  robot_interaction::LockedRobotState ls3(state3);
+  
+  robot_interaction::LockedRobotStatePtr ls4(
+                    new robot_interaction::LockedRobotState(model));
+}
+
+// sanity test the URDF and enum
+TEST(LockedRobotState, URDF_sanity)
+{
+  moveit::core::RobotModelPtr model = getModel();
+  robot_interaction::LockedRobotState ls1(model);
+
+  EXPECT_EQ(ls1.getState()->getVariableNames()[JOINT_A], "joint_a");
+}
+
+// A superclass to test the robotStateChanged() virtual method
+class Super1 : public robot_interaction::LockedRobotState
+{
+public:
+  Super1(const robot_model::RobotModelPtr& model)
+    : LockedRobotState(model)
+    , cnt_(0)
+  {}
+
+  virtual void robotStateChanged()
+  {
+    cnt_++;
+  }
+
+  int cnt_;
+};
+
+static void modify1(robot_state::RobotState* state)
+{
+  state->setVariablePosition(JOINT_A, 0.00006);
+}
+
+TEST(LockedRobotState, robotStateChanged)
+{
+  moveit::core::RobotModelPtr model = getModel();
+
+  Super1 ls1(model);
+
+  EXPECT_EQ(ls1.cnt_, 0);
+
+  robot_state::RobotState cp1(*ls1.getState());
+  cp1.setVariablePosition(JOINT_A, 0.00001);
+  cp1.setVariablePosition(JOINT_C, 0.00002);
+  cp1.setVariablePosition(JOINT_F, 0.00003);
+  ls1.setState(cp1);
+
+  EXPECT_EQ(ls1.cnt_, 1);
+
+  ls1.modifyState(modify1);
+  EXPECT_EQ(ls1.cnt_, 2);
+
+  ls1.modifyState(modify1);
+  EXPECT_EQ(ls1.cnt_, 3);
+}
+
+// Class for testing LockedRobotState in multithreaded environment.
+// Contains thread functions for modifying/checking a LockedRobotState.
+class MyInfo
+{
+public:
+  MyInfo()
+    : quit_(false)
+  {}
+
+  // Thread that repeatedly sets state to different values
+  void setThreadFunc(robot_interaction::LockedRobotState* locked_state,
+                        int* counter,
+                        double offset);
+
+  // Thread that repeatedly modifies  state with different values
+  void modifyThreadFunc(robot_interaction::LockedRobotState* locked_state,
+                        int* counter,
+                        double offset);
+
+  // Thread that repeatedly checks that state is valid (not half-updated)
+  void checkThreadFunc(robot_interaction::LockedRobotState* locked_state,
+                       int* counter);
+
+  // Thread that waits for other threads to complete
+  void waitThreadFunc(robot_interaction::LockedRobotState* locked_state,
+                      int** counters,
+                      int max);
+
+private:
+  // helper function for modifyThreadFunc
+  void modifyFunc( robot_state::RobotState* state, double val);
+
+  // Checks state for validity and self-consistancy.
+  void checkState(robot_interaction::LockedRobotState &locked_state);
+
+  // mutex protects quit_ and counter variables
+  boost::mutex cnt_lock_;
+
+  // set to true by waitThreadFunc() when all counters have reached at least
+  // max.
+  bool quit_;
+};
+
+// Check the state.  It should always be valid.
+void MyInfo::checkState(robot_interaction::LockedRobotState &locked_state)
+{
+  robot_state::RobotStateConstPtr s = locked_state.getState();
+  
+  robot_state::RobotState cp1(*s);
+
+  // take some time
+  cnt_lock_.lock();
+  cnt_lock_.unlock();
+  cnt_lock_.lock();
+  cnt_lock_.unlock();
+  cnt_lock_.lock();
+  cnt_lock_.unlock();
+
+  // check mim_f == joint_f
+  EXPECT_EQ(s->getVariablePositions()[MIM_F],
+            s->getVariablePositions()[JOINT_F] * 1.5 + 0.1);
+
+  robot_state::RobotState cp2(*s);
+
+  EXPECT_NE(cp1.getVariablePositions(), cp2.getVariablePositions());
+  EXPECT_NE(cp1.getVariablePositions(), s->getVariablePositions());
+
+  int cnt = cp1.getVariableCount();
+  for (int i = 0 ; i < cnt ; ++i)
+  {
+    EXPECT_EQ(cp1.getVariablePositions()[i], 
+              cp2.getVariablePositions()[i]);
+    EXPECT_EQ(cp1.getVariablePositions()[i], 
+              s->getVariablePositions()[i]);
+  }
+
+  // check mim_f == joint_f
+  EXPECT_EQ(s->getVariablePositions()[MIM_F],
+            s->getVariablePositions()[JOINT_F] * 1.5 + 0.1);
+}
+
+// spin, checking the state
+void MyInfo::checkThreadFunc(
+    robot_interaction::LockedRobotState* locked_state,
+    int* counter)
+{
+  bool go = true;
+  while(go)
+  {
+    for (int loops = 0 ; loops < 100 ; ++loops)
+    {
+      checkState(*locked_state);
+    }
+
+    cnt_lock_.lock();
+    go = !quit_;
+    ++*counter;
+    cnt_lock_.unlock();
+  }
+}
+
+// spin, setting the state to different values
+void MyInfo::setThreadFunc(
+    robot_interaction::LockedRobotState* locked_state,
+    int* counter,
+    double offset)
+{
+  bool go = true;
+  while(go)
+  {
+    double val = offset;
+    for (int loops = 0 ; loops < 100 ; ++loops)
+    {
+      val += 0.0001;
+      robot_state::RobotState cp1(*locked_state->getState());
+      
+      cp1.setVariablePosition(JOINT_A, val + 0.00001);
+      cp1.setVariablePosition(JOINT_C, val + 0.00002);
+      cp1.setVariablePosition(JOINT_F, val + 0.00003);
+
+      locked_state->setState(cp1);
+    }
+
+    cnt_lock_.lock();
+    go = !quit_;
+    ++*counter;
+    cnt_lock_.unlock();
+
+    checkState(*locked_state);
+
+    val += 0.000001;
+  }
+}
+
+// modify the state in place.  Used by MyInfo::modifyThreadFunc()
+void MyInfo::modifyFunc(
+    robot_state::RobotState* state,
+    double val)
+{
+  state->setVariablePosition(JOINT_A, val + 0.00001);
+  state->setVariablePosition(JOINT_C, val + 0.00002);
+  state->setVariablePosition(JOINT_F, val + 0.00003);
+}
+
+// spin, modifying the state to different values
+void MyInfo::modifyThreadFunc(
+    robot_interaction::LockedRobotState* locked_state,
+    int* counter,
+    double offset)
+{
+  bool go = true;
+  while(go)
+  {
+    double val = offset;
+    for (int loops = 0 ; loops < 100 ; ++loops)
+    {
+      val += 0.0001;
+
+      locked_state->modifyState(boost::bind(&MyInfo::modifyFunc,
+                                                 this,
+                                                 _1,
+                                                 val));
+    }
+
+    cnt_lock_.lock();
+    go = !quit_;
+    ++*counter;
+    cnt_lock_.unlock();
+
+    checkState(*locked_state);
+
+    val += 0.000001;
+  }
+}
+
+// spin until all counters reach at least max
+void MyInfo::waitThreadFunc(
+            robot_interaction::LockedRobotState* locked_state,
+            int** counters,
+            int max)
+{
+  bool go = true;
+  while(go)
+  {
+    go = false;
+    cnt_lock_.lock();
+    for (int i = 0 ; counters[i] ; ++i)
+    {
+      if (counters[i][0] < max)
+        go = true;
+    }
+    cnt_lock_.unlock();
+
+    checkState(*locked_state);
+    checkState(*locked_state);
+  }
+  cnt_lock_.lock();
+  quit_ = true;
+  cnt_lock_.unlock();
+}
+
+// Run several threads and ensure they modify the state consistantly
+//   ncheck - # of checkThreadFunc threads to run
+//   nset   - # of setThreadFunc threads to run
+//   nmod   - # of modifyThreadFunc threads to run
+static void runThreads(int ncheck, int nset, int nmod)
+{
+  MyInfo info;
+
+  moveit::core::RobotModelPtr model = getModel();
+  robot_interaction::LockedRobotState ls1(model);
+
+  int num = ncheck + nset + nmod;
+
+  typedef int *int_ptr;
+  typedef boost::thread * thread_ptr;
+  int *cnt = new int[num];
+  int_ptr *counters = new int_ptr[num+1];
+  thread_ptr *threads = new thread_ptr[num];
+
+  int p = 0;
+  double val = 0.1;
+
+  // These threads check the validity of the RobotState
+  for (int i = 0 ; i < ncheck ; ++i)
+  {
+    cnt[p] = 0;
+    counters[p] = &cnt[p];
+    threads[p] = new boost::thread(&MyInfo::checkThreadFunc,
+                                   &info,
+                                   &ls1,
+                                   &cnt[p]);
+    val += 0.1;
+    p++;
+  }
+
+  // These threads set the RobotState to new values
+  for (int i = 0 ; i < nset ; ++i)
+  {
+    cnt[p] = 0;
+    counters[p] = &cnt[p];
+    threads[p] = new boost::thread(&MyInfo::setThreadFunc,
+                                   &info,
+                                   &ls1,
+                                   &cnt[p],
+                                   val);
+    val += 0.1;
+    p++;
+  }
+
+  // These threads modify the RobotState in place
+  for (int i = 0 ; i < nmod ; ++i)
+  {
+    cnt[p] = 0;
+    counters[p] = &cnt[p];
+    threads[p] = new boost::thread(&MyInfo::modifyThreadFunc,
+                                   &info,
+                                   &ls1,
+                                   &cnt[p],
+                                   val);
+    val += 0.1;
+    p++;
+  }
+
+  ASSERT_EQ(p, num);
+  counters[p] = NULL;
+
+  // this thread waits for all the other threads to make progress, then stops
+  // everything.
+  boost::thread wthread(&MyInfo::waitThreadFunc,
+                   &info,
+                   &ls1,
+                   counters,
+                   1000);
+
+  // wait for all threads to finish
+  for (int i = 0 ; i < p ; ++i)
+  {
+    threads[i]->join();
+    wthread.join();
+  }
+
+  // clean up
+  for (int i = 0 ; i < p ; ++i)
+  {
+    delete threads[i];
+  }
+  delete[] cnt;
+  delete[] counters;
+  delete[] threads;
+}
+
+TEST(LockedRobotState, set1)
+{
+  runThreads(1, 1, 0);
+}
+
+TEST(LockedRobotState, set2)
+{
+  runThreads(1, 2, 0);
+}
+
+TEST(LockedRobotState, set3)
+{
+  runThreads(1, 3, 0);
+}
+
+TEST(LockedRobotState, mod1)
+{
+  runThreads(1, 0, 1);
+}
+
+TEST(LockedRobotState, mod2)
+{
+  runThreads(1, 0, 1);
+}
+
+TEST(LockedRobotState, mod3)
+{
+  runThreads(1, 0, 1);
+}
+
+TEST(LockedRobotState, set1mod1)
+{
+  runThreads(1, 1, 1);
+}
+
+TEST(LockedRobotState, set2mod1)
+{
+  runThreads(1, 2, 1);
+}
+
+TEST(LockedRobotState, set1mod2)
+{
+  runThreads(1, 1, 2);
+}
+
+TEST(LockedRobotState, set3mod1)
+{
+  runThreads(1, 3, 1);
+}
+
+TEST(LockedRobotState, set1mod3)
+{
+  runThreads(1, 1, 3);
+}
+
+TEST(LockedRobotState, set3mod3)
+{
+  runThreads(1, 3, 3);
+}
+
+TEST(LockedRobotState, set3mod3c3)
+{
+  runThreads(3, 3, 3);
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  int arg;
+
+  return RUN_ALL_TESTS();
+}
+
+
+


### PR DESCRIPTION
This change attempts to simplify RobotInteraction and improve thread safety.

These changes focus on InteractionHandler.  Some of the functionality is pulled out into helper classes (LockedRobotState and KinematicOptionsMap) so that the intent of InteractionHandler is more clear.

All non-const members are now protected with internal locks.
The locking scheme is documented in comments.

The state update is simplified, removing the need for condition variables.  Instead in-place updates are done using callback functions with the modifyState method (inherited by RobotInteraction from LockedRobotState).
