### PR TITLE
find PkgConfig before using pkg_check_modules

### DIFF
--- a/benchmarks_gui/CMakeLists.txt
+++ b/benchmarks_gui/CMakeLists.txt
@@ -7,6 +7,8 @@ endif()
 
 find_package(Boost REQUIRED thread program_options date_time system filesystem)
 
+find_package(PkgConfig REQUIRED)
+
 pkg_check_modules(OGRE OGRE)
 link_directories(${OGRE_LIBRARY_DIRS})
 

--- a/visualization/CMakeLists.txt
+++ b/visualization/CMakeLists.txt
@@ -7,6 +7,8 @@ endif()
 
 find_package(Boost REQUIRED thread date_time system filesystem)
 
+find_package(PkgConfig REQUIRED)
+
 # Ogre
 pkg_check_modules(OGRE OGRE)
 link_directories( ${OGRE_LIBRARY_DIRS} )


### PR DESCRIPTION
PC specific functions mustn't be used before including PkgConfig
