### PR TITLE
Allow planning groups to have more than one tip

### DIFF
--- a/planning/kdl_kinematics_plugin/src/chainiksolver_pos_nr_jl_mimic.cpp
+++ b/planning/kdl_kinematics_plugin/src/chainiksolver_pos_nr_jl_mimic.cpp
@@ -38,12 +38,12 @@ ChainIkSolverPos_NR_JL_Mimic::ChainIkSolverPos_NR_JL_Mimic(const Chain& _chain, 
   { 
     mimic_joints[i].reset(i);
   }
-  ROS_DEBUG("Limits");
+  ROS_DEBUG_NAMED("kdl","Limits");
   for(std::size_t i=0; i < q_min.rows(); ++i)
   { 
-    ROS_DEBUG("%ld: Min: %f, Max: %f", long(i), q_min(i), q_max(i));
+    ROS_DEBUG_NAMED("kdl","%ld: Min: %f, Max: %f", long(i), q_min(i), q_max(i));
   }
-  ROS_DEBUG(" ");
+  ROS_DEBUG_NAMED("kdl"," ");
 }
 
 bool ChainIkSolverPos_NR_JL_Mimic::setMimicJoints(const std::vector<kdl_kinematics_plugin::JointMimic>& _mimic_joints)

--- a/planning/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/planning/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -167,7 +167,7 @@ bool KDLKinematicsPlugin::initialize(const std::string &robot_description,
     ROS_ERROR_NAMED("kdl","Could not initialize tree object");
     return false;
   }
