### PR TITLE
Added field next to planning_time for planning_attempts

### DIFF
--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -1438,6 +1438,9 @@ void MotionPlanningDisplay::load(const rviz::Config& config)
     float d;
     if (config.mapGetFloat("MoveIt_Planning_Time", &d))
       frame_->ui_->planning_time->setValue(d);
+    int attempts;
+    if (config.mapGetInt("MoveIt_Planning_Attempts", &attempts))
+      frame_->ui_->planning_attempts->setValue(attempts);
     if (config.mapGetFloat("MoveIt_Goal_Tolerance", &d))
       frame_->ui_->goal_tolerance->setValue(d);
     bool b;
@@ -1454,6 +1457,7 @@ void MotionPlanningDisplay::save(rviz::Config config) const
     config.mapSetValue("MoveIt_Warehouse_Host", frame_->ui_->database_host->text());
     config.mapSetValue("MoveIt_Warehouse_Port", frame_->ui_->database_port->value());
     config.mapSetValue("MoveIt_Planning_Time", frame_->ui_->planning_time->value());
+    config.mapSetValue("MoveIt_Planning_Attempts", frame_->ui_->planning_attempts->value());
     config.mapSetValue("MoveIt_Goal_Tolerance", frame_->ui_->goal_tolerance->value());
     config.mapSetValue("MoveIt_Use_Constraint_Aware_IK", frame_->ui_->collision_aware_ik->isChecked());
   }

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -119,8 +119,7 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay *pdisplay, rviz::
 
   connect( ui_->tabWidget, SIGNAL( currentChanged ( int ) ), this, SLOT( tabChanged( int ) ));
 
-  QShortcut *copy_object_shortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_C), ui_->collision_objects_list);
-  connect(copy_object_shortcut, SIGNAL( activated() ), this, SLOT( copySelectedCollisionObject() ) );
+  QShortcut *copy_object_shortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_C), ui_->collision_objects_list);  connect(copy_object_shortcut, SIGNAL( activated() ), this, SLOT( copySelectedCollisionObject() ) );
 
   ui_->reset_db_button->hide();
   ui_->background_job_progress->hide();

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -264,7 +264,7 @@ void MotionPlanningFrame::populateConstraintsList(const std::vector<std::string>
 void MotionPlanningFrame::constructPlanningRequest(moveit_msgs::MotionPlanRequest &mreq)
 {
   mreq.group_name = planning_display_->getCurrentPlanningGroup();
-  mreq.num_planning_attempts = 1;
+  mreq.num_planning_attempts = ui_->planning_attempts->value();
   mreq.allowed_planning_time = ui_->planning_time->value();
   robot_state::robotStateToRobotStateMsg(*planning_display_->getQueryStartState(), mreq.start_state);
   mreq.workspace_parameters.min_corner.x = ui_->wcenter_x->value() - ui_->wsize_x->value() / 2.0;
@@ -325,6 +325,7 @@ void MotionPlanningFrame::configureForPlanning()
   move_group_->setStartState(*planning_display_->getQueryStartState());
   move_group_->setJointValueTarget(*planning_display_->getQueryGoalState());
   move_group_->setPlanningTime(ui_->planning_time->value());
+  move_group_->setNumPlanningAttempts(ui_->planning_attempts->value());
   configureWorkspace();
 }
 

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
@@ -201,6 +201,7 @@ void MotionPlanningFrame::setAsGoalStateButtonClicked()
   }
 }
 
+
 void MotionPlanningFrame::removeStateButtonClicked()
 {
   if (robot_state_storage_)

--- a/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -589,6 +589,29 @@
               </property>
              </widget>
             </item>
+            <item>
+             <widget class="QLabel" name="label_10">
+              <property name="text">
+               <string>Planning Attempts:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="planning_attempts">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximum">
+               <number>1000</number>
+              </property>
+              <property name="value">
+               <number>10</number>
+              </property>
+             </widget>
+            </item>
            </layout>
           </item>
           <item>

--- a/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -589,6 +589,10 @@
               </property>
              </widget>
             </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
             <item>
              <widget class="QLabel" name="label_10">
               <property name="text">
@@ -609,7 +613,7 @@
               </property>
               <property name="value">
                <number>10</number>
-              </property>
+               </property>
              </widget>
             </item>
            </layout>


### PR DESCRIPTION
New field is tied to move_group::setNumPlanningAttempts().
Now, ParallelPlanner terminates either due to timeout, or due to this many attempts.
Note, that ParallelPlanner run's Dijkstra's on all the nodes of all the successful plans (hybridize==true).
