### PR TITLE
Use custom robot collision padding in occupancy map shape padding

### DIFF
--- a/perception/depth_image_octomap_updater/include/moveit/depth_image_octomap_updater/depth_image_octomap_updater.h
+++ b/perception/depth_image_octomap_updater/include/moveit/depth_image_octomap_updater/depth_image_octomap_updater.h
@@ -59,7 +59,7 @@ public:
   virtual bool initialize();
   virtual void start();
   virtual void stop();
-  virtual ShapeHandle excludeShape(const shapes::ShapeConstPtr &shape);
+  virtual ShapeHandle excludeShape(const shapes::ShapeConstPtr &shape, const double &scale, const double &padding);
   virtual void forgetShape(ShapeHandle handle);
 
 private:

--- a/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
+++ b/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
@@ -144,7 +144,7 @@ void DepthImageOctomapUpdater::stopHelper()
   sub_depth_image_.shutdown();
 }
 
-mesh_filter::MeshHandle DepthImageOctomapUpdater::excludeShape(const shapes::ShapeConstPtr &shape)
+mesh_filter::MeshHandle DepthImageOctomapUpdater::excludeShape(const shapes::ShapeConstPtr &shape, const double &scale, const double &padding)
 {
   mesh_filter::MeshHandle h = 0;
   if (mesh_filter_)

--- a/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
+++ b/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
@@ -102,7 +102,7 @@ public:
   void addUpdater(const OccupancyMapUpdaterPtr &updater);
 
   /** \brief Add this shape to the set of shapes to be filtered out from the octomap */
-  ShapeHandle excludeShape(const shapes::ShapeConstPtr &shape);
+  ShapeHandle excludeShape(const shapes::ShapeConstPtr &shape, const double &scale = 1, const double &padding = 0);
 
   /** \brief Forget about this shape handle and the shapes it corresponds to */
   void forgetShape(ShapeHandle handle);

--- a/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
+++ b/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
@@ -75,7 +75,7 @@ public:
 
   virtual void stop() = 0;
 
-  virtual ShapeHandle excludeShape(const shapes::ShapeConstPtr &shape) = 0;
+  virtual ShapeHandle excludeShape(const shapes::ShapeConstPtr &shape, const double &scale = 1, const double &padding = 0) = 0;
 
   virtual void forgetShape(ShapeHandle handle) = 0;
 

--- a/perception/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/perception/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -205,16 +205,16 @@ void OccupancyMapMonitor::setMapFrame(const std::string &frame)
   map_frame_ = frame;
 }
 
-ShapeHandle OccupancyMapMonitor::excludeShape(const shapes::ShapeConstPtr &shape)
+ShapeHandle OccupancyMapMonitor::excludeShape(const shapes::ShapeConstPtr &shape, const double &scale, const double &padding)
 {
   // if we have just one updater, remove the additional level of indirection
   if (map_updaters_.size() == 1)
-    return map_updaters_[0]->excludeShape(shape);
+    return map_updaters_[0]->excludeShape(shape, scale, padding);
 
   ShapeHandle h = 0;
   for (std::size_t i = 0 ; i < map_updaters_.size() ; ++i)
   {
-    ShapeHandle mh = map_updaters_[i]->excludeShape(shape);
+    ShapeHandle mh = map_updaters_[i]->excludeShape(shape, scale, padding);
     if (mh)
     {
       if (h == 0)

--- a/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
+++ b/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
@@ -79,8 +79,6 @@ private:
 
   /* params */
   std::string point_cloud_topic_;
-  double scale_;
-  double padding_;
   double max_range_;
   unsigned int point_subsample_;
   std::string filtered_cloud_topic_;

--- a/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
+++ b/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
@@ -60,7 +60,7 @@ public:
   virtual bool initialize();
   virtual void start();
   virtual void stop();
-  virtual ShapeHandle excludeShape(const shapes::ShapeConstPtr &shape);
+  virtual ShapeHandle excludeShape(const shapes::ShapeConstPtr &shape, const double &scale, const double &padding);
   virtual void forgetShape(ShapeHandle handle);
 
 protected:

--- a/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -46,8 +46,6 @@ namespace occupancy_map_monitor
 
 PointCloudOctomapUpdater::PointCloudOctomapUpdater() : OccupancyMapUpdater("PointCloudUpdater"),
                                                        private_nh_("~"),
-                                                       scale_(1.0),
-                                                       padding_(0.0),
                                                        max_range_(std::numeric_limits<double>::infinity()),
                                                        point_subsample_(1),
                                                        point_cloud_subscriber_(NULL),
@@ -69,8 +67,6 @@ bool PointCloudOctomapUpdater::setParams(XmlRpc::XmlRpcValue &params)
     point_cloud_topic_ = static_cast<const std::string&>(params["point_cloud_topic"]);
 
     readXmlParam(params, "max_range", &max_range_);
-    readXmlParam(params, "padding_offset", &padding_);
-    readXmlParam(params, "padding_scale", &scale_);
     readXmlParam(params, "point_subsample", &point_subsample_);
     if (params.hasMember("filtered_cloud_topic"))
       filtered_cloud_topic_ = static_cast<const std::string&>(params["filtered_cloud_topic"]);

--- a/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -126,11 +126,11 @@ void PointCloudOctomapUpdater::stop()
   point_cloud_subscriber_ = NULL;
 }
 
-ShapeHandle PointCloudOctomapUpdater::excludeShape(const shapes::ShapeConstPtr &shape)
+ShapeHandle PointCloudOctomapUpdater::excludeShape(const shapes::ShapeConstPtr &shape, const double &scale, const double &padding)
 {
   ShapeHandle h = 0;
   if (shape_mask_)
-    h = shape_mask_->addShape(shape, scale_, padding_);
+    h = shape_mask_->addShape(shape, scale, padding);
   else
     ROS_ERROR("Shape filter not yet initialized!");
   return h;

--- a/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -595,7 +595,6 @@ void planning_scene_monitor::PlanningSceneMonitor::excludeRobotLinksFromOctree()
   {
     const double &link_padding = getPlanningScene()->getCollisionRobot()->getLinkPadding(links[i]->getName());
     const double &link_scale = getPlanningScene()->getCollisionRobot()->getLinkScale(links[i]->getName());    
-    std::cout << "link " << links[i]->getName() << " has padding " << link_padding << " and scale " << link_scale << std::endl;
 
     std::vector<shapes::ShapeConstPtr> shapes = links[i]->getShapes(); // copy shared ptrs on purpuse
     for (std::size_t j = 0 ; j < shapes.size() ; ++j)


### PR DESCRIPTION
Currently you can only use one padding and scale value for all robot self-filtering. I have an application where the fingers and end effector should have no padding or scaling, but I'd like the rest of the robot to still have padding.

This change uses the same variable collision padding as set in the planning scene monitor for the perception pipeline. Does not change API because the new function parameters have default values.

This does break user's current `sensors_rgbd.yaml` files in that it will not longer use padding from there, but instead from `paddings.yaml` file.

I'd also be happy to create default configuration files for the Setup Assistant for these changes.