-  if (!kdl_tree.getChain(base_frame_, tip_frame_, kdl_chain_))
+  if (!kdl_tree.getChain(base_frame_, getTipFrame(), kdl_chain_))
   {
     ROS_ERROR_NAMED("kdl","Could not initialize chain object");
     return false;
@@ -187,12 +187,12 @@ bool KDLKinematicsPlugin::initialize(const std::string &robot_description,
   fk_chain_info_.joint_names = ik_chain_info_.joint_names;
   fk_chain_info_.limits = ik_chain_info_.limits;
 
-  if(!joint_model_group->hasLinkModel(tip_frame_))
+  if(!joint_model_group->hasLinkModel(getTipFrame()))
   {
     ROS_ERROR_NAMED("kdl","Could not find tip name in joint group '%s'", group_name.c_str());
     return false;
   }
-  ik_chain_info_.link_names.push_back(tip_frame_);
+  ik_chain_info_.link_names.push_back(getTipFrame());
   fk_chain_info_.link_names = joint_model_group->getLinkModelNames();
 
   joint_min_.resize(ik_chain_info_.limits.size());
@@ -382,7 +382,7 @@ bool KDLKinematicsPlugin::getPositionIK(const geometry_msgs::Pose &ik_pose,
 
   return searchPositionIK(ik_pose,
                           ik_seed_state,
-              default_timeout_,
+                          default_timeout_,
                           solution,
                           solution_callback,
                           error_code,
@@ -486,14 +486,14 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
 
   if(ik_seed_state.size() != dimension_)
   {
-    ROS_ERROR_STREAM("Seed state must have size " << dimension_ << " instead of size " << ik_seed_state.size());
+    ROS_ERROR_STREAM_NAMED("kdl","Seed state must have size " << dimension_ << " instead of size " << ik_seed_state.size());
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
 
   if(!consistency_limits.empty() && consistency_limits.size() != dimension_)
   {
-    ROS_ERROR_STREAM("Consistency limits be empty or must have size " << dimension_ << " instead of size " << consistency_limits.size());
+    ROS_ERROR_STREAM_NAMED("kdl","Consistency limits be empty or must have size " << dimension_ << " instead of size " << consistency_limits.size());
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
@@ -524,7 +524,7 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
   KDL::Frame pose_desired;
   tf::poseMsgToKDL(ik_pose, pose_desired);
 
-  ROS_DEBUG_STREAM("searchPositionIK2: Position request pose is " <<
+  ROS_DEBUG_STREAM_NAMED("kdl","searchPositionIK2: Position request pose is " <<
                    ik_pose.position.x << " " <<
                    ik_pose.position.y << " " <<
                    ik_pose.position.z << " " <<
@@ -583,7 +583,7 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
 
     if(error_code.val == error_code.SUCCESS)
     {
-      ROS_DEBUG_STREAM("Solved after " << counter << " iterations");
+      ROS_DEBUG_STREAM_NAMED("kdl","Solved after " << counter << " iterations");
       ik_solver_vel.unlockRedundantJoints();
       return true;
     }

--- a/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -50,14 +50,21 @@ namespace kinematics_plugin_loader
 class KinematicsPluginLoader::KinematicsLoaderImpl
 {
 public:
+  /**
+   * \brief Pimpl Implementation of KinematicsLoader
+   * \param robot_description
+   * \param possible_kinematics_solvers
+   * \param search_res
+   * \param iksolver_to_tip_links - a map between each ik solver and a vector of custom-specified tip link(s)
+   */
   KinematicsLoaderImpl(const std::string &robot_description,
                        const std::map<std::string, std::vector<std::string> > &possible_kinematics_solvers,
                        const std::map<std::string, std::vector<double> > &search_res,
-                       const std::map<std::string, std::string> &ik_links) :
+                       const std::map<std::string, std::vector<std::string> > &iksolver_to_tip_links) :
     robot_description_(robot_description),
     possible_kinematics_solvers_(possible_kinematics_solvers),
     search_res_(search_res),
-    ik_links_(ik_links)
+    iksolver_to_tip_links_(iksolver_to_tip_links)
   {
     try
     {
@@ -67,6 +74,49 @@ public:
     {
       ROS_ERROR("Unable to construct kinematics loader. Error: %s", e.what());
     }
+  }
+
+  /**
+   * \brief Helper function to decide which, and how many, tip frames a planning group has
+   * \param jmg - joint model group pointer
+   * \return tips - list of valid links in a planning group to plan for
+   */
+  std::vector<std::string> chooseTipFrames(const robot_model::JointModelGroup *jmg)
+  {
+    std::vector<std::string> tips;
+    std::map<std::string, std::vector<std::string> >::const_iterator ik_it = iksolver_to_tip_links_.find(jmg->getName());
+
+    // Check if tips were loaded onto the rosparam server previously
+    if (ik_it != iksolver_to_tip_links_.end())
+    {
+      // the tip is being chosen based on a corresponding rosparam ik link
+      ROS_DEBUG_STREAM_NAMED("kinematics_plugin_loader","Chooing tip frame of kinematic solver for group "
+        << jmg->getName() << " based on values in rosparam server.");
+      tips = ik_it->second;
+    }
+    else
+    {
+      // get the last link in the chain
+      ROS_DEBUG_STREAM_NAMED("kinematics_plugin_loader","Chooing tip frame of kinematic solver for group "
+        << jmg->getName() << " based on last link in chain");
+
+      tips.push_back(jmg->getLinkModels().back()->getName());
+    }
+
+    // Error check
+    if (tips.empty())
+    {
+      ROS_ERROR_STREAM_NAMED("kinematics_plugin_loader","Error choosing kinematic solver tip frame(s).");
+    }
+
+    // Debug tip choices
+    std::stringstream tip_debug;
+    tip_debug << "Planning group '" << jmg->getName() << "' has tip(s): ";
+    for (std::size_t i = 0; i < tips.size(); ++i)
+      tip_debug << tips[i] << ", ";
+    ROS_DEBUG_STREAM_NAMED("kinematics_plugin_loader", tip_debug.str());
+
+    return tips;
   }
 
   boost::shared_ptr<kinematics::KinematicsBase> allocKinematicsSolver(const robot_model::JointModelGroup *jmg)
@@ -100,11 +150,15 @@ public:
               {
                 const std::string &base = links.front()->getParentJointModel()->getParentLinkModel() ?
                   links.front()->getParentJointModel()->getParentLinkModel()->getName() : jmg->getParentModel().getModelFrame();
-                std::map<std::string, std::string>::const_iterator ik_it = ik_links_.find(jmg->getName());
-                const std::string &tip = ik_it != ik_links_.end() ? ik_it->second : links.back()->getName();
+
+                // choose the tip of the IK solver
+                const std::vector<std::string> tips = chooseTipFrames(jmg);
+
+                // choose search resolution
                 double search_res = search_res_.find(jmg->getName())->second[i]; // we know this exists, by construction
+
                 if (!result->initialize(robot_description_, jmg->getName(),
-                                        (base.empty() || base[0] != '/') ? base : base.substr(1) , tip, search_res))
+                                        (base.empty() || base[0] != '/') ? base : base.substr(1) , tips, search_res))
                 {
                   ROS_ERROR("Kinematics solver of type '%s' could not be initialized for group '%s'", it->second[i].c_str(), jmg->getName().c_str());
                   result.reset();
@@ -172,7 +226,7 @@ private:
   std::string                                                            robot_description_;
   std::map<std::string, std::vector<std::string> >                       possible_kinematics_solvers_;
   std::map<std::string, std::vector<double> >                            search_res_;
-  std::map<std::string, std::string>                                     ik_links_;
+  std::map<std::string, std::vector<std::string> >                       iksolver_to_tip_links_;  // a map between each ik solver and a vector of custom-specified tip link(s)
   boost::shared_ptr<pluginlib::ClassLoader<kinematics::KinematicsBase> > kinematics_loader_;
   std::map<const robot_model::JointModelGroup*,
            std::vector<boost::shared_ptr<kinematics::KinematicsBase> > > instances_;
@@ -214,7 +268,7 @@ robot_model::SolverAllocatorFn kinematics_plugin_loader::KinematicsPluginLoader:
 
     std::map<std::string, std::vector<std::string> > possible_kinematics_solvers;
     std::map<std::string, std::vector<double> > search_res;
-    std::map<std::string, std::string> ik_links;
+    std::map<std::string, std::vector<std::string> > iksolver_to_tip_links;
 
     if (srdf_model)
     {
@@ -233,18 +287,18 @@ robot_model::SolverAllocatorFn kinematics_plugin_loader::KinematicsPluginLoader:
         for (std::size_t i = 0 ; i < known_groups.size() ; ++i)
         {
           std::string base_param_name = known_groups[i].name_;
-          ROS_DEBUG("Looking for param %s ", (base_param_name + "/kinematics_solver").c_str());
+          ROS_DEBUG_NAMED("kinematics_plugin_loader","Looking for param %s ", (base_param_name + "/kinematics_solver").c_str());
           std::string ksolver_param_name;
           bool found = nh.searchParam(base_param_name + "/kinematics_solver", ksolver_param_name);
           if (!found || !nh.hasParam(ksolver_param_name))
           {
             base_param_name = robot_description_ + "_kinematics/" + known_groups[i].name_;
-            ROS_DEBUG("Looking for param %s ", (base_param_name + "/kinematics_solver").c_str());
+            ROS_DEBUG_NAMED("kinematics_plugin_loader","Looking for param %s ", (base_param_name + "/kinematics_solver").c_str());
             found = nh.searchParam(base_param_name + "/kinematics_solver", ksolver_param_name);
           }
           if (found)
           {
-            ROS_DEBUG("Found param %s", ksolver_param_name.c_str());
+            ROS_DEBUG_NAMED("kinematics_plugin_loader","Found param %s", ksolver_param_name.c_str());
             std::string ksolver;
             if (nh.getParam(ksolver_param_name, ksolver))
             {
@@ -259,7 +313,7 @@ robot_model::SolverAllocatorFn kinematics_plugin_loader::KinematicsPluginLoader:
                 }
                 std::string solver; ss >> solver >> std::ws;
                 possible_kinematics_solvers[known_groups[i].name_].push_back(solver);
-                ROS_DEBUG("Using kinematics solver '%s' for group '%s'.", solver.c_str(), known_groups[i].name_.c_str());
+                ROS_DEBUG_NAMED("kinematics_plugin_loader","Using kinematics solver '%s' for group '%s'.", solver.c_str(), known_groups[i].name_.c_str());
               }
             }
           }
@@ -313,12 +367,40 @@ robot_model::SolverAllocatorFn kinematics_plugin_loader::KinematicsPluginLoader:
             }
           }
 
+          // Allow a kinematic solver's tip link to be specified on the rosparam server
+          // Depreciated in favor of array version now
           std::string ksolver_ik_link_param_name;
           if (nh.searchParam(base_param_name + "/kinematics_solver_ik_link", ksolver_ik_link_param_name))
           {
             std::string ksolver_ik_link;
-            if (nh.getParam(ksolver_ik_link_param_name, ksolver_ik_link))
-              ik_links[known_groups[i].name_] = ksolver_ik_link;
+            if (nh.getParam(ksolver_ik_link_param_name, ksolver_ik_link)) // has a custom rosparam-based tip link
+            {
+              ROS_WARN_STREAM_NAMED("kinematics_plugin_loader","Using kinematics_solver_ik_link rosparam is deprecated in favor of kinematics_solver_ik_links rosparam array.");
+              iksolver_to_tip_links[known_groups[i].name_].push_back(ksolver_ik_link);
+            }
+          }
+
+          // Allow a kinematic solver's tip links to be specified on the rosparam server as an array
+          std::string ksolver_ik_links_param_name;
+          if (nh.searchParam(base_param_name + "/kinematics_solver_ik_links", ksolver_ik_links_param_name))
+          {
+            XmlRpc::XmlRpcValue ksolver_ik_links;
+            if (nh.getParam(ksolver_ik_links_param_name, ksolver_ik_links)) // has custom rosparam-based tip link(s)
+            {
+              if (ksolver_ik_links.getType() != XmlRpc::XmlRpcValue::TypeArray)
+              {
+                ROS_WARN_STREAM_NAMED("kinematics_plugin_loader","rosparam '" << ksolver_ik_links_param_name << "' should be an XmlRpc value type 'Array'");
+              }
+              else
+              {
+                for (int32_t j = 0; j < ksolver_ik_links.size(); ++j)
+                {
+                  ROS_ASSERT(ksolver_ik_links[j].getType() == XmlRpc::XmlRpcValue::TypeString);
+                  ROS_DEBUG_STREAM_NAMED("kinematics_plugin_loader","found tip " << static_cast<std::string>(ksolver_ik_links[j]) << " for group " << known_groups[i].name_ );
+                  iksolver_to_tip_links[known_groups[i].name_].push_back( static_cast<std::string>(ksolver_ik_links[j]) );
+                }
+              }
+            }
           }
 
           // make sure there is a default resolution at least specified for every solver (in case it was not specified on the param server)
@@ -340,7 +422,7 @@ robot_model::SolverAllocatorFn kinematics_plugin_loader::KinematicsPluginLoader:
       }
     }
 
-    loader_.reset(new KinematicsLoaderImpl(robot_description_, possible_kinematics_solvers, search_res, ik_links));
+    loader_.reset(new KinematicsLoaderImpl(robot_description_, possible_kinematics_solvers, search_res, iksolver_to_tip_links));
   }
 
   return boost::bind(&KinematicsPluginLoader::KinematicsLoaderImpl::allocKinematicsSolverWithCache, loader_.get(), _1);

--- a/planning/rdf_loader/src/rdf_loader.cpp
+++ b/planning/rdf_loader/src/rdf_loader.cpp
@@ -76,7 +76,7 @@ rdf_loader::RDFLoader::RDFLoader(const std::string &robot_description)
     else
       ROS_ERROR("Robot model not found! Did you remap '%s'?", robot_description_.c_str());
   }
-  ROS_DEBUG_STREAM("Loaded robot model in " << (ros::WallTime::now() - start).toSec() << " seconds");
+  ROS_DEBUG_STREAM_NAMED("rdf",  "Loaded robot model in " << (ros::WallTime::now() - start).toSec() << " seconds");
 }
 
 rdf_loader::RDFLoader::RDFLoader(const std::string &urdf_string, const std::string &srdf_string)

--- a/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -150,14 +150,14 @@ void robot_model_loader::RobotModelLoader::configure(const Options &opt)
         if (nh.getParam(prefix + "has_acceleration_limits", has_acc_limits))
           jlim[j].has_acceleration_limits = has_acc_limits;
       }
-      jmodel->setVariableBounds(jlim); 
+      jmodel->setVariableBounds(jlim);
     }
   }
 
   if (model_ && opt.load_kinematics_solvers_)
     loadKinematicsSolvers();
 
