### PR TITLE
Allow planning groups to have more than one tip, with addition.

### DIFF
--- a/planning/kinematics_plugin_loader/include/moveit/kinematics_plugin_loader/kinematics_plugin_loader.h
+++ b/planning/kinematics_plugin_loader/include/moveit/kinematics_plugin_loader/kinematics_plugin_loader.h
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Ioan Sucan */
+/* Author: Ioan Sucan, Dave Coleman */
 
 #ifndef MOVEIT_KINEMATICS_PLUGIN_LOADER_
 #define MOVEIT_KINEMATICS_PLUGIN_LOADER_

--- a/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -150,14 +150,14 @@ void robot_model_loader::RobotModelLoader::configure(const Options &opt)
         if (nh.getParam(prefix + "has_acceleration_limits", has_acc_limits))
           jlim[j].has_acceleration_limits = has_acc_limits;
       }
-      jmodel->setVariableBounds(jlim); 
+      jmodel->setVariableBounds(jlim);
     }
   }
 
   if (model_ && opt.load_kinematics_solvers_)
     loadKinematicsSolvers();
 
-  ROS_DEBUG_STREAM("Loaded kinematic model in " << (ros::WallTime::now() - start).toSec() << " seconds");
+  ROS_DEBUG_STREAM_NAMED("robot_model_loader","Loaded kinematic model in " << (ros::WallTime::now() - start).toSec() << " seconds");
 }
 
 void robot_model_loader::RobotModelLoader::loadKinematicsSolvers(const kinematics_plugin_loader::KinematicsPluginLoaderPtr &kloader)
@@ -181,11 +181,14 @@ void robot_model_loader::RobotModelLoader::loadKinematicsSolvers(const kinematic
     std::map<std::string, robot_model::SolverAllocatorFn> imap;
     for (std::size_t i = 0 ; i < groups.size() ; ++i)
     {
+      // Check if a group in kinematics.yaml exists in the srdf
       if (!model_->hasJointModelGroup(groups[i]))
         continue;
+
       const robot_model::JointModelGroup *jmg = model_->getJointModelGroup(groups[i]);
-      if (jmg->isChain())
-        imap[groups[i]] = kinematics_allocator;
+
+      // Any planning group can have an IK solver, not just chains
+      imap[groups[i]] = kinematics_allocator;
     }
     model_->setKinematicsAllocators(imap);
 

--- a/robot_interaction/src/robot_interaction.cpp
+++ b/robot_interaction/src/robot_interaction.cpp
@@ -286,7 +286,6 @@ void RobotInteraction::decideActiveEndEffectors(const std::string &group, Intera
           ee.eef_group = eef[i].component_group_;
           ee.interaction = style;
           active_eef_.push_back(ee);
-          break;
         }
     }
   }
@@ -317,7 +316,7 @@ void RobotInteraction::decideActiveEndEffectors(const std::string &group, Intera
 
   for (std::size_t i = 0 ; i < active_eef_.size() ; ++i)
   {
-    // if we have a separate group for the eef, we compte the scale based on
+    // if we have a separate group for the eef, we compute the scale based on
     // it; otherwise, we use a default scale
     active_eef_[i].size = active_eef_[i].eef_group == active_eef_[i].parent_group ?
                             computeGroupMarkerSize("") :


### PR DESCRIPTION
This is a copy of #431 with an additional commit.  Previously #431 did not actually call the new KinematicsBase::supportsGroup() function.  This just adds that call and some associated error messaging.
