### PR TITLE
motion_planning_rviz_plugin: add move_group namespace option

### DIFF
--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -249,10 +249,11 @@ void MotionPlanningFrame::changePlanningGroupHelper()
   {
     if (move_group_ && move_group_->getName() == group)
       return;
-    ROS_INFO("Constructing new MoveGroup connection for group '%s'", group.c_str());
+    ROS_INFO("Constructing new MoveGroup connection for group '%s' in namespace '%s'", group.c_str(), planning_display_->getMoveGroupNS().c_str());
     moveit::planning_interface::MoveGroup::Options opt(group);
     opt.robot_model_ = kmodel;
-    opt.robot_description_.clear();
+    opt.robot_description_.clear(); 
+    opt.node_handle_ = ros::NodeHandle(planning_display_->getMoveGroupNS());
     try
     {
       move_group_.reset(new moveit::planning_interface::MoveGroup(opt, context_->getFrameManager()->getTFClientPtr(), ros::Duration(30, 0)));

--- a/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -98,6 +98,7 @@ public:
   // remove all queued jobs
   void clearJobs();
 
+  const std::string getMoveGroupNS() const;
   const robot_model::RobotModelConstPtr& getRobotModel() const;
   planning_scene_monitor::LockedPlanningSceneRO getPlanningSceneRO() const;
   planning_scene_monitor::LockedPlanningSceneRW getPlanningSceneRW();
@@ -108,6 +109,7 @@ private Q_SLOTS:
   // ******************************************************************************************
   // Slot Event Functions
   // ******************************************************************************************
+  void changedMoveGroupNS();
   void changedRobotDescription();
   void changedSceneName();
   void changedSceneEnabled();
@@ -184,6 +186,7 @@ protected:
   rviz::Property* scene_category_;
   rviz::Property* robot_category_;
 
+  rviz::StringProperty* move_group_ns_property_;
   rviz::StringProperty* robot_description_property_;
   rviz::StringProperty* scene_name_property_;
   rviz::BoolProperty* scene_enabled_property_;

--- a/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -69,6 +69,10 @@ PlanningSceneDisplay::PlanningSceneDisplay(bool listen_to_planning_scene, bool s
   planning_scene_needs_render_(true),
   current_scene_time_(0.0f)
 {
+  move_group_ns_property_ =
+    new rviz::StringProperty( "Move Group Namespace", "", "The name of the ROS namespace in which the move_group node is running",
+                              this,
+                              SLOT( changedMoveGroupNS() ), this );
   robot_description_property_ =
     new rviz::StringProperty( "Robot Description", "robot_description", "The name of the ROS parameter where the URDF for the robot is loaded",
                               this,
@@ -270,6 +274,11 @@ const planning_scene_monitor::PlanningSceneMonitorPtr& PlanningSceneDisplay::get
   return planning_scene_monitor_;
 }
 
+const std::string PlanningSceneDisplay::getMoveGroupNS() const
+{
+  return move_group_ns_property_->getStdString();
+}
+
 const robot_model::RobotModelConstPtr& PlanningSceneDisplay::getRobotModel() const
 {
   if (planning_scene_monitor_)
@@ -299,6 +308,12 @@ void PlanningSceneDisplay::changedAttachedBodyColor()
 void PlanningSceneDisplay::changedSceneColor()
 {
   queueRenderSceneGeometry();
+}
+
+void PlanningSceneDisplay::changedMoveGroupNS()
+{
+  if (isEnabled())
+    reset();
 }
 
 void PlanningSceneDisplay::changedRobotDescription()
@@ -361,7 +376,8 @@ void PlanningSceneDisplay::changedPlanningSceneTopic()
   if (planning_scene_monitor_ && planning_scene_topic_property_)
   {
     planning_scene_monitor_->startSceneMonitor(planning_scene_topic_property_->getStdString());
-    planning_scene_monitor_->requestPlanningSceneState();
+    planning_scene_monitor_->requestPlanningSceneState(
+        ros::names::append(getMoveGroupNS(),planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_SERVICE));
   }
 }
 


### PR DESCRIPTION
This allows multiple motion_planning_rviz_plugin / planning_scene_rviz_plugin to be used in RViz and connect to differently-namespaced move_group nodes.
