### PR TITLE
Add time factor support for trajectory time parametrization

### DIFF
--- a/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
+++ b/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
@@ -157,7 +157,7 @@ public:
     if (result && res.trajectory_)
     {
       ROS_DEBUG("Running '%s'", getDescription().c_str());
-      if (!time_param_.computeTimeStamps(*res.trajectory_))
+      if (!time_param_.computeTimeStamps(*res.trajectory_, req.motion_execution_time_factor))
         ROS_WARN("Time parametrization for the solution path failed.");
     }
 

--- a/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
+++ b/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
@@ -157,7 +157,7 @@ public:
     if (result && res.trajectory_)
     {
       ROS_DEBUG("Running '%s'", getDescription().c_str());
-      if (!time_param_.computeTimeStamps(*res.trajectory_, req.motion_execution_time_factor))
+      if (!time_param_.computeTimeStamps(*res.trajectory_, req.max_velocity_scaling_factor))
         ROS_WARN("Time parametrization for the solution path failed.");
     }
 

--- a/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -150,6 +150,9 @@ public:
 
   /** \brief Set the number of times the motion plan is to be computed from scratch before the shortest solution is returned. The default value is 1.*/
   void setNumPlanningAttempts(unsigned int num_planning_attempts);
+
+  /** \brief Set a factor that can be used to slow down trajectory execution speed from (0..1] The default value is 1 (i.e. max speed)*/
+  void setMotionExecutionTimeFactor(double motion_execution_time_factor);
   
   /** \brief Get the number of seconds set by setPlanningTime() */
   double getPlanningTime() const;

--- a/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -151,8 +151,12 @@ public:
   /** \brief Set the number of times the motion plan is to be computed from scratch before the shortest solution is returned. The default value is 1.*/
   void setNumPlanningAttempts(unsigned int num_planning_attempts);
 
-  /** \brief Set a factor that can be used to slow down trajectory execution speed from (0..1] The default value is 1 (i.e. max speed)*/
-  void setMotionExecutionTimeFactor(double motion_execution_time_factor);
+  /** \brief Set a scaling factor for optionally reducing the maximum joint velocity.
+      Allowed values are in (0,1]. The maximum joint velocity specified
+      in the robot model is multiplied by the factor. If outside valid range
+      (imporantly, this includes it being set to 0.0), the factor is set to a
+      default value of 1.0 internally (i.e. maximum joint velocity) */  
+  void setMaxVelocityScalingFactor(double max_velocity_scaling_factor);
   
   /** \brief Get the number of seconds set by setPlanningTime() */
   double getPlanningTime() const;

--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -116,6 +116,7 @@ public:
     goal_orientation_tolerance_ = 1e-3; // ~0.1 deg
     planning_time_ = 5.0;
     num_planning_attempts_ = 1;
+    motion_execution_time_factor_ = 1.0;
     initializing_constraints_ = false;
 
     if (joint_model_group_->isChain())
@@ -234,6 +235,11 @@ public:
   void setNumPlanningAttempts(unsigned int num_planning_attempts)
   {
     num_planning_attempts_ = num_planning_attempts;
+  }
+
+  void setMotionExecutionTimeFactor(double motion_execution_time_factor)
+  {
+    motion_execution_time_factor_ = motion_execution_time_factor;
   }
   
   robot_state::RobotState& getJointStateTarget()
@@ -820,6 +826,7 @@ public:
     moveit_msgs::MoveGroupGoal goal;
     goal.request.group_name = opt_.group_name_;
     goal.request.num_planning_attempts = num_planning_attempts_;
+    goal.request.motion_execution_time_factor = motion_execution_time_factor_;
     goal.request.allowed_planning_time = planning_time_;
     goal.request.planner_id = planner_id_;
     goal.request.workspace_parameters = workspace_parameters_;
@@ -1005,6 +1012,7 @@ private:
   double planning_time_;
   std::string planner_id_;
   unsigned int num_planning_attempts_;
