### PR TITLE
Speed up loading of KDL and SRV kinematic plugins

### DIFF
--- a/planning/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
+++ b/planning/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
@@ -125,6 +125,15 @@ namespace kdl_kinematics_plugin
                             const std::string &group_name,
                             const std::string &base_name,
                             const std::string &tip_name,
+                            double search_discretization)
+    {
+      ROS_ERROR_STREAM_NAMED("kdl","This initialization function is deprecated and not implemented");
+    }
+
+    virtual bool initialize(const std::string &robot_description,
+                            const std::string &group_name,
+                            const std::string &base_name,
+                            const std::string &tip_name,
                             double search_discretization,
                             const robot_model::RobotModel* robot_model);
 

--- a/planning/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
+++ b/planning/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
@@ -125,7 +125,8 @@ namespace kdl_kinematics_plugin
                             const std::string &group_name,
                             const std::string &base_name,
                             const std::string &tip_name,
-                            double search_discretization);
+                            double search_discretization,
+                            const robot_model::RobotModel* robot_model);
 
     /**
      * @brief  Return all the joint names in the order they are used internally
@@ -214,16 +215,14 @@ namespace kdl_kinematics_plugin
 
     mutable random_numbers::RandomNumberGenerator random_number_generator_;
 
-    robot_model::RobotModelPtr robot_model_;
-
-    robot_state::RobotStatePtr state_, state_2_;
+    robot_state::RobotStatePtr robot_state_;
 
     int num_possible_redundant_joints_;
     std::vector<unsigned int> redundant_joints_map_index_;
 
     // Storage required for when the set of redundant joints is reset
     bool position_ik_; //whether this solver is only being used for position ik
-    robot_model::JointModelGroup* joint_model_group_;
+    const robot_model::JointModelGroup* joint_model_group_;
     double max_solver_iterations_;
     double epsilon_;
     std::vector<JointMimic> mimic_joints_;

--- a/planning/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/planning/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -53,13 +53,15 @@ CLASS_LOADER_REGISTER_CLASS(kdl_kinematics_plugin::KDLKinematicsPlugin, kinemati
 namespace kdl_kinematics_plugin
 {
 
-  KDLKinematicsPlugin::KDLKinematicsPlugin():active_(false) {}
+KDLKinematicsPlugin::KDLKinematicsPlugin()
+  : active_(false)
+{}
 
 void KDLKinematicsPlugin::getRandomConfiguration(KDL::JntArray &jnt_array, bool lock_redundancy) const
 {
   std::vector<double> jnt_array_vector(dimension_, 0.0);
-  state_->setToRandomPositions(joint_model_group_);
-  state_->copyJointGroupPositions(joint_model_group_, &jnt_array_vector[0]);
+  robot_state_->setToRandomPositions(joint_model_group_);
+  robot_state_->copyJointGroupPositions(joint_model_group_, &jnt_array_vector[0]);
   for (std::size_t i = 0; i < dimension_; ++i)
   {
     if (lock_redundancy)
@@ -96,8 +98,8 @@ void KDLKinematicsPlugin::getRandomConfiguration(const KDL::JntArray &seed_state
     consistency_limits_mimic.push_back(consistency_limits[i]);
   }
 
-  joint_model_group_->getVariableRandomPositionsNearBy(state_->getRandomNumberGenerator(), values, near, consistency_limits_mimic);
-  
+  joint_model_group_->getVariableRandomPositionsNearBy(robot_state_->getRandomNumberGenerator(), values, near, consistency_limits_mimic);
+
   for (std::size_t i = 0; i < dimension_; ++i)
   {
     bool skip = false;
@@ -128,27 +130,23 @@ bool KDLKinematicsPlugin::initialize(const std::string &robot_description,
                                      const std::string& group_name,
                                      const std::string& base_frame,
                                      const std::string& tip_frame,
-                                     double search_discretization)
+                                     double search_discretization,
+                                     const robot_model::RobotModel* robot_model)
 {
   setValues(robot_description, group_name, base_frame, tip_frame, search_discretization);
 
-  ros::NodeHandle private_handle("~");
-  rdf_loader::RDFLoader rdf_loader(robot_description_);
-  const boost::shared_ptr<srdf::Model> &srdf = rdf_loader.getSRDF();
-  const boost::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader.getURDF();
-
-  if (!urdf_model || !srdf)
+  // Check robot_state is initialized
+  if (!robot_state_)
   {
-    ROS_ERROR_NAMED("kdl","URDF and SRDF must be loaded for KDL kinematics solver to work.");
-    return false;
+    robot_state_.reset(new robot_state::RobotState(robot_model->getConstPtr()));
   }
 
-  robot_model_.reset(new robot_model::RobotModel(urdf_model, srdf));
+  ros::NodeHandle private_handle("~");
 
-  robot_model::JointModelGroup* joint_model_group = robot_model_->getJointModelGroup(group_name);
+  const robot_model::JointModelGroup* joint_model_group = robot_model->getJointModelGroup(group_name);
   if (!joint_model_group)
     return false;
-  
+
   if(!joint_model_group->isChain())
   {
     ROS_ERROR_NAMED("kdl","Group '%s' is not a chain", group_name.c_str());
@@ -162,11 +160,12 @@ bool KDLKinematicsPlugin::initialize(const std::string &robot_description,
 
   KDL::Tree kdl_tree;
 
-  if (!kdl_parser::treeFromUrdfModel(*urdf_model, kdl_tree))
+  if (!kdl_parser::treeFromUrdfModel(*(robot_model->getURDF()), kdl_tree))
   {
     ROS_ERROR_NAMED("kdl","Could not initialize tree object");
     return false;
   }
+
   if (!kdl_tree.getChain(base_frame_, getTipFrame(), kdl_chain_))
   {
     ROS_ERROR_NAMED("kdl","Could not initialize chain object");
@@ -228,8 +227,8 @@ bool KDLKinematicsPlugin::initialize(const std::string &robot_description,
   unsigned int joint_counter = 0;
   for (std::size_t i = 0; i < kdl_chain_.getNrOfSegments(); ++i)
   {
-    const robot_model::JointModel *jm = robot_model_->getJointModel(kdl_chain_.segments[i].getJoint().getName());
-    
+    const robot_model::JointModel *jm = robot_model->getJointModel(kdl_chain_.segments[i].getJoint().getName());
+
     //first check whether it belongs to the set of active joints in the group
     if (jm->getMimic() == NULL && jm->getVariableCount() > 0)
     {
@@ -270,10 +269,6 @@ bool KDLKinematicsPlugin::initialize(const std::string &robot_description,
     }
   }
   mimic_joints_ = mimic_joints;
-
-  // Setup the joint state groups that we need
-  state_.reset(new robot_state::RobotState(robot_model_));
-  state_2_.reset(new robot_state::RobotState(robot_model_));
 
   // Store things for when the set of redundant joints may change
   position_ik_ = position_ik;
@@ -329,7 +324,7 @@ bool KDLKinematicsPlugin::setRedundantJoints(const std::vector<unsigned int> &re
     if(!is_redundant_joint)
     {
       // check for mimic
-      if(mimic_joints_[i].active) 
+      if(mimic_joints_[i].active)
       {
 	redundant_joints_map_index.push_back(counter);
 	counter++;

--- a/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -158,7 +158,8 @@ public:
                 double search_res = search_res_.find(jmg->getName())->second[i]; // we know this exists, by construction
 
                 if (!result->initialize(robot_description_, jmg->getName(),
-                                        (base.empty() || base[0] != '/') ? base : base.substr(1) , tips, search_res))
+                                        (base.empty() || base[0] != '/') ? base : base.substr(1) , tips, search_res,
+                                        jmg->getParentModelPtr()))
                 {
                   ROS_ERROR("Kinematics solver of type '%s' could not be initialized for group '%s'", it->second[i].c_str(), jmg->getName().c_str());
                   result.reset();

--- a/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -67,14 +67,14 @@ bool canSpecifyPosition(const robot_model::JointModel *jmodel, const unsigned in
   if (jmodel->getType() == robot_model::JointModel::PLANAR && index == 2)
     ROS_ERROR("Cannot specify position limits for orientation of planar joint '%s'", jmodel->getName().c_str());
   else
-  if (jmodel->getType() == robot_model::JointModel::FLOATING && index > 2)
-    ROS_ERROR("Cannot specify position limits for orientation of floating joint '%s'", jmodel->getName().c_str());
-  else
-  if (jmodel->getType() == robot_model::JointModel::REVOLUTE &&
-      static_cast<const robot_model::RevoluteJointModel*>(jmodel)->isContinuous())
-    ROS_ERROR("Cannot specify position limits for continuous joint '%s'", jmodel->getName().c_str());
-  else
-    ok = true;
+    if (jmodel->getType() == robot_model::JointModel::FLOATING && index > 2)
+      ROS_ERROR("Cannot specify position limits for orientation of floating joint '%s'", jmodel->getName().c_str());
+    else
+      if (jmodel->getType() == robot_model::JointModel::REVOLUTE &&
+          static_cast<const robot_model::RevoluteJointModel*>(jmodel)->isContinuous())
+        ROS_ERROR("Cannot specify position limits for continuous joint '%s'", jmodel->getName().c_str());
+      else
+        ok = true;
   return ok;
 }
 }

--- a/planning/srv_kinematics_plugin/include/moveit/srv_kinematics_plugin/srv_kinematics_plugin.h
+++ b/planning/srv_kinematics_plugin/include/moveit/srv_kinematics_plugin/srv_kinematics_plugin.h
@@ -120,6 +120,15 @@ namespace srv_kinematics_plugin
     virtual bool initialize(const std::string &robot_description,
                             const std::string &group_name,
                             const std::string &base_name,
+                            const std::string &tip_name,
+                            double search_discretization)
+    {
+      ROS_ERROR_STREAM_NAMED("kdl","This initialization function is deprecated and not implemented");
+    }
+
+    virtual bool initialize(const std::string &robot_description,
+                            const std::string &group_name,
+                            const std::string &base_name,
                             const std::string &tip_frame,
                             double search_discretization,
                             const robot_model::RobotModel* robot_model)

--- a/planning/srv_kinematics_plugin/include/moveit/srv_kinematics_plugin/srv_kinematics_plugin.h
+++ b/planning/srv_kinematics_plugin/include/moveit/srv_kinematics_plugin/srv_kinematics_plugin.h
@@ -121,18 +121,21 @@ namespace srv_kinematics_plugin
                             const std::string &group_name,
                             const std::string &base_name,
                             const std::string &tip_frame,
-                            double search_discretization)
+                            double search_discretization,
+                            const robot_model::RobotModel* robot_model)
     {
       std::vector<std::string> tip_frames;
       tip_frames.push_back(tip_frame);
-      return initialize(robot_description, group_name, base_name, tip_frames, search_discretization);
+
+      return initialize(robot_description, group_name, base_name, tip_frames, search_discretization, robot_model);
     }
 
     virtual bool initialize(const std::string &robot_description,
                             const std::string &group_name,
                             const std::string &base_name,
                             const std::vector<std::string> &tip_frames,
-                            double search_discretization);
+                            double search_discretization,
+                            const robot_model::RobotModel* robot_model);
 
     /**
      * @brief  Return all the joint names in the order they are used internally
@@ -185,8 +188,7 @@ namespace srv_kinematics_plugin
 
     unsigned int dimension_; /** Dimension of the group */
 
