### PR TITLE
Publish organized pointcloud as self-filtered pointcloud.

### DIFF
--- a/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
+++ b/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
@@ -107,7 +107,7 @@ protected:
 
   static void readXmlParam(XmlRpc::XmlRpcValue &params, const std::string &param_name, double *value);
   static void readXmlParam(XmlRpc::XmlRpcValue &params, const std::string &param_name, unsigned int *value);
-
+  static void readXmlParam(XmlRpc::XmlRpcValue &params, const std::string &param_name, bool *value);
 };
 
 typedef boost::shared_ptr<OccupancyMapUpdater> OccupancyMapUpdaterPtr;

--- a/perception/occupancy_map_monitor/src/occupancy_map_updater.cpp
+++ b/perception/occupancy_map_monitor/src/occupancy_map_updater.cpp
@@ -71,6 +71,13 @@ void OccupancyMapUpdater::readXmlParam(XmlRpc::XmlRpcValue &params, const std::s
     *value = (int) params[param_name];
 }
 
+void OccupancyMapUpdater::readXmlParam(XmlRpc::XmlRpcValue &params, const std::string &param_name, bool *value)
+{
+  if (params.hasMember(param_name))
+    *value = (bool) params[param_name];
+}
+
+
 bool OccupancyMapUpdater::updateTransformCache(const std::string &target_frame, const ros::Time &target_time)
 {
   transform_cache_.clear();

--- a/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
+++ b/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
@@ -87,6 +87,7 @@ private:
   unsigned int point_subsample_;
   std::string filtered_cloud_topic_;
   ros::Publisher filtered_cloud_publisher_;
+  bool filtered_cloud_keep_organized_;
 
   message_filters::Subscriber<sensor_msgs::PointCloud2> *point_cloud_subscriber_;
   tf::MessageFilter<sensor_msgs::PointCloud2> *point_cloud_filter_;


### PR DESCRIPTION
Add filtered_cloud_keep_organized parameter to OctomapUpdater to publish organized and self filtered pointcloud.
1. Add readXmlParam for boolean value
2. Fill the filtered point with nan to keep organized
