### PR TITLE
Fix RobotState rviz plugin to not display when disabled

### DIFF
--- a/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -118,7 +118,7 @@ void RobotStateDisplay::onInitialize()
   robot_.reset(new RobotStateVisualization(scene_node_, context_, "Robot State", this));
   changedEnableVisualVisible();
   changedEnableCollisionVisible();
-  robot_->setVisible(true);
+  robot_->setVisible(false);
 }
 
 void RobotStateDisplay::reset()


### PR DESCRIPTION
To reproduce bug:
- load a robot description to param server
- launch a blank rviz (no config)
- add a RobotState Display
- disable the display
- save the Rviz config
- close rviz
- relaunch rviz with same config

You will see the base of your robot incorrectly displayed with all appendages missing. What should happen is you should see no robot at all, because the display is disabled. Simple fix.
