### PR TITLE
Loading octomap_monitor optional in planning_scene_monitor WorldGeometryMonitor

### DIFF
--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -305,9 +305,12 @@ public:
 
   /** @brief Start listening for objects in the world, the collision map and attached collision objects. Additionally, this function starts the OccupancyMapMonitor as well.
    *  @param collision_objects_topic The topic on which to listen for collision objects
-   *  @param planning_scene_world_topic The topic to listen to for world scene geometry */
+   *  @param planning_scene_world_topic The topic to listen to for world scene geometry
+   *  @param load_octomap_monitor Flag to disable octomap monitor if desired
+   */
   void startWorldGeometryMonitor(const std::string &collision_objects_topic = DEFAULT_COLLISION_OBJECT_TOPIC,
-                                 const std::string &planning_scene_world_topic = DEFAULT_PLANNING_SCENE_WORLD_TOPIC);
+                                 const std::string &planning_scene_world_topic = DEFAULT_PLANNING_SCENE_WORLD_TOPIC,
+                                 const bool load_octomap_monitor = true);
 
   /** @brief Stop the world geometry monitor */
   void stopWorldGeometryMonitor();


### PR DESCRIPTION
I'm not using the Octomap mointor or tf, but I always get warnings about these components not working properly. This change provides a bool that defaults to true (enabled) that allows the octomap_monitor not to be loaded. Throughout the planning_scene_monitor there were already a lot of checks to see if the octomap_monitor was already loaded, but I added a few missing ones to be safe.
