### PR TITLE
Filter Point Cloud without Occupancy Map

### DIFF
--- a/perception/CMakeLists.txt
+++ b/perception/CMakeLists.txt
@@ -43,12 +43,15 @@ catkin_package(
     point_containment_filter/include
     occupancy_map_monitor/include
     pointcloud_octomap_updater/include
+    pointcloud_filter/include
     semantic_world/include
     ${OCTOMAP_INCLUDE_DIRS}
   LIBRARIES
     moveit_point_containment_filter
     moveit_occupancy_map_monitor
     moveit_pointcloud_octomap_updater_core
+    moveit_depth_image_octomap_updater_core
+    moveit_pointcloud_filter_core
     moveit_semantic_world
     ${OCTOMAP_LIBRARIES}
   CATKIN_DEPENDS
@@ -60,6 +63,7 @@ include_directories(mesh_filter/include
                     point_containment_filter/include
                     occupancy_map_monitor/include
                     pointcloud_octomap_updater/include
+                    pointcloud_filter/include
                     semantic_world/include
                     ${catkin_INCLUDE_DIRS}
                     )
@@ -77,6 +81,7 @@ link_directories(${catkin_LIBRARY_DIRS})
 add_subdirectory(point_containment_filter)
 add_subdirectory(occupancy_map_monitor)
 add_subdirectory(pointcloud_octomap_updater)
+add_subdirectory(pointcloud_filter)
 add_subdirectory(mesh_filter)
 add_subdirectory(depth_image_octomap_updater)
 
@@ -85,6 +90,7 @@ add_subdirectory(semantic_world)
 install(
   FILES
     pointcloud_octomap_updater_plugin_description.xml
+    pointcloud_filter_plugin_description.xml
     depth_image_octomap_updater_plugin_description.xml
   DESTINATION
     ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/perception/package.xml
+++ b/perception/package.xml
@@ -51,6 +51,7 @@
 
   <export>
     <moveit_ros_perception plugin="${prefix}/pointcloud_octomap_updater_plugin_description.xml"/>
+    <moveit_ros_perception plugin="${prefix}/pointcloud_filter_plugin_description.xml"/>
     <moveit_ros_perception plugin="${prefix}/depth_image_octomap_updater_plugin_description.xml"/>
   </export>
 

--- a/perception/pointcloud_filter/CMakeLists.txt
+++ b/perception/pointcloud_filter/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(MOVEIT_LIB_NAME moveit_pointcloud_filter)
+
+add_library(${MOVEIT_LIB_NAME}_core src/pointcloud_filter.cpp)
+target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_point_containment_filter moveit_occupancy_map_monitor ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+set_target_properties(${MOVEIT_LIB_NAME}_core PROPERTIES LINK_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+
+add_library(${MOVEIT_LIB_NAME} src/plugin_init.cpp)
+target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+install(DIRECTORY include/ DESTINATION include)
+
+install(TARGETS ${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})

--- a/perception/pointcloud_filter/include/moveit/pointcloud_filter/pointcloud_filter.h
+++ b/perception/pointcloud_filter/include/moveit/pointcloud_filter/pointcloud_filter.h
@@ -1,0 +1,99 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, University of Colorado, Boulder
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Univ of CO, Boulder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Dave Coleman
+   Desc:   Does not actually update the octomap, only filters point clouds
+*/
+
+#ifndef MOVEIT_PERCEPTION_POINTCLOUD_FILTER_
+#define MOVEIT_PERCEPTION_POINTCLOUD_FILTER_
+
+#include <ros/ros.h>
+#include <tf/tf.h>
+#include <tf/message_filter.h>
+#include <message_filters/subscriber.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <moveit/occupancy_map_monitor/occupancy_map_updater.h>
+#include <moveit/point_containment_filter/shape_mask.h>
+
+namespace occupancy_map_monitor
+{
+
+class PointCloudFilter : public OccupancyMapUpdater
+{
+public:
+
+  PointCloudFilter();
+  virtual ~PointCloudFilter();
+
+  virtual bool setParams(XmlRpc::XmlRpcValue &params);
+
+  virtual bool initialize();
+  virtual void start();
+  virtual void stop();
+  virtual ShapeHandle excludeShape(const shapes::ShapeConstPtr &shape, const double &scale, const double &padding);
+  virtual void forgetShape(ShapeHandle handle);
+
+private:
+
+  bool getShapeTransform(ShapeHandle h, Eigen::Affine3d &transform) const;
+  void cloudMsgCallback(const sensor_msgs::PointCloud2::ConstPtr &cloud_msg);
+  void stopHelper();
+
+  ros::NodeHandle root_nh_;
+  ros::NodeHandle private_nh_;
+  boost::shared_ptr<tf::Transformer> tf_;
+
+  /* params */
+  std::string point_cloud_topic_;
+  double max_range_;
+  unsigned int point_subsample_;
+  std::string filtered_cloud_topic_;
+  ros::Publisher filtered_cloud_publisher_;
+
+  message_filters::Subscriber<sensor_msgs::PointCloud2> *point_cloud_subscriber_;
+  tf::MessageFilter<sensor_msgs::PointCloud2> *point_cloud_filter_;
+
+  /* used to store all cells in the map which a given ray passes through during raycasting.
+     we cache this here because it dynamically pre-allocates a lot of memory in its contsructor */
+  //octomap::KeyRay key_ray_;
+
+  boost::scoped_ptr<point_containment_filter::ShapeMask> shape_mask_;
+  std::vector<int> mask_;
+
+};
+
+}
+
+#endif

--- a/perception/pointcloud_filter/src/plugin_init.cpp
+++ b/perception/pointcloud_filter/src/plugin_init.cpp
@@ -1,0 +1,40 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2008, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Dave Coleman, Ioan Sucan */
+
+#include <class_loader/class_loader.h>
+#include <moveit/pointcloud_filter/pointcloud_filter.h>
+
+CLASS_LOADER_REGISTER_CLASS( occupancy_map_monitor::PointCloudFilter, occupancy_map_monitor::OccupancyMapUpdater )

--- a/perception/pointcloud_filter/src/pointcloud_filter.cpp
+++ b/perception/pointcloud_filter/src/pointcloud_filter.cpp
@@ -216,9 +216,11 @@ void PointCloudFilter::cloudMsgCallback(const sensor_msgs::PointCloud2::ConstPtr
 
   filtered_cloud.reset(new sensor_msgs::PointCloud2());
   filtered_cloud->header = cloud_msg->header;
-  sensor_msgs::PointCloud2Modifier pcd_modifier(*filtered_cloud);
-  pcd_modifier.setPointCloud2FieldsByString(1, "xyz");
-  pcd_modifier.resize(cloud_msg->width * cloud_msg->height);
+  {
+    sensor_msgs::PointCloud2Modifier pcd_modifier(*filtered_cloud);
+    pcd_modifier.setPointCloud2FieldsByString(1, "xyz");
+    pcd_modifier.resize(cloud_msg->width * cloud_msg->height);
+  }
 
   //we have created a filtered_out, so we can create the iterators now
   iter_filtered_x.reset(new sensor_msgs::PointCloud2Iterator<float>(*filtered_cloud, "x"));
@@ -268,10 +270,11 @@ void PointCloudFilter::cloudMsgCallback(const sensor_msgs::PointCloud2::ConstPtr
   }
 
   ROS_DEBUG("Processed point cloud in %lf ms", (ros::WallTime::now() - start).toSec() * 1000.0);
-
-  sensor_msgs::PointCloud2Modifier pcd_modifier(*filtered_cloud);
-  pcd_modifier.resize(filtered_cloud_size);
-  filtered_cloud_publisher_.publish(*filtered_cloud);
+  {
+    sensor_msgs::PointCloud2Modifier pcd_modifier(*filtered_cloud);
+    pcd_modifier.resize(filtered_cloud_size);
+    filtered_cloud_publisher_.publish(*filtered_cloud);
+  }
 }
 
 }

--- a/perception/pointcloud_filter/src/pointcloud_filter.cpp
+++ b/perception/pointcloud_filter/src/pointcloud_filter.cpp
@@ -1,0 +1,277 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, University of Colorado, Boulder
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Univ of CO, Boulder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Dave Coleman
+ */
+
+#include <cmath>
+#include <moveit/pointcloud_filter/pointcloud_filter.h>
+#include <moveit/occupancy_map_monitor/occupancy_map_monitor.h>
+#include <message_filters/subscriber.h>
+#include <sensor_msgs/point_cloud2_iterator.h>
+#include <XmlRpcException.h>
+
+namespace occupancy_map_monitor
+{
+
+PointCloudFilter::PointCloudFilter() : OccupancyMapUpdater("PointCloudFilter"),
+                                       private_nh_("~"),
+                                       max_range_(std::numeric_limits<double>::infinity()),
+                                       point_subsample_(1),
+                                       point_cloud_subscriber_(NULL),
+                                       point_cloud_filter_(NULL)
+{
+}
+
+PointCloudFilter::~PointCloudFilter()
+{
+  stopHelper();
+}
+
+bool PointCloudFilter::setParams(XmlRpc::XmlRpcValue &params)
+{
+  try
+  {
+    if (!params.hasMember("point_cloud_topic"))
+      return false;
+    point_cloud_topic_ = static_cast<const std::string&>(params["point_cloud_topic"]);
+
+    readXmlParam(params, "max_range", &max_range_);
+    readXmlParam(params, "point_subsample", &point_subsample_);
+    if (params.hasMember("filtered_cloud_topic"))
+      filtered_cloud_topic_ = static_cast<const std::string&>(params["filtered_cloud_topic"]);
+    else
+    {
+      ROS_ERROR_STREAM_NAMED("filter","Must specify filtered_cloud_topic");
+      return false;
+    }
+  }
+  catch (XmlRpc::XmlRpcException &ex)
+  {
+    ROS_ERROR("XmlRpc Exception: %s", ex.getMessage().c_str());
+    return false;
+  }
+
+  return true;
+}
+
+bool PointCloudFilter::initialize()
+{
+  tf_ = monitor_->getTFClient();
+  shape_mask_.reset(new point_containment_filter::ShapeMask());
+  shape_mask_->setTransformCallback(boost::bind(&PointCloudFilter::getShapeTransform, this, _1, _2));
+  if (!filtered_cloud_topic_.empty())
+    filtered_cloud_publisher_ = private_nh_.advertise<sensor_msgs::PointCloud2>(filtered_cloud_topic_, 10, false);
+  else
+  {
+    ROS_ERROR_STREAM_NAMED("filter","Must specify filtered_cloud_topic");
+    return false;
+  }
+  return true;
+}
+
+void PointCloudFilter::start()
+{
+  if (point_cloud_subscriber_)
+    return;
+  /* subscribe to point cloud topic using tf filter*/
+  point_cloud_subscriber_ = new message_filters::Subscriber<sensor_msgs::PointCloud2>(root_nh_, point_cloud_topic_, 5);
+  if (tf_ && !monitor_->getMapFrame().empty())
+  {
+    point_cloud_filter_ = new tf::MessageFilter<sensor_msgs::PointCloud2>(*point_cloud_subscriber_, *tf_, monitor_->getMapFrame(), 5);
+    point_cloud_filter_->registerCallback(boost::bind(&PointCloudFilter::cloudMsgCallback, this, _1));
+    ROS_INFO("Listening to '%s' using message filter with target frame '%s'", point_cloud_topic_.c_str(), point_cloud_filter_->getTargetFramesString().c_str());
+  }
+  else
+  {
+    point_cloud_subscriber_->registerCallback(boost::bind(&PointCloudFilter::cloudMsgCallback, this, _1));
+    ROS_INFO("Listening to '%s'", point_cloud_topic_.c_str());
+  }
+}
+
+void PointCloudFilter::stopHelper()
+{
+  delete point_cloud_filter_;
+  delete point_cloud_subscriber_;
+}
+
+void PointCloudFilter::stop()
+{
+  stopHelper();
+  point_cloud_filter_ = NULL;
+  point_cloud_subscriber_ = NULL;
+}
+
+ShapeHandle PointCloudFilter::excludeShape(const shapes::ShapeConstPtr &shape, const double &scale, const double &padding)
+{
+  ShapeHandle h = 0;
+  if (shape_mask_)
+    h = shape_mask_->addShape(shape, scale, padding);
+  else
+    ROS_ERROR("Shape filter not yet initialized!");
+  return h;
+}
+
+void PointCloudFilter::forgetShape(ShapeHandle handle)
+{
+  if (shape_mask_)
+    shape_mask_->removeShape(handle);
+}
+
+bool PointCloudFilter::getShapeTransform(ShapeHandle h, Eigen::Affine3d &transform) const
+{
+  ShapeTransformCache::const_iterator it = transform_cache_.find(h);
+  if (it == transform_cache_.end())
+  {
+    ROS_ERROR("Internal error. Shape filter handle %u not found", h);
+    return false;
+  }
+  transform = it->second;
+  return true;
+}
+
+void PointCloudFilter::cloudMsgCallback(const sensor_msgs::PointCloud2::ConstPtr &cloud_msg)
+{
+  ROS_DEBUG("Received a new point cloud message");
+  ros::WallTime start = ros::WallTime::now();
+
+  if (monitor_->getMapFrame().empty())
+    monitor_->setMapFrame(cloud_msg->header.frame_id);
+
+  /* get transform for cloud into map frame */
+  tf::StampedTransform map_H_sensor;
+  if (monitor_->getMapFrame() == cloud_msg->header.frame_id)
+    map_H_sensor.setIdentity();
+  else
+  {
+    if (tf_)
+    {
+      try
+      {
+        tf_->lookupTransform(monitor_->getMapFrame(), cloud_msg->header.frame_id, cloud_msg->header.stamp, map_H_sensor);
+      }
+      catch (tf::TransformException& ex)
+      {
+        ROS_ERROR_STREAM("Transform error of sensor data: " << ex.what() << "; quitting callback");
+        return;
+      }
+    }
+    else
+      return;
+  }
+
+  /* compute sensor origin in map frame */
+  //const tf::Vector3 &sensor_origin_tf = map_H_sensor.getOrigin();
+  Eigen::Vector3d sensor_origin_eigen; // unused - todo, remove
+  // (sensor_origin_tf.getX(), sensor_origin_tf.getY(), sensor_origin_tf.getZ());
+
+  if (!updateTransformCache(cloud_msg->header.frame_id, cloud_msg->header.stamp))
+  {
+    ROS_ERROR_THROTTLE(1, "Transform cache was not updated. Self-filtering may fail.");
+    return;
+  }
+
+  /* mask out points on the robot */
+  shape_mask_->maskContainment(*cloud_msg, sensor_origin_eigen, 0.0, max_range_, mask_);
+
+  boost::scoped_ptr<sensor_msgs::PointCloud2> filtered_cloud;
+
+  //We only use these iterators if we are creating a filtered_cloud for
+  //publishing. We cannot default construct these, so we use scoped_ptr's
+  //to defer construction
+  boost::scoped_ptr<sensor_msgs::PointCloud2Iterator<float> > iter_filtered_x;
+  boost::scoped_ptr<sensor_msgs::PointCloud2Iterator<float> > iter_filtered_y;
+  boost::scoped_ptr<sensor_msgs::PointCloud2Iterator<float> > iter_filtered_z;
+
+  filtered_cloud.reset(new sensor_msgs::PointCloud2());
+  filtered_cloud->header = cloud_msg->header;
+  sensor_msgs::PointCloud2Modifier pcd_modifier(*filtered_cloud);
+  pcd_modifier.setPointCloud2FieldsByString(1, "xyz");
+  pcd_modifier.resize(cloud_msg->width * cloud_msg->height);
+
+  //we have created a filtered_out, so we can create the iterators now
+  iter_filtered_x.reset(new sensor_msgs::PointCloud2Iterator<float>(*filtered_cloud, "x"));
+  iter_filtered_y.reset(new sensor_msgs::PointCloud2Iterator<float>(*filtered_cloud, "y"));
+  iter_filtered_z.reset(new sensor_msgs::PointCloud2Iterator<float>(*filtered_cloud, "z"));
+
+  size_t filtered_cloud_size = 0;
+
+  for(unsigned int row = 0; row < cloud_msg->height; row += point_subsample_)
+  {
+    unsigned int row_c = row * cloud_msg->width;
+    sensor_msgs::PointCloud2ConstIterator<float> pt_iter(*cloud_msg, "x");
+    //set iterator to point at start of the current row
+    pt_iter += row_c;
+
+    for (unsigned int col = 0; col < cloud_msg->width; col += point_subsample_,
+           pt_iter += point_subsample_)
+    {
+      /* check for NaN */
+      if (!isnan(pt_iter[0]) && !isnan(pt_iter[1]) && !isnan(pt_iter[2]))
+      {
+        /* transform to map frame */
+        // TODO remove this line
+        tf::Vector3 point_tf = map_H_sensor * tf::Vector3(pt_iter[0], pt_iter[1],
+                                                          pt_iter[2]);
+
+        /* occupied cell at ray endpoint if ray is shorter than max range and this point
+           isn't on a part of the robot*/
+        if (mask_[row_c + col] == point_containment_filter::ShapeMask::INSIDE)
+        {}
+        else if (mask_[row_c + col] == point_containment_filter::ShapeMask::CLIP)
+        {}
+        else
+        {
+          //build list of valid points if we want to publish them
+
+          **iter_filtered_x = pt_iter[0];
+          **iter_filtered_y = pt_iter[1];
+          **iter_filtered_z = pt_iter[2];
+          ++filtered_cloud_size;
+          ++*iter_filtered_x;
+          ++*iter_filtered_y;
+          ++*iter_filtered_z;
+        }
+      }
+    }
+  }
+
+  ROS_DEBUG("Processed point cloud in %lf ms", (ros::WallTime::now() - start).toSec() * 1000.0);
+
+  sensor_msgs::PointCloud2Modifier pcd_modifier(*filtered_cloud);
+  pcd_modifier.resize(filtered_cloud_size);
+  filtered_cloud_publisher_.publish(*filtered_cloud);
+}
+
+}

--- a/perception/pointcloud_filter_plugin_description.xml
+++ b/perception/pointcloud_filter_plugin_description.xml
@@ -1,0 +1,7 @@
+<library path="libmoveit_pointcloud_filter">
+  <class name="occupancy_map_monitor/PointCloudFilter" type="occupancy_map_monitor::PointCloudFilter" base_class_type="occupancy_map_monitor::OccupancyMapUpdater">
+    <description>
+    </description>
+  </class>
+
+</library>


### PR DESCRIPTION
This new plugin allows you to republish a point cloud that has filtered out the robot's links, and it run much faster than the current occupancy map filter since it does not use the occupancy map.

See https://github.com/ros-planning/moveit_ros/pull/523#issuecomment-63455744
