### PR TITLE
Fix crash due to robot state not getting updated in collision check evaluation tool (moveit_ros #559)

### DIFF
--- a/planning/planning_components_tools/src/evaluate_collision_checking_speed.cpp
+++ b/planning/planning_components_tools/src/evaluate_collision_checking_speed.cpp
@@ -103,6 +103,7 @@ int main(int argc, char **argv)
       do
       {
         state->setToRandomPositions();
+        state->update();
         collision_detection::CollisionResult res;
         psm.getPlanningScene()->checkCollision(req, res);
         if (!res.collision)


### PR DESCRIPTION
See hint provided by @mikeferguson in #559.
