### PR TITLE
Fix spurious warning ("execution should start at current state")

### DIFF
--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -823,6 +823,7 @@ public:
     goal.request.allowed_planning_time = planning_time_;
     goal.request.planner_id = planner_id_;
     goal.request.workspace_parameters = workspace_parameters_;
+    goal.request.start_state.is_diff = true;
 
     if (considered_start_state_)
       robot_state::robotStateToRobotStateMsg(*considered_start_state_, goal.request.start_state);


### PR DESCRIPTION
Whenever `group.move()` is called, the following spurious warning was always
printed:

   Execution of motions should always start at the robot's current state.
Ignoring the state supplied as start state in the motion planning request

This is what happened:
- `group.move()` is called
- in `MoveGroupImpl::constructGoal()`:
  - when `considered_start_state_` is empty, `goal.request.start_state.is_diff`
    remains `false`
- in `MoveGroupMoveAction::executeMoveCallback_PlanAndExecute()`:
  - `planning_scene::PlanningScene::isEmpty(request.start_state) == false`

This led to the warning being printed.
