### PR TITLE
Fixed issue with unordered_map and libc++ (LLVM, Mac OS X Mavericks)

### DIFF
--- a/perception/depth_image_octomap_updater/include/moveit/depth_image_octomap_updater/lazy_free_space_updater.h
+++ b/perception/depth_image_octomap_updater/include/moveit/depth_image_octomap_updater/lazy_free_space_updater.h
@@ -55,7 +55,11 @@ public:
 
 private:
 
+#ifdef __APPLE__
+  typedef std::unordered_map<octomap::OcTreeKey, unsigned int, octomap::OcTreeKey::KeyHash> OcTreeKeyCountMap;
+#else
   typedef std::tr1::unordered_map<octomap::OcTreeKey, unsigned int, octomap::OcTreeKey::KeyHash> OcTreeKeyCountMap;
+#endif
 
   void pushBatchToProcess(OcTreeKeyCountMap *occupied_cells, octomap::KeySet *model_cells, const octomap::point3d &sensor_origin);
 


### PR DESCRIPTION
libc++ doesn't have std::tr1::unordered_map, just std::unordered_map
