### PR TITLE
disable test that needs display when no display defined

### DIFF
--- a/perception/mesh_filter/CMakeLists.txt
+++ b/perception/mesh_filter/CMakeLists.txt
@@ -10,9 +10,13 @@ add_library(${MOVEIT_LIB_NAME}
 
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${gl_LIBS} glut GLEW)
 
-catkin_add_gtest(mesh_filter_test test/mesh_filter_test.cpp)
-target_link_libraries(mesh_filter_test ${catkin_LIBRARIES} ${Boost_LIBRARIES} moveit_mesh_filter)
-
+# Can only run this test if we have a display
+if (DEFINED ENV{DISPLAY} AND NOT $ENV{DISPLAY} STREQUAL "")
+  catkin_add_gtest(mesh_filter_test test/mesh_filter_test.cpp)
+  target_link_libraries(mesh_filter_test ${catkin_LIBRARIES} ${Boost_LIBRARIES} moveit_mesh_filter)
+else()
+  message("No display, will not configure tests for moveit_ros_perception/mesh_filter")
+endif()
 
 install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION lib)
 install(DIRECTORY include/ DESTINATION include)


### PR DESCRIPTION
This should disable the opengl-dependent tests in mesh_filter when running on the farm. This should be the last thing needed to finish #524 and get devel jobs in the green.
