### PR TITLE
perception: adding locks to planning scene monitor (RAII version)

### DIFF
--- a/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map.h
+++ b/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map.h
@@ -85,6 +85,19 @@ public:
     tree_mutex_.unlock();
   }
 
+  typedef boost::shared_lock<boost::shared_mutex> ReadLock;
+  typedef boost::unique_lock<boost::shared_mutex> WriteLock;
+
+  ReadLock reading()
+  {
+    return ReadLock(tree_mutex_);
+  }
+
+  WriteLock writing()
+  {
+    return WriteLock(tree_mutex_);
+  }
+
   void triggerUpdateCallback(void)
   {
     if (update_callback_)

--- a/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -310,7 +310,11 @@ void planning_scene_monitor::PlanningSceneMonitor::scenePublishingThread()
 
   // publish the full planning scene
   moveit_msgs::PlanningScene msg;
-  scene_->getPlanningSceneMsg(msg);
+  {
+    if (octomap_monitor_) octomap_monitor_->getOcTreePtr()->lockRead();
+    scene_->getPlanningSceneMsg(msg);
+    if (octomap_monitor_) octomap_monitor_->getOcTreePtr()->unlockRead();
+  }
   planning_scene_publisher_.publish(msg);
   ROS_DEBUG("Published the full planning scene: '%s'", msg.name.c_str());
 
@@ -331,7 +335,11 @@ void planning_scene_monitor::PlanningSceneMonitor::scenePublishingThread()
           if (new_scene_update_ == UPDATE_SCENE)
             is_full = true;
           else
+          {
+            if (octomap_monitor_) octomap_monitor_->getOcTreePtr()->lockRead();
             scene_->getPlanningSceneDiffMsg(msg);
+            if (octomap_monitor_) octomap_monitor_->getOcTreePtr()->unlockRead();
+          }
           boost::recursive_mutex::scoped_lock prevent_shape_cache_updates(shape_handles_lock_); // we don't want the transform cache to update while we are potentially changing attached bodies
           scene_->setAttachedBodyUpdateCallback(robot_state::AttachedBodyCallback());
           scene_->setCollisionObjectUpdateCallback(collision_detection::World::ObserverCallbackFn());
@@ -344,8 +352,12 @@ void planning_scene_monitor::PlanningSceneMonitor::scenePublishingThread()
             excludeAttachedBodiesFromOctree(); // in case updates have happened to the attached bodies, put them in
             excludeWorldObjectsFromOctree(); // in case updates have happened to the attached bodies, put them in
           }
-          if (is_full)
+          if (is_full) 
+          {
+            if (octomap_monitor_) octomap_monitor_->getOcTreePtr()->lockRead();
             scene_->getPlanningSceneMsg(msg);
+            if (octomap_monitor_) octomap_monitor_->getOcTreePtr()->unlockRead();
+          }
           publish_msg = true;
         }
         new_scene_update_ = UPDATE_NONE;

--- a/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -311,9 +311,9 @@ void planning_scene_monitor::PlanningSceneMonitor::scenePublishingThread()
   // publish the full planning scene
   moveit_msgs::PlanningScene msg;
   {
-    if (octomap_monitor_) octomap_monitor_->getOcTreePtr()->lockRead();
+    occupancy_map_monitor::OccMapTree::ReadLock lock;
+    if (octomap_monitor_) lock = octomap_monitor_->getOcTreePtr()->reading();
     scene_->getPlanningSceneMsg(msg);
-    if (octomap_monitor_) octomap_monitor_->getOcTreePtr()->unlockRead();
   }
   planning_scene_publisher_.publish(msg);
   ROS_DEBUG("Published the full planning scene: '%s'", msg.name.c_str());
@@ -336,9 +336,9 @@ void planning_scene_monitor::PlanningSceneMonitor::scenePublishingThread()
             is_full = true;
           else
           {
-            if (octomap_monitor_) octomap_monitor_->getOcTreePtr()->lockRead();
+            occupancy_map_monitor::OccMapTree::ReadLock lock;
+            if (octomap_monitor_) lock = octomap_monitor_->getOcTreePtr()->reading();
             scene_->getPlanningSceneDiffMsg(msg);
-            if (octomap_monitor_) octomap_monitor_->getOcTreePtr()->unlockRead();
           }
           boost::recursive_mutex::scoped_lock prevent_shape_cache_updates(shape_handles_lock_); // we don't want the transform cache to update while we are potentially changing attached bodies
           scene_->setAttachedBodyUpdateCallback(robot_state::AttachedBodyCallback());
@@ -354,9 +354,9 @@ void planning_scene_monitor::PlanningSceneMonitor::scenePublishingThread()
           }
           if (is_full) 
           {
-            if (octomap_monitor_) octomap_monitor_->getOcTreePtr()->lockRead();
+            occupancy_map_monitor::OccMapTree::ReadLock lock;
+            if (octomap_monitor_) lock = octomap_monitor_->getOcTreePtr()->reading();
             scene_->getPlanningSceneMsg(msg);
-            if (octomap_monitor_) octomap_monitor_->getOcTreePtr()->unlockRead();
           }
           publish_msg = true;
         }


### PR DESCRIPTION
fixes #291
fixes #514 

Note that this should unlock things properly in case `getPlanningSceneMsg` throws. It could be useful to clean up stuff elsewhere too.
