### PR TITLE
Allow planning context to be saved in planning pipeline

### DIFF
--- a/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
+++ b/planning/planning_pipeline/include/moveit/planning_pipeline/planning_pipeline.h
@@ -128,11 +128,14 @@ public:
       \param planning_scene The planning scene where motion planning is to be done
       \param req The request for motion planning
       \param res The motion planning response
-      \param adapter_added_state_index Sometimes planning request adapters may add states on the solution path (e.g., add the current state of the robot as prefix, when the robot started to plan only from near that state, as the current state itself appears to touch obstacles). This is helpful because the added states should not be considered invalid in all situations. */
+      \param adapter_added_state_index Sometimes planning request adapters may add states on the solution path (e.g., add the current state of the robot as prefix, when the robot started to plan only from near that state, as the current state itself appears to touch obstacles). This is helpful because the added states should not be considered invalid in all situations. 
+      \param context The planning context that this function loads for you - allows a handle to be passed back so offline processing can be done to the planner after solving is complete
+  */
   bool generatePlan(const planning_scene::PlanningSceneConstPtr& planning_scene,
                     const planning_interface::MotionPlanRequest& req,
                     planning_interface::MotionPlanResponse& res,
-                    std::vector<std::size_t> &adapter_added_state_index) const;
+                    std::vector<std::size_t> &adapter_added_state_index,
+                    planning_interface::PlanningContextPtr &context) const;
 
   /** \brief Request termination, if a generatePlan() function is currently computing plans */
   void terminate() const;

--- a/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -202,13 +202,15 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
                                                        planning_interface::MotionPlanResponse& res) const
 {
   std::vector<std::size_t> dummy;
-  return generatePlan(planning_scene, req, res, dummy);
+  planning_interface::PlanningContextPtr context;
+  return generatePlan(planning_scene, req, res, dummy, context);
 }
 
 bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::PlanningSceneConstPtr& planning_scene,
                                                        const planning_interface::MotionPlanRequest& req,
                                                        planning_interface::MotionPlanResponse& res,
-                                                       std::vector<std::size_t> &adapter_added_state_index) const
+                                                       std::vector<std::size_t> &adapter_added_state_index,
+                                                       planning_interface::PlanningContextPtr &context) const
 {
   // broadcast the request we are about to work on, if needed
   if (publish_received_requests_)
@@ -226,7 +228,8 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
   {
     if (adapter_chain_)
     {
-      solved = adapter_chain_->adaptAndPlan(planner_instance_, planning_scene, req, res, adapter_added_state_index);
+      solved = adapter_chain_->adaptAndPlan(planner_instance_, planning_scene, req, res, adapter_added_state_index, context);
+
       if (!adapter_added_state_index.empty())
       {
         std::stringstream ss;
@@ -237,7 +240,7 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
     }
     else
     {
-      planning_interface::PlanningContextPtr context = planner_instance_->getPlanningContext(planning_scene, req, res.error_code_);
+      context = planner_instance_->getPlanningContext(planning_scene, req, res.error_code_);
       solved = context ? context->solve(res) : false;
     }
   }

--- a/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
+++ b/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
@@ -151,7 +151,8 @@ public:
                             const planning_scene::PlanningSceneConstPtr& planning_scene,
                             const planning_interface::MotionPlanRequest &req,
                             planning_interface::MotionPlanResponse &res,
-                            std::vector<std::size_t> &added_path_index) const
+                            std::vector<std::size_t> &added_path_index,
+                            planning_interface::PlanningContextPtr &context) const
   {
     bool result = planner(planning_scene, req, res);
     if (result && res.trajectory_)

--- a/planning/planning_request_adapter_plugins/src/empty.cpp
+++ b/planning/planning_request_adapter_plugins/src/empty.cpp
@@ -49,7 +49,8 @@ public:
                             const planning_scene::PlanningSceneConstPtr& planning_scene,
                             const planning_interface::MotionPlanRequest &req,
                             planning_interface::MotionPlanResponse &res,
-                            std::vector<std::size_t> &added_path_index) const
+                            std::vector<std::size_t> &added_path_index,
+                            planning_interface::PlanningContextPtr &context) const
   {
     return planner(planning_scene, req, res);
   }

--- a/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
+++ b/planning/planning_request_adapter_plugins/src/fix_start_state_bounds.cpp
@@ -77,7 +77,8 @@ public:
                             const planning_scene::PlanningSceneConstPtr& planning_scene,
                             const planning_interface::MotionPlanRequest &req,
                             planning_interface::MotionPlanResponse &res,
-                            std::vector<std::size_t> &added_path_index) const
+                            std::vector<std::size_t> &added_path_index,
+                            planning_interface::PlanningContextPtr &context) const
   {
     ROS_DEBUG("Running '%s'", getDescription().c_str());
 

--- a/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
+++ b/planning/planning_request_adapter_plugins/src/fix_start_state_collision.cpp
@@ -92,7 +92,8 @@ public:
                             const planning_scene::PlanningSceneConstPtr& planning_scene,
                             const planning_interface::MotionPlanRequest &req,
                             planning_interface::MotionPlanResponse &res,
-                            std::vector<std::size_t> &added_path_index) const
+                            std::vector<std::size_t> &added_path_index,
+                            planning_interface::PlanningContextPtr &context) const
   {
     ROS_DEBUG("Running '%s'", getDescription().c_str());
 

--- a/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
+++ b/planning/planning_request_adapter_plugins/src/fix_start_state_path_constraints.cpp
@@ -59,7 +59,8 @@ public:
                             const planning_scene::PlanningSceneConstPtr& planning_scene,
                             const planning_interface::MotionPlanRequest &req,
                             planning_interface::MotionPlanResponse &res,
-                            std::vector<std::size_t> &added_path_index) const
+                            std::vector<std::size_t> &added_path_index,
+                            planning_interface::PlanningContextPtr &context) const
   {
     ROS_DEBUG("Running '%s'", getDescription().c_str());
 

--- a/planning/planning_request_adapter_plugins/src/fix_workspace_bounds.cpp
+++ b/planning/planning_request_adapter_plugins/src/fix_workspace_bounds.cpp
@@ -65,7 +65,8 @@ public:
                             const planning_scene::PlanningSceneConstPtr& planning_scene,
                             const planning_interface::MotionPlanRequest &req,
                             planning_interface::MotionPlanResponse &res,
-                            std::vector<std::size_t> &added_path_index) const
+                            std::vector<std::size_t> &added_path_index,
+                            planning_interface::PlanningContextPtr &context) const
   {
     ROS_DEBUG("Running '%s'", getDescription().c_str());
     const moveit_msgs::WorkspaceParameters &wparams = req.workspace_parameters;


### PR DESCRIPTION
Modifies the planning pipeline's `generatePlan()` function to accept an optional planning context parameter by reference so that the user can get a pointer to the used planning context.

Also modifies all the `planning_request_adapter_plugins` to accept the new `context` parameter as changed in https://github.com/ros-planning/moveit_core/pull/182/files
