### PR TITLE
Changed rviz plugin action server wait to non-simulated time

### DIFF
--- a/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -299,6 +299,7 @@ void MotionPlanningFrame::waitForAction(const T &action, const ros::NodeHandle &
   // wait for the server (and spin as needed)                                                           
   if (wait_for_server == ros::Duration(0, 0))
   {
+    // wait forever until action server connects
     while (node_handle.ok() && !action->isServerConnected())
     {
       ros::WallDuration(0.02).sleep();
@@ -307,8 +308,9 @@ void MotionPlanningFrame::waitForAction(const T &action, const ros::NodeHandle &
   }
   else
   {
-    ros::Time final_time = ros::Time::now() + wait_for_server;
-    while (node_handle.ok() && !action->isServerConnected() && final_time > ros::Time::now())
+    // wait for a limited amount of non-simulated time
+    ros::WallTime final_time = ros::WallTime::now() + ros::WallDuration(wait_for_server.toSec());
+    while (node_handle.ok() && !action->isServerConnected() && final_time > ros::WallTime::now())
     {
       ros::WallDuration(0.02).sleep();
       ros::spinOnce();


### PR DESCRIPTION
When using MoveIt! with slowed down simulated time (for me, using `rosbag play -r 0.1`), the MoveIt Rviz Plugin takes a very long time to load because it waits for the action servers to connect in simulated time. This PR changes the `wait_for_server` time to `WallTime`, which is the actual system/cpu time. Does not change functionality for non-simulated systems, and it simply allows the GUI to load in real time for simulated systems.