-  ROS_DEBUG_STREAM("Loaded kinematic model in " << (ros::WallTime::now() - start).toSec() << " seconds");
+  ROS_DEBUG_STREAM_NAMED("robot_model_loader","Loaded kinematic model in " << (ros::WallTime::now() - start).toSec() << " seconds");
 }
 
 void robot_model_loader::RobotModelLoader::loadKinematicsSolvers(const kinematics_plugin_loader::KinematicsPluginLoaderPtr &kloader)
@@ -181,11 +181,14 @@ void robot_model_loader::RobotModelLoader::loadKinematicsSolvers(const kinematic
     std::map<std::string, robot_model::SolverAllocatorFn> imap;
     for (std::size_t i = 0 ; i < groups.size() ; ++i)
     {
+      // Check if a group in kinematics.yaml exists in the srdf
       if (!model_->hasJointModelGroup(groups[i]))
         continue;
+
       const robot_model::JointModelGroup *jmg = model_->getJointModelGroup(groups[i]);
-      if (jmg->isChain())
-        imap[groups[i]] = kinematics_allocator;
+
+      // Any planning group can have an IK solver, not just chains
+      imap[groups[i]] = kinematics_allocator;
     }
     model_->setKinematicsAllocators(imap);
 

--- a/robot_interaction/src/robot_interaction.cpp
+++ b/robot_interaction/src/robot_interaction.cpp
@@ -286,7 +286,6 @@ void RobotInteraction::decideActiveEndEffectors(const std::string &group, Intera
           ee.eef_group = eef[i].component_group_;
           ee.interaction = style;
           active_eef_.push_back(ee);
-          break;
         }
     }
   }
