### PR TITLE
planning_scene_monitor: add ros parameter for adding a wait-for-transform lookup time

### DIFF
--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -493,6 +493,11 @@ private:
   // This field is protected by state_pending_mutex_
   ros::WallDuration dt_state_update_;
 
+  /// the amount of time to wait when looking up transforms
+  // Setting this to a non-zero value resolves issues when the sensor data is
+  // arriving so fast that it is preceding the transform state.
+  ros::Duration shape_transform_cache_lookup_wait_time_;
+
   /// timer for state updates.
   // Check if last_state_update_ is true and if so call updateSceneWithCurrentState()
   // Not safe to access from callback functions.

--- a/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -216,6 +216,14 @@ void planning_scene_monitor::PlanningSceneMonitor::initialize(const planning_sce
   last_update_time_ = ros::Time::now();
   last_state_update_ = ros::WallTime::now();
   dt_state_update_ = ros::WallDuration(0.1);
+
+  double temp_wait_time;
+  nh_.param(
+      robot_description_ + "_planning/shape_transform_cache_lookup_wait_time",
+      temp_wait_time,
+      0.05);
+  shape_transform_cache_lookup_wait_time_ = ros::Duration(temp_wait_time);
+
   state_update_pending_ = false;
   state_update_timer_ = nh_.createWallTimer(dt_state_update_,
                                             &PlanningSceneMonitor::stateUpdateTimerCallback,
@@ -846,6 +854,7 @@ bool planning_scene_monitor::PlanningSceneMonitor::getShapeTransformCache(const 
     for (LinkShapeHandles::const_iterator it = link_shape_handles_.begin() ; it != link_shape_handles_.end() ; ++it)
     {
       tf::StampedTransform tr;
+      tf_->waitForTransform(target_frame, it->first->getName(), target_time, shape_transform_cache_lookup_wait_time_);
       tf_->lookupTransform(target_frame, it->first->getName(), target_time, tr);
       Eigen::Affine3d ttr;
       tf::transformTFToEigen(tr, ttr);
@@ -855,6 +864,7 @@ bool planning_scene_monitor::PlanningSceneMonitor::getShapeTransformCache(const 
     for (AttachedBodyShapeHandles::const_iterator it = attached_body_shape_handles_.begin() ; it != attached_body_shape_handles_.end() ; ++it)
     {
       tf::StampedTransform tr;
+      tf_->waitForTransform(target_frame, it->first->getAttachedLinkName(), target_time, shape_transform_cache_lookup_wait_time_);
       tf_->lookupTransform(target_frame, it->first->getAttachedLinkName(), target_time, tr);
       Eigen::Affine3d transform;
       tf::transformTFToEigen(tr, transform);
@@ -863,6 +873,7 @@ bool planning_scene_monitor::PlanningSceneMonitor::getShapeTransformCache(const 
     }
     {
       tf::StampedTransform tr;
+      tf_->waitForTransform(target_frame, scene_->getPlanningFrame(), target_time, shape_transform_cache_lookup_wait_time_);
       tf_->lookupTransform(target_frame, scene_->getPlanningFrame(), target_time, tr);
       Eigen::Affine3d transform;
       tf::transformTFToEigen(tr, transform);


### PR DESCRIPTION
fixes #465

supersedes #540
