### PR TITLE
use named logging for manipulation components

### DIFF
--- a/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
+++ b/manipulation/move_group_pick_place_capability/src/pick_place_action_capability.cpp
@@ -101,11 +101,11 @@ void move_group::MoveGroupPickPlaceAction::executePickupCallback_PlanOnly(const 
   }
   catch(std::runtime_error &ex)
   {
-    ROS_ERROR("Pick&place threw an exception: %s", ex.what());
+    ROS_ERROR_NAMED("manipulation", "Pick&place threw an exception: %s", ex.what());
   }
   catch(...)
   {
-    ROS_ERROR("Pick&place threw an exception");
+    ROS_ERROR_NAMED("manipulation", "Pick&place threw an exception");
   }
 
   if (plan)
@@ -143,11 +143,11 @@ void move_group::MoveGroupPickPlaceAction::executePlaceCallback_PlanOnly(const m
   }
   catch(std::runtime_error &ex)
   {
-    ROS_ERROR("Pick&place threw an exception: %s", ex.what());
+    ROS_ERROR_NAMED("manipulation", "Pick&place threw an exception: %s", ex.what());
   }
   catch(...)
   {
-    ROS_ERROR("Pick&place threw an exception");
+    ROS_ERROR_NAMED("manipulation", "Pick&place threw an exception");
   }
 
   if (plan)
@@ -189,11 +189,11 @@ bool move_group::MoveGroupPickPlaceAction::planUsingPickPlace_Pickup(const movei
   }
   catch(std::runtime_error &ex)
   {
-    ROS_ERROR("Pick&place threw an exception: %s", ex.what());
+    ROS_ERROR_NAMED("manipulation", "Pick&place threw an exception: %s", ex.what());
   }
   catch(...)
   {
-    ROS_ERROR("Pick&place threw an exception");
+    ROS_ERROR_NAMED("manipulation", "Pick&place threw an exception");
   }
 
   if (pick_plan)
@@ -234,11 +234,11 @@ bool move_group::MoveGroupPickPlaceAction::planUsingPickPlace_Place(const moveit
   }
   catch(std::runtime_error &ex)
   {
-    ROS_ERROR("Pick&place threw an exception: %s", ex.what());
+    ROS_ERROR_NAMED("manipulation", "Pick&place threw an exception: %s", ex.what());
   }
   catch(...)
   {
-    ROS_ERROR("Pick&place threw an exception");
+    ROS_ERROR_NAMED("manipulation", "Pick&place threw an exception");
   }
 
   if (place_plan)
