### PR TITLE
add dependency on std_srvs (part of octomap clearing service)

### DIFF
--- a/move_group/CMakeLists.txt
+++ b/move_group/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
   actionlib
   roscpp
   pluginlib
+  std_srvs
   tf
 )
 

--- a/move_group/package.xml
+++ b/move_group/package.xml
@@ -21,12 +21,14 @@
   <build_depend>actionlib</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>pluginlib</build_depend>
+  <build_depend>std_srvs</build_depend>
 
   <run_depend>moveit_core</run_depend>
   <run_depend>moveit_ros_planning</run_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>pluginlib</run_depend>
+  <run_depend>std_srvs</run_depend>
 
   <export>
     <moveit_ros_move_group plugin="${prefix}/default_capabilities_plugin_description.xml"/>


### PR DESCRIPTION
This is intended to fix the build of move_group http://jenkins.ros.org/job/ros-indigo-moveit-ros-move-group_binarydeb_saucy_amd64/67/console