+  double motion_execution_time_factor_;
   double goal_joint_tolerance_;
   double goal_position_tolerance_;
   double goal_orientation_tolerance_;
@@ -1076,6 +1084,12 @@ void moveit::planning_interface::MoveGroup::setNumPlanningAttempts(unsigned int 
 {
   impl_->setNumPlanningAttempts(num_planning_attempts);
 }
+
+void moveit::planning_interface::MoveGroup::setMotionExecutionTimeFactor(double motion_execution_time_factor)
+{
+  impl_->setMotionExecutionTimeFactor(motion_execution_time_factor);
+}
+
 
 moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGroup::asyncMove()
 {

--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -116,7 +116,7 @@ public:
     goal_orientation_tolerance_ = 1e-3; // ~0.1 deg
     planning_time_ = 5.0;
     num_planning_attempts_ = 1;
-    motion_execution_time_factor_ = 1.0;
+    max_velocity_scaling_factor_ = 1.0;
     initializing_constraints_ = false;
 
     if (joint_model_group_->isChain())
@@ -237,9 +237,9 @@ public:
     num_planning_attempts_ = num_planning_attempts;
   }
 
-  void setMotionExecutionTimeFactor(double motion_execution_time_factor)
+  void setMaxVelocityScalingFactor(double max_velocity_scaling_factor)
   {
-    motion_execution_time_factor_ = motion_execution_time_factor;
+    max_velocity_scaling_factor_ = max_velocity_scaling_factor;
   }
   
   robot_state::RobotState& getJointStateTarget()
@@ -826,7 +826,7 @@ public:
     moveit_msgs::MoveGroupGoal goal;
     goal.request.group_name = opt_.group_name_;
     goal.request.num_planning_attempts = num_planning_attempts_;
-    goal.request.motion_execution_time_factor = motion_execution_time_factor_;
+    goal.request.max_velocity_scaling_factor = max_velocity_scaling_factor_;
     goal.request.allowed_planning_time = planning_time_;
     goal.request.planner_id = planner_id_;
     goal.request.workspace_parameters = workspace_parameters_;
@@ -1012,7 +1012,7 @@ private:
   double planning_time_;
   std::string planner_id_;
   unsigned int num_planning_attempts_;
-  double motion_execution_time_factor_;
+  double max_velocity_scaling_factor_;
   double goal_joint_tolerance_;
   double goal_position_tolerance_;
   double goal_orientation_tolerance_;
@@ -1085,9 +1085,9 @@ void moveit::planning_interface::MoveGroup::setNumPlanningAttempts(unsigned int 
   impl_->setNumPlanningAttempts(num_planning_attempts);
 }
 
-void moveit::planning_interface::MoveGroup::setMotionExecutionTimeFactor(double motion_execution_time_factor)
+void moveit::planning_interface::MoveGroup::setMaxVelocityScalingFactor(double max_velocity_scaling_factor)
 {
-  impl_->setMotionExecutionTimeFactor(motion_execution_time_factor);
+  impl_->setMaxVelocityScalingFactor(max_velocity_scaling_factor);
 }
 
 

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -274,6 +274,7 @@ void MotionPlanningFrame::constructPlanningRequest(moveit_msgs::MotionPlanReques
   mreq.group_name = planning_display_->getCurrentPlanningGroup();
   mreq.num_planning_attempts = ui_->planning_attempts->value();
   mreq.allowed_planning_time = ui_->planning_time->value();
+  mreq.motion_execution_time_factor = ui_->exec_time_factor->value();
   robot_state::robotStateToRobotStateMsg(*planning_display_->getQueryStartState(), mreq.start_state);
   mreq.workspace_parameters.min_corner.x = ui_->wcenter_x->value() - ui_->wsize_x->value() / 2.0;
   mreq.workspace_parameters.min_corner.y = ui_->wcenter_y->value() - ui_->wsize_y->value() / 2.0;
@@ -334,6 +335,7 @@ void MotionPlanningFrame::configureForPlanning()
   move_group_->setJointValueTarget(*planning_display_->getQueryGoalState());
   move_group_->setPlanningTime(ui_->planning_time->value());
   move_group_->setNumPlanningAttempts(ui_->planning_attempts->value());
+  move_group_->setMotionExecutionTimeFactor(ui_->exec_time_factor->value());
   configureWorkspace();
 }
 

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -274,7 +274,7 @@ void MotionPlanningFrame::constructPlanningRequest(moveit_msgs::MotionPlanReques
   mreq.group_name = planning_display_->getCurrentPlanningGroup();
   mreq.num_planning_attempts = ui_->planning_attempts->value();
   mreq.allowed_planning_time = ui_->planning_time->value();
-  mreq.motion_execution_time_factor = ui_->exec_time_factor->value();
+  mreq.max_velocity_scaling_factor = ui_->exec_time_factor->value();
   robot_state::robotStateToRobotStateMsg(*planning_display_->getQueryStartState(), mreq.start_state);
   mreq.workspace_parameters.min_corner.x = ui_->wcenter_x->value() - ui_->wsize_x->value() / 2.0;
   mreq.workspace_parameters.min_corner.y = ui_->wcenter_y->value() - ui_->wsize_y->value() / 2.0;
@@ -335,7 +335,7 @@ void MotionPlanningFrame::configureForPlanning()
   move_group_->setJointValueTarget(*planning_display_->getQueryGoalState());
   move_group_->setPlanningTime(ui_->planning_time->value());
   move_group_->setNumPlanningAttempts(ui_->planning_attempts->value());
-  move_group_->setMotionExecutionTimeFactor(ui_->exec_time_factor->value());
+  move_group_->setMaxVelocityScalingFactor(ui_->exec_time_factor->value());
   configureWorkspace();
 }
 

--- a/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -623,7 +623,7 @@
             <item>
              <widget class="QLabel" name="label_11">
               <property name="text">
-               <string>Execution Time Factor:</string>
+               <string>Velocity Scaling:</string>	               
               </property>
              </widget>
             </item>

--- a/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -609,10 +609,10 @@
                </sizepolicy>
               </property>
               <property name="maximum">
-               <double>1000.000000000000000</double>
+               <number>1000</number>
               </property>
               <property name="value">
-               <double>10.000000000000000</double>
+               <number>10</number>
               </property>
              </widget>
             </item>

--- a/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>688</width>
-    <height>377</height>
+    <width>702</width>
+    <height>395</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -310,7 +310,7 @@
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>218</width>
+                   <width>109</width>
                    <height>78</height>
                   </rect>
                  </property>
@@ -360,7 +360,7 @@
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>218</width>
+                   <width>205</width>
                    <height>78</height>
                   </rect>
                  </property>
@@ -609,11 +609,35 @@
                </sizepolicy>
               </property>
               <property name="maximum">
-               <number>1000</number>
+               <double>1000.000000000000000</double>
               </property>
               <property name="value">
-               <number>10</number>
-               </property>
+               <double>10.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_10">
+            <item>
+             <widget class="QLabel" name="label_11">
+              <property name="text">
+               <string>Execution Time Factor:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="exec_time_factor">
+              <property name="maximum">
+               <double>1.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>0.010000000000000</double>
+              </property>
+              <property name="value">
+               <double>1.000000000000000</double>
+              </property>
              </widget>
             </item>
            </layout>


### PR DESCRIPTION
This adds support for setting a motion_execution_time_factor in the MotionPlanRequest msg, which can be used to scale the velocity bounds in add_time_parametrization.

Includes necessary changes to
- move_group
- move_group_interface
- Spinbox for motion planning rviz plugin

Requires other pulls requests in moveit_msgs and moveit_core which are stated below.
