### PR TITLE
fix duplicate planning attempt box, also fix warning about name

### DIFF
--- a/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -589,33 +589,10 @@
               </property>
              </widget>
             </item>
-            <item>
-             <widget class="QLabel" name="label_10">
-              <property name="text">
-               <string>Planning Attempts:</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QDoubleSpinBox" name="planning_attempts">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maximum">
-               <number>1000</number>
-              </property>
-              <property name="value">
-               <number>10</number>
-              </property>
-             </widget>
-            </item>
            </layout>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_4">
+           <layout class="QHBoxLayout" name="horizontalLayout_15">
             <item>
              <widget class="QLabel" name="label_10">
               <property name="text">


### PR DESCRIPTION
An earlier version of the PR seems to have been merged, and thus f26a731a921993acea394ccf09f187fad284ca7b should not have been cherry picked recently into indigo-devel. This PR gets rid of the duplicate planning_attempt box in the GUI. Also makes the name of the horizontal layout unique, thus getting rid of a warning.