@@ -317,7 +316,7 @@ void RobotInteraction::decideActiveEndEffectors(const std::string &group, Intera
 
   for (std::size_t i = 0 ; i < active_eef_.size() ; ++i)
   {
-    // if we have a separate group for the eef, we compte the scale based on
+    // if we have a separate group for the eef, we compute the scale based on
     // it; otherwise, we use a default scale
     active_eef_[i].size = active_eef_[i].eef_group == active_eef_[i].parent_group ?
                             computeGroupMarkerSize("") :


### PR DESCRIPTION
Note: This commit will not build until the pending PR for moveit_core is merged https://github.com/ros-planning/moveit_core/pull/149

Adds functionality for moveit_ros to reason with kinematic solvers that have multiple tips, ie kinematic trees.
- Modifies KinematicsPluginLoader to check the rosparam server for an optional array of tips per kinematic solver. This is the recommended way to enable a kinematic solver to have more than one tip frame. Creates a vector of tip links to planning groups, instead of just a string. 
- Moves the logic for choosing a planning group's tip frames into a separate helper function, to make it clearer and support multiple tips
- Removes the assumption in robot_model_loader that a joint model group can only have a kinematics solver if it is a chain
- Namespaces a lot of debug output
- Removes direct dependency on tip_frame_ from KDL since it is deprecated, instead uses getTipFrame()

I'd recommend this be tested more against regular kinematic chain robots to ensure it doesn't have any adverse consequences, but I don't believe it does.