-    robot_model::RobotModelPtr robot_model_;
-    robot_model::JointModelGroup* joint_model_group_;
+    const robot_model::JointModelGroup* joint_model_group_;
 
     robot_state::RobotStatePtr robot_state_;
 

--- a/planning/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/planning/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -55,14 +55,15 @@ namespace srv_kinematics_plugin
 {
 
 SrvKinematicsPlugin::SrvKinematicsPlugin()
- : active_(false) 
+ : active_(false)
 {}
 
 bool SrvKinematicsPlugin::initialize(const std::string &robot_description,
-  const std::string& group_name,
-  const std::string& base_frame,
-  const std::vector<std::string>& tip_frames,
-  double search_discretization)
+                                     const std::string& group_name,
+                                     const std::string& base_frame,
+                                     const std::vector<std::string>& tip_frames,
+                                     double search_discretization,
+                                     const robot_model::RobotModel* robot_model)
 {
   bool debug = false;
 
@@ -71,19 +72,15 @@ bool SrvKinematicsPlugin::initialize(const std::string &robot_description,
   setValues(robot_description, group_name, base_frame, tip_frames, search_discretization);
 
   ros::NodeHandle private_handle("~");
-  rdf_loader::RDFLoader rdf_loader(robot_description_);
-  const boost::shared_ptr<srdf::Model> &srdf = rdf_loader.getSRDF();
-  const boost::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader.getURDF();
 
-  if (!urdf_model || !srdf)
+  // Check robot_state is initialized
+  if (!robot_state_)
   {
-    ROS_ERROR_NAMED("srv","URDF and SRDF must be loaded for SRV kinematics solver to work."); // TODO: is this true?
-    return false;
+    robot_state_.reset(new robot_state::RobotState(robot_model->getConstPtr()));
+    robot_state_->setToDefaultValues();
   }
 
-  robot_model_.reset(new robot_model::RobotModel(urdf_model, srdf));
-
-  joint_model_group_ = robot_model_->getJointModelGroup(group_name);
+  joint_model_group_ = robot_model->getJointModelGroup(group_name);
   if (!joint_model_group_)
     return false;
 
@@ -96,7 +93,7 @@ bool SrvKinematicsPlugin::initialize(const std::string &robot_description,
   }
 
   // Get the dimension of the planning group
-  dimension_ = joint_model_group_->getVariableCount(); 
+  dimension_ = joint_model_group_->getVariableCount();
   ROS_INFO_STREAM_NAMED("srv","Dimension planning group '" << group_name << "': " << dimension_
     << ". Active Joints Models: " << joint_model_group_->getActiveJointModels().size()
     << ". Mimic Joint Models: " << joint_model_group_->getMimicJointModels().size());
@@ -130,9 +127,6 @@ bool SrvKinematicsPlugin::initialize(const std::string &robot_description,
   std::string ik_service_name;
   private_handle.param(group_name_ + "/kinematics_solver_service_name", ik_service_name, std::string("solve_ik"));
 
-  // Setup the joint state groups that we need
-  robot_state_.reset(new robot_state::RobotState(robot_model_));
-  robot_state_->setToDefaultValues();
 
   // Create the ROS service client
   ros::NodeHandle nonprivate_handle("");


### PR DESCRIPTION
This needs to be merged at the same time as https://github.com/ros-planning/moveit_core/pull/216

Improves the KDL and SRV kinematic plugins to load faster by bypassing loading and parsing the robot model.

Changes:
- Accept robot_model pointer
- Rename robot_state object
- Remove need for RDF loader
- Remove unused robot_state objects
- Cleanup formatting