@@ -339,7 +339,7 @@ void move_group::MoveGroupPickPlaceAction::executePickupCallback(const moveit_ms
   if (goal->planning_options.plan_only || !context_->allow_trajectory_execution_)
   {
     if (!goal->planning_options.plan_only)
-      ROS_WARN("This instance of MoveGroup is not allowed to execute trajectories but the pick goal request has plan_only set to false. Only a motion plan will be computed anyway.");
+      ROS_WARN_NAMED("manipulation", "This instance of MoveGroup is not allowed to execute trajectories but the pick goal request has plan_only set to false. Only a motion plan will be computed anyway.");
     executePickupCallback_PlanOnly(goal, action_res);
   }
   else
@@ -371,7 +371,7 @@ void move_group::MoveGroupPickPlaceAction::executePlaceCallback(const moveit_msg
   if (goal->planning_options.plan_only || !context_->allow_trajectory_execution_)
   {
     if (!goal->planning_options.plan_only)
-      ROS_WARN("This instance of MoveGroup is not allowed to execute trajectories but the place goal request has plan_only set to false. Only a motion plan will be computed anyway.");
+      ROS_WARN_NAMED("manipulation", "This instance of MoveGroup is not allowed to execute trajectories but the place goal request has plan_only set to false. Only a motion plan will be computed anyway.");
     executePlaceCallback_PlanOnly(goal, action_res);
   }
   else
@@ -438,24 +438,24 @@ void move_group::MoveGroupPickPlaceAction::fillGrasps(moveit_msgs::PickupGoal& g
       try
       {
         dbp.model_id = boost::lexical_cast<int>(dbp.type.key);
-        ROS_DEBUG("Asking database for grasps for '%s' with model id: %d", dbp.type.key.c_str(), dbp.model_id);
+        ROS_DEBUG_NAMED("manipulation", "Asking database for grasps for '%s' with model id: %d", dbp.type.key.c_str(), dbp.model_id);
         request.target.potential_models.push_back(dbp);
       }
       catch (boost::bad_lexical_cast &)
       {
         valid = false;
-        ROS_ERROR("Expected an integer object id, not '%s'", dbp.type.key.c_str());
+        ROS_ERROR_NAMED("manipulation", "Expected an integer object id, not '%s'", dbp.type.key.c_str());
       }
     }
     else
     {
       valid = false;
-      ROS_ERROR("Object has no geometry");
+      ROS_ERROR_NAMED("manipulation", "Object has no geometry");
     }
 
     if (valid)
     {
-      ROS_DEBUG("Calling grasp planner...");
+      ROS_DEBUG_NAMED("manipulation", "Calling grasp planner...");
       if (grasp_planning_service_.call(request, response))
       {
         goal.possible_grasps.resize(response.grasps.size());
@@ -507,7 +507,7 @@ void move_group::MoveGroupPickPlaceAction::fillGrasps(moveit_msgs::PickupGoal& g
 
   if (goal.possible_grasps.empty())
   {
-    ROS_DEBUG("Using default grasp poses");
+    ROS_DEBUG_NAMED("manipulation", "Using default grasp poses");
     goal.minimize_object_distance = true;
 
     // add a number of default grasp points

--- a/manipulation/pick_place/src/approach_and_translate_stage.cpp
+++ b/manipulation/pick_place/src/approach_and_translate_stage.cpp
@@ -129,7 +129,7 @@ bool executeAttachObject(const ManipulationPlanSharedDataConstPtr &shared_plan_d
                          const trajectory_msgs::JointTrajectory &detach_posture,
                          const plan_execution::ExecutableMotionPlan *motion_plan)
 {
-  ROS_DEBUG("Applying attached object diff to maintained planning scene (attaching/detaching object to end effector)");
+  ROS_DEBUG_NAMED("manipulation", "Applying attached object diff to maintained planning scene (attaching/detaching object to end effector)");
   bool ok = false;
   {
     planning_scene_monitor::LockedPlanningSceneRW ps(motion_plan->planning_scene_monitor_);
@@ -173,7 +173,7 @@ void addGripperTrajectory(const ManipulationPlanPtr &plan, const collision_detec
   }
   else
   {
-    ROS_WARN_STREAM("No joint states of grasp postures have been defined in the pick place action.");
+    ROS_WARN_NAMED("manipulation", "No joint states of grasp postures have been defined in the pick place action.");
   }
 }
 

--- a/manipulation/pick_place/src/manipulation_pipeline.cpp
+++ b/manipulation/pick_place/src/manipulation_pipeline.cpp
@@ -143,8 +143,8 @@ void ManipulationPipeline::stop()
 
 void ManipulationPipeline::processingThread(unsigned int index)
 {
-  ROS_DEBUG_STREAM("Start thread " << index << " for '" << name_ << "'");
-  
+  ROS_DEBUG_STREAM_NAMED("manipulation", "Start thread " << index << " for '" << name_ << "'");
+
   while (!stop_processing_)
   {
     bool inc_queue = false;
@@ -181,7 +181,7 @@ void ManipulationPipeline::processingThread(unsigned int index)
           {
             boost::mutex::scoped_lock slock(result_lock_);
             failed_.push_back(g);
-            ROS_INFO_STREAM("Manipulation plan " << g->id_ << " failed at stage '" << stages_[i]->getName() << "' on thread " << index);
+            ROS_INFO_STREAM_NAMED("manipulation", "Manipulation plan " << g->id_ << " failed at stage '" << stages_[i]->getName() << "' on thread " << index);
             break;
           }
         }
@@ -193,18 +193,18 @@ void ManipulationPipeline::processingThread(unsigned int index)
             success_.push_back(g);
           }
           signalStop();
-          ROS_INFO_STREAM("Found successful manipulation plan!");
+          ROS_INFO_STREAM_NAMED("manipulation", "Found successful manipulation plan!");
           if (solution_callback_)
             solution_callback_();
         }
       }
       catch (std::runtime_error &ex)
       {
-        ROS_ERROR("[%s:%u] %s", name_.c_str(), index, ex.what());
+        ROS_ERROR_NAMED("manipulation", "[%s:%u] %s", name_.c_str(), index, ex.what());
       }
       catch (...)
       {
-        ROS_ERROR("[%s:%u] Caught unknown exception while processing manipulation stage", name_.c_str(), index);
+        ROS_ERROR_NAMED("manipulation", "[%s:%u] Caught unknown exception while processing manipulation stage", name_.c_str(), index);
       }
       queue_access_lock_.lock();
     }
@@ -215,7 +215,7 @@ void ManipulationPipeline::push(const ManipulationPlanPtr &plan)
 {
   boost::mutex::scoped_lock slock(queue_access_lock_);
   queue_.push_back(plan);
-  ROS_INFO_STREAM("Added plan for pipeline '" << name_ << "'. Queue is now of size " << queue_.size());
+  ROS_INFO_STREAM_NAMED("manipulation", "Added plan for pipeline '" << name_ << "'. Queue is now of size " << queue_.size());
   queue_access_cond_.notify_all();
 }
 
@@ -228,7 +228,7 @@ void ManipulationPipeline::reprocessLastFailure()
   failed_.pop_back();
   plan->clear();
   queue_.push_back(plan);
-  ROS_INFO_STREAM("Re-added last failed plan for pipeline '" << name_ << "'. Queue is now of size " << queue_.size());
+  ROS_INFO_STREAM_NAMED("manipulation", "Re-added last failed plan for pipeline '" << name_ << "'. Queue is now of size " << queue_.size());
   queue_access_cond_.notify_all();
 }
 

--- a/manipulation/pick_place/src/pick.cpp
+++ b/manipulation/pick_place/src/pick.cpp
@@ -84,7 +84,7 @@ bool PickPlan::plan(const planning_scene::PlanningSceneConstPtr &planning_scene,
     {
       end_effector = eefs.front();
       if (eefs.size() > 1)
-        ROS_WARN_STREAM("Choice of end-effector for group '" << planning_group << "' is ambiguous. Assuming '" << end_effector << "'");
+        ROS_WARN_STREAM_NAMED("manipulation", "Choice of end-effector for group '" << planning_group << "' is ambiguous. Assuming '" << end_effector << "'");
     }
   }
   else
@@ -99,17 +99,17 @@ bool PickPlan::plan(const planning_scene::PlanningSceneConstPtr &planning_scene,
       planning_group = jmg->getEndEffectorParentGroup().first;
       if (planning_group.empty())
       {   
-        ROS_ERROR_STREAM("No parent group to plan in was identified based on end-effector '" << end_effector << "'. Please define a parent group in the SRDF.");
+        ROS_ERROR_STREAM_NAMED("manipulation", "No parent group to plan in was identified based on end-effector '" << end_effector << "'. Please define a parent group in the SRDF.");
         error_code_.val = moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME;
         return false;
       }
       else
-        ROS_INFO_STREAM("Assuming the planning group for end effector '" << end_effector << "' is '" << planning_group << "'");
+        ROS_INFO_STREAM_NAMED("manipulation", "Assuming the planning group for end effector '" << end_effector << "' is '" << planning_group << "'");
     }
   const robot_model::JointModelGroup *eef = end_effector.empty() ? NULL : planning_scene->getRobotModel()->getEndEffector(end_effector);
   if (!eef)
   {
-    ROS_ERROR("No end-effector specified for pick action");
+    ROS_ERROR_NAMED("manipulation", "No end-effector specified for pick action");
     error_code_.val = moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME;
     return false;
   }
@@ -202,7 +202,7 @@ bool PickPlan::plan(const planning_scene::PlanningSceneConstPtr &planning_scene,
       error_code_.val = moveit_msgs::MoveItErrorCodes::PLANNING_FAILED;
       if (goal.possible_grasps.size() > 0)
       {
-        ROS_WARN("All supplied grasps failed. Retrying last grasp in verbose mode.");
+        ROS_WARN_NAMED("manipulation", "All supplied grasps failed. Retrying last grasp in verbose mode.");
         // everything failed. we now start the pipeline again in verbose mode for one grasp
         initialize();
         pipeline_.setVerbose(true);
@@ -214,7 +214,7 @@ bool PickPlan::plan(const planning_scene::PlanningSceneConstPtr &planning_scene,
       }
     }
   }
-  ROS_INFO("Pickup planning completed after %lf seconds", last_plan_time_);
+  ROS_INFO_NAMED("manipulation", "Pickup planning completed after %lf seconds", last_plan_time_);
 
   return error_code_.val == moveit_msgs::MoveItErrorCodes::SUCCESS;
 }

--- a/manipulation/pick_place/src/place.cpp
+++ b/manipulation/pick_place/src/place.cpp
@@ -85,7 +85,7 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr &planning_scene
       const std::string &eef_parent = eef->getEndEffectorParentGroup().first;
       if (eef_parent.empty())
       {
-        ROS_ERROR_STREAM("No parent group to plan in was identified based on end-effector '" << goal.group_name << "'. Please define a parent group in the SRDF.");
+        ROS_ERROR_STREAM_NAMED("manipulation", "No parent group to plan in was identified based on end-effector '" << goal.group_name << "'. Please define a parent group in the SRDF.");
         error_code_.val = moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME;
         return false;
       }
@@ -103,7 +103,7 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr &planning_scene
       const std::vector<std::string> &eef_names = jmg->getAttachedEndEffectorNames();  
       if (eef_names.empty())
       {
-        ROS_ERROR_STREAM("There are no end-effectors specified for group '" << goal.group_name << "'");
+        ROS_ERROR_STREAM_NAMED("manipulation", "There are no end-effectors specified for group '" << goal.group_name << "'");
         error_code_.val = moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME;
         return false;
       }
@@ -152,8 +152,8 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr &planning_scene
             // if we previoulsy have set the eef it means we have more options we could use, so things are ambiguous
             if (eef)
             {
-              ROS_ERROR_STREAM("There are multiple end-effectors for group '" << goal.group_name <<
-                               "' that are currently holding objects. It is ambiguous which end-effector to use. Please specify it explicitly.");
+              ROS_ERROR_STREAM_NAMED("manipulation", "There are multiple end-effectors for group '" << goal.group_name <<
+                                     "' that are currently holding objects. It is ambiguous which end-effector to use. Please specify it explicitly.");
               error_code_.val = moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME;
               return false;
             }
@@ -179,8 +179,8 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr &planning_scene
         {
           if (eef)
           {
-            ROS_ERROR_STREAM("There are multiple end-effectors that include the link '" << link->getName() <<
-                             "' which is where the body '" << attached_object_name << "' is attached. It is unclear which end-effector to use.");
+            ROS_ERROR_STREAM_NAMED("manipulation", "There are multiple end-effectors that include the link '" << link->getName() <<
+                                   "' which is where the body '" << attached_object_name << "' is attached. It is unclear which end-effector to use.");
             error_code_.val = moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME;
             return false;
           }
@@ -193,7 +193,7 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr &planning_scene
       const std::string &eef_parent = eef->getEndEffectorParentGroup().first;
       if (eef_parent.empty())
       {
-        ROS_ERROR_STREAM("No parent group to plan in was identified based on end-effector '" << goal.group_name << "'. Please define a parent group in the SRDF.");
+        ROS_ERROR_STREAM_NAMED("manipulation", "No parent group to plan in was identified based on end-effector '" << goal.group_name << "'. Please define a parent group in the SRDF.");
         error_code_.val = moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME;
         return false;
       }
@@ -220,7 +220,7 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr &planning_scene
     loop_count++;
     if (attached_bodies.size() > 1)
     {
-      ROS_ERROR("Multiple attached bodies for group '%s' but no explicit attached object to place was specified", goal.group_name.c_str());
+      ROS_ERROR_NAMED("manipulation", "Multiple attached bodies for group '%s' but no explicit attached object to place was specified", goal.group_name.c_str());
       error_code_.val = moveit_msgs::MoveItErrorCodes::INVALID_OBJECT_NAME;
       return false;
     }
@@ -231,7 +231,7 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr &planning_scene
   const robot_state::AttachedBody *attached_body = planning_scene->getCurrentState().getAttachedBody(attached_object_name);
   if (!attached_body)
   {
-    ROS_ERROR("There is no object to detach for place action");
+    ROS_ERROR_NAMED("manipulation", "There is no object to detach for place action");
     error_code_.val = moveit_msgs::MoveItErrorCodes::INVALID_OBJECT_NAME;
     return false;
   }
@@ -303,7 +303,7 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr &planning_scene
       if (!transformToEndEffectorGoal(pl.place_pose, attached_body, p->goal_pose_))
       {    
         p->goal_pose_ = pl.place_pose;
-        ROS_ERROR("Unable to transform the desired pose of the object to the pose of the end-effector");
+        ROS_ERROR_NAMED("manipulation", "Unable to transform the desired pose of the object to the pose of the end-effector");
       }
     
     p->approach_ = pl.pre_place_approach;
@@ -314,7 +314,7 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr &planning_scene
       p->retreat_posture_ = attached_body->getDetachPosture();
     pipeline_.push(p);
   }
-  ROS_INFO("Added %d place locations", (int) goal.place_locations.size());
+  ROS_INFO_NAMED("manipulation", "Added %d place locations", (int) goal.place_locations.size());
 
   // wait till we're done
   waitForPipeline(endtime);
@@ -334,7 +334,7 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr &planning_scene
       error_code_.val = moveit_msgs::MoveItErrorCodes::PLANNING_FAILED;
       if (goal.place_locations.size() > 0)
       {
-        ROS_WARN("All supplied place locations failed. Retrying last location in verbose mode.");
+        ROS_WARN_NAMED("manipulation", "All supplied place locations failed. Retrying last location in verbose mode.");
         // everything failed. we now start the pipeline again in verbose mode for one grasp
         initialize();
         pipeline_.setVerbose(true);
@@ -346,7 +346,7 @@ bool PlacePlan::plan(const planning_scene::PlanningSceneConstPtr &planning_scene
       }
     }
   }
-  ROS_INFO("Place planning completed after %lf seconds", last_plan_time_);
+  ROS_INFO_NAMED("manipulation", "Place planning completed after %lf seconds", last_plan_time_);
 
   return error_code_.val == moveit_msgs::MoveItErrorCodes::SUCCESS;
 }

--- a/manipulation/pick_place/src/reachable_valid_pose_filter.cpp
+++ b/manipulation/pick_place/src/reachable_valid_pose_filter.cpp
@@ -137,10 +137,10 @@ bool pick_place::ReachableAndValidPoseFilter::evaluate(const ManipulationPlanPtr
       }
       else
         if (verbose_)
-          ROS_INFO("Sampler failed to produce a state");
+          ROS_INFO_NAMED("manipulation", "Sampler failed to produce a state");
     }
     else
-      ROS_ERROR_THROTTLE(1, "No sampler was constructed");
+      ROS_ERROR_THROTTLE_NAMED(1, "manipulation", "No sampler was constructed");
   }
   plan->error_code_.val = moveit_msgs::MoveItErrorCodes::GOAL_IN_COLLISION;
   return false;


### PR DESCRIPTION
While debugging SBPL with pick&place I ended up pushing all the (abundant) logging messages from manipulation into a named logger. This is especially useful for turning on debug messages in order to figure out what is going on.
