### PR TITLE
Removed PlanningContext clear before planning call

### DIFF
--- a/benchmarks/benchmarks/src/benchmark_execution.cpp
+++ b/benchmarks/benchmarks/src/benchmark_execution.cpp
@@ -1079,7 +1079,6 @@ void moveit_benchmarks::BenchmarkExecution::runPlanningBenchmark(BenchmarkReques
 
           // run a single benchmark
           ROS_DEBUG("Calling %s:%s", planner_interfaces_to_benchmark[i]->getDescription().c_str(), motion_plan_req.planner_id.c_str());
-          pcontext->clear();
           planning_interface::MotionPlanDetailedResponse mp_res;
           ros::WallTime start = ros::WallTime::now();
           bool solved = pcontext->solve(mp_res);


### PR DESCRIPTION
Originally, before each benchmark was tested, PlanningContext was cleared prior to calling solve.

Deleting the line lets the test continue as normal and produce results.

Credit for the fix: https://groups.google.com/d/msg/moveit-users/DjI9yE_BoHU/oa9IvVrUTmoJ
