### PR TITLE
Add python wrapper for new robot_model function getEndEffector tips

### DIFF
--- a/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
+++ b/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
@@ -237,6 +237,7 @@ static void wrap_robot_interface()
 
   RobotClass.def("get_joint_names", &RobotInterfacePython::getJointNames);
   RobotClass.def("get_group_joint_names", &RobotInterfacePython::getGroupJointNames);
+  RobotClass.def("get_group_joint_tips", &RobotInterfacePython::getGroupJointTips);
   RobotClass.def("get_group_names", &RobotInterfacePython::getGroupNames);
   RobotClass.def("get_link_names", &RobotInterfacePython::getLinkNames);
   RobotClass.def("get_group_link_names", &RobotInterfacePython::getGroupLinkNames);

--- a/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
+++ b/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
@@ -74,6 +74,19 @@ public:
       return bp::list();
   }
 
+  bp::list getGroupJointTips(const std::string &group) const
+  {
+    const robot_model::JointModelGroup *jmg = robot_model_->getJointModelGroup(group);
+    if (jmg)
+    {
+      std::vector<std::string> tips;
+      jmg->getEndEffectorTips(tips);
+      return py_bindings_tools::listFromString(tips);
+    }
+    else
+      return bp::list();
+  }
+
   bp::list getLinkNames() const
   {
     return py_bindings_tools::listFromString(robot_model_->getLinkModelNames());


### PR DESCRIPTION
For use with new [joystick control functionality](https://github.com/ros-planning/moveit_ros/pull/471) in MoveIt!

Requires https://github.com/ros-planning/moveit_core/pull/196 be merged first

@garaemon
