### PR TITLE
Fixing segfault if filtered_cloud_topic is not set in PointCloudOctomapUpdater

### DIFF
--- a/perception/CMakeLists.txt
+++ b/perception/CMakeLists.txt
@@ -28,6 +28,7 @@ find_package(catkin REQUIRED COMPONENTS
   image_transport
   object_recognition_msgs
   cmake_modules
+  sensor_msgs
 )
 find_package(Eigen REQUIRED)
 
@@ -53,22 +54,22 @@ catkin_package(
   CATKIN_DEPENDS
     moveit_core
     image_transport)
-  
+
 include_directories(mesh_filter/include
                     depth_image_octomap_updater/include
-		    point_containment_filter/include
+                    point_containment_filter/include
                     occupancy_map_monitor/include
-		    pointcloud_octomap_updater/include
-		    semantic_world/include
+                    pointcloud_octomap_updater/include
+                    semantic_world/include
                     ${catkin_INCLUDE_DIRS}
                     )
 include_directories(SYSTEM
-		    ${OpenCV_INCLUDE_DIRS}
+                    ${OpenCV_INCLUDE_DIRS}
                     ${EIGEN_INCLUDE_DIRS}
                     ${Boost_INCLUDE_DIRS}
-		    ${GLEW_INCLUDE_DIR}
-		    ${GLUT_INCLUDE_DIR}
-		    )
+                    ${GLEW_INCLUDE_DIR}
+                    ${GLUT_INCLUDE_DIR}
+                    )
 
 link_directories(${Boost_LIBRARY_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})

--- a/perception/depth_image_octomap_updater/CMakeLists.txt
+++ b/perception/depth_image_octomap_updater/CMakeLists.txt
@@ -9,9 +9,10 @@ set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES COMPILE_FLAGS "${CMAKE_
 set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
 target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_mesh_filter ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
+add_dependencies(${MOVEIT_LIB_NAME}_core sensor_msgs_generate_cpp)
+
 add_library(${MOVEIT_LIB_NAME} src/updater_plugin.cpp)
 target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})
-  
+
 install(TARGETS ${MOVEIT_LIB_NAME}_core ${MOVEIT_LIB_NAME} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 install(DIRECTORY include/ DESTINATION include)
- 

--- a/perception/package.xml
+++ b/perception/package.xml
@@ -31,6 +31,7 @@
   <build_depend>opengl</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>cmake_modules</build_depend>
+  <build_depend>sensor_msgs</build_depend>
 
   <run_depend>moveit_core</run_depend>
   <run_depend>roscpp</run_depend>
@@ -46,6 +47,7 @@
   <run_depend>libglew-dev</run_depend>
   <run_depend>opengl</run_depend>
   <run_depend>cv_bridge</run_depend>
+  <run_depend>sensor_msgs</run_depend>
 
   <export>
     <moveit_ros_perception plugin="${prefix}/pointcloud_octomap_updater_plugin_description.xml"/>


### PR DESCRIPTION
Iterators were created into a PointCloud2 message which was only created if filtered_cloud_topic was set. Furthermore, the incoming data was never used during the update - the octomap update iterated over the output PointCloud2, as opposed to the input PointCloud 2. On my setup (Trusty/Indigo), PointCloudOctomapUpdater would crash immediately unless I defined filtered_cloud_topic, and I would never see any output data. I believe this pull request fixes this issue.
