### PR TITLE
Add check for planning scene monitor connection, with 5 sec delay

### DIFF
--- a/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -419,13 +419,20 @@ bool planning_scene_monitor::PlanningSceneMonitor::requestPlanningSceneState(con
       srv.request.components.LINK_PADDING_AND_SCALING |
       srv.request.components.OBJECT_COLORS;
 
+  // Make sure client is connected to server
+  if (!client.exists())
+  {
+    ROS_DEBUG_STREAM("Waiting for service `" << service_name << "` to exist.");
+    client.waitForExistence(ros::Duration(5.0));
+  }
+
   if (client.call(srv))
   {
     newPlanningSceneMessage(srv.response.scene);
   }
   else
   {
-    ROS_ERROR("Failed to call service %s at %s:%d",
+    ROS_WARN("Failed to call service %s, have you launched move_group? at %s:%d",
       service_name.c_str(),
       __FILE__,
       __LINE__);

--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -182,7 +182,7 @@ public:
     }
 
     if (!action->isServerConnected())
-      throw std::runtime_error("Unable to connect to action server within allotted time");
+      throw std::runtime_error("Unable to connect to move_group action server within allotted time (2)");
     else
       ROS_DEBUG("Connected to '%s'", name.c_str());
   }

--- a/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -316,7 +316,7 @@ void MotionPlanningFrame::waitForAction(const T &action, const ros::NodeHandle &
   }
 
   if (!action->isServerConnected())
-    throw std::runtime_error("Unable to connect to action server within allotted time");
+    throw std::runtime_error("Unable to connect to move_group action server within allotted time");
   else
     ROS_DEBUG("Connected to '%s'", name.c_str());
 };


### PR DESCRIPTION
**Note:** _this is a fixed PR from https://github.com/ros-planning/moveit_ros/pull/446_

Fix for error that sometimes occurs when the Rviz Motion Planning plugin is launch with the move_group node in the same launch file. Before making a service call to get an updated planning scene, this causes it to wait for the service to exist up to 5 seconds before showing the error

```
Failed to call service /get_planning_scene
```

The 5 seconds is arbitrary but is enough to allow the timing issue to usually work out. This fix doesn't change any functionality, just helps remove the error message.

This PR also helps clarify some of the related error messages and changes one to just a warning since the Rviz motion planning plugin will still continue to work and there are use cases when its ok to not have move_group launched.
