### PR TITLE
add plugin interface for collision detectors

### DIFF
--- a/planning/CMakeLists.txt
+++ b/planning/CMakeLists.txt
@@ -43,6 +43,7 @@ set(THIS_PACKAGE_INCLUDE_DIRS
     plan_execution/include
     kdl_kinematics_plugin/include
     srv_kinematics_plugin/include
+    collision_plugin_loader/include
 )
 
 catkin_package(
@@ -75,6 +76,7 @@ link_directories(${Boost_LIBRARY_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
 
 add_subdirectory(rdf_loader)
+add_subdirectory(collision_plugin_loader)
 add_subdirectory(kdl_kinematics_plugin)
 add_subdirectory(srv_kinematics_plugin)
 add_subdirectory(kinematics_plugin_loader)

--- a/planning/collision_plugin_loader/CMakeLists.txt
+++ b/planning/collision_plugin_loader/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(MOVEIT_LIB_NAME moveit_collision_plugin_loader)
+
+add_library(${MOVEIT_LIB_NAME} src/collision_plugin_loader.cpp)
+target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES})
+
+install(TARGETS ${MOVEIT_LIB_NAME} LIBRARY DESTINATION lib)
+install(DIRECTORY include/ DESTINATION include)

--- a/planning/collision_plugin_loader/include/moveit/collision_plugin_loader/collision_plugin_loader.h
+++ b/planning/collision_plugin_loader/include/moveit/collision_plugin_loader/collision_plugin_loader.h
@@ -1,0 +1,74 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014 Fetch Robotics Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Fetch Robotics nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#ifndef MOVEIT_COLLISION_PLUGIN_LOADER_COLLISION_PLUGIN_LOADER_H
+#define MOVEIT_COLLISION_PLUGIN_LOADER_COLLISION_PLUGIN_LOADER_H
+
+#include <ros/ros.h>
+#include <moveit/collision_detection/collision_plugin.h>
+
+namespace collision_detection
+{
+
+/**
+ * @brief This is used to load the collision plugin
+ */
+class CollisionPluginLoader
+{
+public:
+  CollisionPluginLoader();
+  ~CollisionPluginLoader();
+
+  /** @brief This can be called on a new planning scene to setup the collision detector. */
+  void setupScene(ros::NodeHandle& nh, const planning_scene::PlanningScenePtr& scene);
+
+  /**
+   * @brief Load a collision detection robot/world into a planning scene instance.
+   * @param name The plugin name.
+   * @param scene The planning scene instance.
+   * @param exclusive If true, sets the new detection robot/world to be the only one.
+   * @return True if collision robot/world were added to scene.
+   */
+  bool activate(const std::string& name,
+    const planning_scene::PlanningScenePtr& scene,
+    bool exclusive);
+
+private:
+  class CollisionPluginLoaderImpl;
+  boost::shared_ptr<CollisionPluginLoaderImpl> loader_;
+};
+
+}  // namespace collision_detection
+
+#endif  // MOVEIT_COLLISION_PLUGIN_LOADER_COLLISION_PLUGIN_LOADER_H

--- a/planning/collision_plugin_loader/src/collision_plugin_loader.cpp
+++ b/planning/collision_plugin_loader/src/collision_plugin_loader.cpp
@@ -1,0 +1,152 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014 Fetch Robotics Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Fetch Robotics nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <moveit/collision_plugin_loader/collision_plugin_loader.h>
+#include <pluginlib/class_loader.h>
+
+namespace collision_detection
+{
+
+class CollisionPluginLoader::CollisionPluginLoaderImpl
+{
+  typedef boost::shared_ptr<CollisionPlugin> CollisionPluginPtr;
+
+public:
+  CollisionPluginLoaderImpl()
+  {
+    try
+    {
+      loader_.reset(new pluginlib::ClassLoader<CollisionPlugin>("moveit_core", "collision_detection::CollisionPlugin"));
+    }
+    catch(pluginlib::PluginlibException& e)
+    {
+      ROS_ERROR("Unable to construct colllision plugin loader. Error: %s", e.what());
+    }
+  }
+
+  CollisionPluginPtr load(const std::string& name)
+  {
+    CollisionPluginPtr plugin;
+    try
+    {
+      plugin.reset(loader_->createUnmanagedInstance(name));
+      plugins_[name] = plugin;
+    }
+    catch (pluginlib::PluginlibException& ex)
+    {
+      ROS_ERROR_STREAM("Exception while loading " << name << ": " << ex.what());
+    }
+    return plugin;
+  }
+
+  bool activate(
+    const std::string& name,
+    const planning_scene::PlanningScenePtr& scene,
+    bool exclusive)
+  {
+    std::map<std::string, CollisionPluginPtr>::iterator it = plugins_.find(name);
+    if (it == plugins_.end())
+    {
+      CollisionPluginPtr plugin = load(name);
+      if (plugin)
+      {
+        return plugin->initialize(scene, exclusive);
+      }
+      return false;
+    }
+    if (it->second)
+    {
+      return it->second->initialize(scene, exclusive);
+    }
+    return false;
+  }
+
+private:
+  boost::shared_ptr<pluginlib::ClassLoader<CollisionPlugin> > loader_;
+  std::map<std::string, CollisionPluginPtr> plugins_;
+};
+
+CollisionPluginLoader::CollisionPluginLoader()
+{
+  loader_.reset(new CollisionPluginLoaderImpl());
+}
+
+CollisionPluginLoader::~CollisionPluginLoader()
+{
+}
+
+bool CollisionPluginLoader::activate(
+  const std::string& name,
+  const planning_scene::PlanningScenePtr& scene,
+  bool exclusive)
+{
+  return loader_->activate(name, scene, exclusive);
+}
+
+void CollisionPluginLoader::setupScene(
+  ros::NodeHandle& nh,
+  const planning_scene::PlanningScenePtr& scene)
+{
+  if (!scene)
+    return;
+
+  std::string param_name;
+  std::string collision_detector_name;
+
+  if (nh.searchParam("collision_detector", param_name))
+  {
+    nh.getParam(param_name, collision_detector_name);
+  }
+  else if (nh.hasParam("/move_group/collision_detector"))
+  {
+    // Check for existence in move_group namespace
+    // mainly for rviz plugins to get same collision detector.
+    nh.getParam("/move_group/collision_detector", collision_detector_name);
+  }
+  else
+  {
+    return;
+  }
+
+  if (collision_detector_name == "")
+  {
+    // This is not a valid name for a collision detector plugin
+    return;
+  }
+
+  activate(collision_detector_name, scene, true);
+  ROS_INFO_STREAM("Using collision detector:" << scene->getActiveCollisionDetectorName().c_str());
+}
+
+}  // namespace collision_detection

--- a/planning/planning_scene_monitor/CMakeLists.txt
+++ b/planning/planning_scene_monitor/CMakeLists.txt
@@ -4,7 +4,11 @@ add_library(${MOVEIT_LIB_NAME}
   src/planning_scene_monitor.cpp
   src/current_state_monitor.cpp
   src/trajectory_monitor.cpp)
-target_link_libraries(${MOVEIT_LIB_NAME} moveit_robot_model_loader ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME}
+  moveit_robot_model_loader
+  moveit_collision_plugin_loader
+  ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES})
 
 add_executable(demo_scene demos/demo_scene.cpp)
 target_link_libraries(demo_scene ${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -45,6 +45,7 @@
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <moveit/occupancy_map_monitor/occupancy_map_monitor.h>
 #include <moveit/planning_scene_monitor/current_state_monitor.h>
+#include <moveit/collision_plugin_loader/collision_plugin_loader.h>
 #include <boost/noncopyable.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>
@@ -503,6 +504,8 @@ private:
 
   robot_model_loader::RobotModelLoaderPtr rm_loader_;
   robot_model::RobotModelConstPtr robot_model_;
+
+  collision_detection::CollisionPluginLoader collision_loader_;
 
   class DynamicReconfigureImpl;
   DynamicReconfigureImpl *reconfigure_impl_;

--- a/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -170,12 +170,14 @@ void planning_scene_monitor::PlanningSceneMonitor::initialize(const planning_sce
   {
     robot_model_ = rm_loader_->getModel();
     scene_ = scene;
+    collision_loader_.setupScene(nh_, scene_);
     scene_const_ = scene_;
     if (!scene_)
     {
       try
       {
         scene_.reset(new planning_scene::PlanningScene(rm_loader_->getModel()));
+        collision_loader_.setupScene(nh_, scene_);
         scene_const_ = scene_;
         configureCollisionMatrix(scene_);
         configureDefaultPadding();


### PR DESCRIPTION
This is a potential solution to #532. Highlights:
- Given the way the allocator stuff works (templated and CRTP), I chose not to wrap the CollisionRobot/World classes, but rather to create a new class that has an initialize() method in which one calls setActiveCollisionDetector() and does any other setup related to the collision detector.
- Parameter for the name of the collision plugin is held in "collision_detector", and I implemented a parameter search. In addition, if the parameter is not found, we check for "move_group/collision_detector", mainly so that the RVIZ plugin can use the collision detector.

@isucan please review and give feedback.
