### PR TITLE
slight modification to move() documentation

### DIFF
--- a/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -574,7 +574,7 @@ public:
   MoveItErrorCode asyncMove();
 
   /** \brief Plan and execute a trajectory that takes the group of joints declared in the constructor to the specified target.
-      This call is always blocking (waits for the execution of the trajectory to complete). */
+      This call is always blocking (waits for the execution of the trajectory to complete) and requires an asynchronous spinner to be started.*/
   MoveItErrorCode move();
 
   /** \brief Compute a motion plan that takes the group declared in the constructor from the current state to the specified


### PR DESCRIPTION
Updated documentation on move() to inform the user that an asynchronous spinner is required. Commonly new users don't do this and move() blocks permanently
