### PR TITLE
Add functions to python bindings

### DIFF
--- a/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -718,7 +718,9 @@ public:
   /** \brief Get the names of the constraints known as read from the MongoDB server, if a connection was achieved. */
   std::vector<std::string> getKnownConstraints() const;
 
-  /** \brief Get the actual set of constraints for this MoveGroup. **/
+  /** \brief Get the actual set of constraints for this MoveGroup. 
+      @return A copy of the current path constraints set for this move_group
+      */
   moveit_msgs::Constraints getPathConstraints() const;
 
   /** \brief Specify a set of path constraints to use.

--- a/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -718,6 +718,9 @@ public:
   /** \brief Get the names of the constraints known as read from the MongoDB server, if a connection was achieved. */
   std::vector<std::string> getKnownConstraints() const;
 
+  /** \brief Get the actual set of constraints for this MoveGroup. **/
+  moveit_msgs::Constraints getPathConstraints() const;
+
   /** \brief Specify a set of path constraints to use.
       The constraints are looked up by name from the MongoDB server.
       This replaces any path constraints set in previous calls to setPathConstraints(). */

--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -916,6 +916,14 @@ public:
     return c;
   }
 
+  moveit_msgs::Constraints getPathConstraints() const
+  {
+    if (path_constraints_)
+       return *path_constraints_;
+    else
+       return moveit_msgs::Constraints();
+  }
+
   void initializeConstraintsStorage(const std::string &host, unsigned int port)
   {
     initializing_constraints_ = true;
@@ -1637,6 +1645,11 @@ void moveit::planning_interface::MoveGroup::allowReplanning(bool flag)
 std::vector<std::string> moveit::planning_interface::MoveGroup::getKnownConstraints() const
 {
   return impl_->getKnownConstraints();
+}
+
+moveit_msgs::Constraints moveit::planning_interface::MoveGroup::getPathConstraints() const 
+{
+   return impl_->getPathConstraints();
 }
 
 bool moveit::planning_interface::MoveGroup::setPathConstraints(const std::string &constraint)

--- a/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -359,6 +359,13 @@ public:
       py_bindings_tools::deserializeMsg(constraints_str,constraints_msg);
       setPathConstraints(constraints_msg);
   } 
+
+  std::string getPathConstraintsPython()
+  {
+     moveit_msgs::Constraints constraints_msg(getPathConstraints());
+     std::string constraints_str = py_bindings_tools::serializeMsg(constraints_msg);
+     return constraints_str;
+  }
   
 };
 
@@ -448,8 +455,8 @@ static void wrap_move_group_interface()
 
   bool (MoveGroupWrapper::*setPathConstraints_1)(const std::string&) = &MoveGroupWrapper::setPathConstraints;
   MoveGroupClass.def("set_path_constraints", setPathConstraints_1);
-  MoveGroupClass.def("set_path_constraints_by_msgs", &MoveGroupWrapper::setPathConstraintsFromMsg);
-
+  MoveGroupClass.def("set_path_constraints_from_msg", &MoveGroupWrapper::setPathConstraintsFromMsg);
+  MoveGroupClass.def("get_path_constraints", &MoveGroupWrapper::getPathConstraintsPython);
   MoveGroupClass.def("clear_path_constraints", &MoveGroupWrapper::clearPathConstraints);
   MoveGroupClass.def("get_known_constraints", &MoveGroupWrapper::getKnownConstraintsList);
   MoveGroupClass.def("set_constraints_database", &MoveGroupWrapper::setConstraintsDatabase);

--- a/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -352,6 +352,13 @@ public:
       py_bindings_tools::deserializeMsg(bp::extract<std::string>(grasp_list[i]), grasps[i]);
     return pick(object, grasps);
   }
+
+  void setPathConstraintsFromMsg(const std::string &constraints_str)
+  {
+      moveit_msgs::Constraints constraints_msg;
+      py_bindings_tools::deserializeMsg(constraints_str,constraints_msg);
+      setPathConstraints(constraints_msg);
+  } 
   
 };
 
@@ -441,6 +448,7 @@ static void wrap_move_group_interface()
 
   bool (MoveGroupWrapper::*setPathConstraints_1)(const std::string&) = &MoveGroupWrapper::setPathConstraints;
   MoveGroupClass.def("set_path_constraints", setPathConstraints_1);
+  MoveGroupClass.def("set_path_constraints_by_msgs", &MoveGroupWrapper::setPathConstraintsFromMsg);
 
   MoveGroupClass.def("clear_path_constraints", &MoveGroupWrapper::clearPathConstraints);
   MoveGroupClass.def("get_known_constraints", &MoveGroupWrapper::getKnownConstraintsList);


### PR DESCRIPTION
Added python bindings to manage path constraints

this function was not accessible from python code:

```
void moveit::planning_interface::MoveGroup::setPathConstraints(const moveit_msgs::Constraint &constraint)
```

I added the necesary code to generate the python bindings.

At the same time created a function to retrieve this paths constraints
and generated also the python bindings.

```
moveit_msgs::Constraint moveit::planning_interface::MoveGroup::getPathConstraints() const
```

I opened this issue in the moveit_commander in order to track this missing functionality: 
https://github.com/ros-planning/moveit_commander/issues/18
