### PR TITLE
benchmarks: add missing include.

### DIFF
--- a/benchmarks/benchmarks/src/benchmark_execution.cpp
+++ b/benchmarks/benchmarks/src/benchmark_execution.cpp
@@ -49,6 +49,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/math/constants/constants.hpp>
 #include <boost/progress.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <eigen_conversions/eigen_msg.h>
 #include <Eigen/Core>


### PR DESCRIPTION
Fix a bug reported on Arch Linux: https://aur.archlinux.org/packages/ros-hydro-moveit-ros-benchmarks/
