### PR TITLE
empty state should be a diff state, otherwise attached objects are delet...

### DIFF
--- a/move_group/src/move_group_capability.cpp
+++ b/move_group/src/move_group_capability.cpp
@@ -87,6 +87,7 @@ planning_interface::MotionPlanRequest move_group::MoveGroupCapability::clearRequ
 {
   planning_interface::MotionPlanRequest r = request;
   r.start_state = moveit_msgs::RobotState();
+  r.start_state.is_diff = true;  
   ROS_WARN("Execution of motions should always start at the robot's current state. Ignoring the state supplied as start state in the motion planning request");
   return r;
 }
@@ -95,6 +96,7 @@ moveit_msgs::PlanningScene move_group::MoveGroupCapability::clearSceneRobotState
 {
   moveit_msgs::PlanningScene r = scene;
   r.robot_state = moveit_msgs::RobotState();
+  r.robot_state.is_diff = true;  
   ROS_WARN("Execution of motions should always start at the robot's current state. Ignoring the state supplied as difference in the planning scene diff");
   return r;
 }


### PR DESCRIPTION
...ed

Please don't merge this yet. This should fix one of the issues in #411 : when plan and execute is called in move_group, this should make sure that attached objects to the current state are not deleted. plan and execute is called when move_group_interface uses the move() function. 

@isucan - could you please comment. 
