### PR TITLE
Minor non-functional changes to KDL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ compiler:
 notifications:
   email:
     recipients:
-      - davetcoleman@gmail.com
+    #  - davetcoleman@gmail.com
     on_success: change #[always|never|change] # default: change
     on_failure: change #[always|never|change] # default: always
 before_install: # Use this to prepare the system to install prerequisites or dependencies

--- a/planning/kdl_kinematics_plugin/src/chainiksolver_pos_nr_jl_mimic.cpp
+++ b/planning/kdl_kinematics_plugin/src/chainiksolver_pos_nr_jl_mimic.cpp
@@ -38,12 +38,12 @@ ChainIkSolverPos_NR_JL_Mimic::ChainIkSolverPos_NR_JL_Mimic(const Chain& _chain, 
   { 
     mimic_joints[i].reset(i);
   }
-  ROS_DEBUG("Limits");
+  ROS_DEBUG_NAMED("kdl","Limits");
   for(std::size_t i=0; i < q_min.rows(); ++i)
   { 
-    ROS_DEBUG("%ld: Min: %f, Max: %f", long(i), q_min(i), q_max(i));
+    ROS_DEBUG_NAMED("kdl","%ld: Min: %f, Max: %f", long(i), q_min(i), q_max(i));
   }
-  ROS_DEBUG(" ");
+  ROS_DEBUG_NAMED("kdl"," ");
 }
 
 bool ChainIkSolverPos_NR_JL_Mimic::setMimicJoints(const std::vector<kdl_kinematics_plugin::JointMimic>& _mimic_joints)

--- a/planning/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/planning/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -167,7 +167,7 @@ bool KDLKinematicsPlugin::initialize(const std::string &robot_description,
     ROS_ERROR_NAMED("kdl","Could not initialize tree object");
     return false;
   }
-  if (!kdl_tree.getChain(base_frame_, tip_frame_, kdl_chain_))
+  if (!kdl_tree.getChain(base_frame_, getTipFrame(), kdl_chain_))
   {
     ROS_ERROR_NAMED("kdl","Could not initialize chain object");
     return false;
@@ -187,12 +187,12 @@ bool KDLKinematicsPlugin::initialize(const std::string &robot_description,
   fk_chain_info_.joint_names = ik_chain_info_.joint_names;
   fk_chain_info_.limits = ik_chain_info_.limits;
 
-  if(!joint_model_group->hasLinkModel(tip_frame_))
+  if(!joint_model_group->hasLinkModel(getTipFrame()))
   {
     ROS_ERROR_NAMED("kdl","Could not find tip name in joint group '%s'", group_name.c_str());
     return false;
   }
-  ik_chain_info_.link_names.push_back(tip_frame_);
+  ik_chain_info_.link_names.push_back(getTipFrame());
   fk_chain_info_.link_names = joint_model_group->getLinkModelNames();
 
   joint_min_.resize(ik_chain_info_.limits.size());
@@ -382,7 +382,7 @@ bool KDLKinematicsPlugin::getPositionIK(const geometry_msgs::Pose &ik_pose,
 
   return searchPositionIK(ik_pose,
                           ik_seed_state,
-              default_timeout_,
+                          default_timeout_,
                           solution,
                           solution_callback,
                           error_code,
@@ -486,14 +486,14 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
 
   if(ik_seed_state.size() != dimension_)
   {
-    ROS_ERROR_STREAM("Seed state must have size " << dimension_ << " instead of size " << ik_seed_state.size());
+    ROS_ERROR_STREAM_NAMED("kdl","Seed state must have size " << dimension_ << " instead of size " << ik_seed_state.size());
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
 
   if(!consistency_limits.empty() && consistency_limits.size() != dimension_)
   {
-    ROS_ERROR_STREAM("Consistency limits be empty or must have size " << dimension_ << " instead of size " << consistency_limits.size());
+    ROS_ERROR_STREAM_NAMED("kdl","Consistency limits be empty or must have size " << dimension_ << " instead of size " << consistency_limits.size());
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
@@ -524,7 +524,7 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
   KDL::Frame pose_desired;
   tf::poseMsgToKDL(ik_pose, pose_desired);
 
-  ROS_DEBUG_STREAM("searchPositionIK2: Position request pose is " <<
+  ROS_DEBUG_STREAM_NAMED("kdl","searchPositionIK2: Position request pose is " <<
                    ik_pose.position.x << " " <<
                    ik_pose.position.y << " " <<
                    ik_pose.position.z << " " <<
@@ -583,7 +583,7 @@ bool KDLKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
 
     if(error_code.val == error_code.SUCCESS)
     {
-      ROS_DEBUG_STREAM("Solved after " << counter << " iterations");
+      ROS_DEBUG_STREAM_NAMED("kdl","Solved after " << counter << " iterations");
       ik_solver_vel.unlockRedundantJoints();
       return true;
     }

--- a/planning/rdf_loader/src/rdf_loader.cpp
+++ b/planning/rdf_loader/src/rdf_loader.cpp
@@ -76,7 +76,7 @@ rdf_loader::RDFLoader::RDFLoader(const std::string &robot_description)
     else
       ROS_ERROR("Robot model not found! Did you remap '%s'?", robot_description_.c_str());
   }
-  ROS_DEBUG_STREAM("Loaded robot model in " << (ros::WallTime::now() - start).toSec() << " seconds");
+  ROS_DEBUG_STREAM_NAMED("rdf",  "Loaded robot model in " << (ros::WallTime::now() - start).toSec() << " seconds");
 }
 
 rdf_loader::RDFLoader::RDFLoader(const std::string &urdf_string, const std::string &srdf_string)


### PR DESCRIPTION
This PR does not change any functionality and does not depend on any other commits. 
- Removes direct dependency on tip_frame_ from KDL since it is deprecated, instead uses getTipFrame()
- Namespaces a lot of debug output
- Disables travis emails for me :)
