### PR TITLE
Avoid adding a slash if getMoveGroupNS() is empty.

### DIFF
--- a/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -376,8 +376,10 @@ void PlanningSceneDisplay::changedPlanningSceneTopic()
   if (planning_scene_monitor_ && planning_scene_topic_property_)
   {
     planning_scene_monitor_->startSceneMonitor(planning_scene_topic_property_->getStdString());
-    planning_scene_monitor_->requestPlanningSceneState(
-        ros::names::append(getMoveGroupNS(),planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_SERVICE));
+    std::string service_name = planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_SERVICE;
+    if (!getMoveGroupNS().empty())
+      service_name = ros::names::append(getMoveGroupNS(), service_name);
+    planning_scene_monitor_->requestPlanningSceneState(service_name);
   }
 }
 


### PR DESCRIPTION
If the getMoveGroupNS() returns an empty string, ros::names::append() inserts a slash in front of 'right', which changes it to a global name.
Checking getMoveGroupNS() before calling append removes the issue.
append() behaviour will not be changed, see ros/ros_comm#562. Therefore, i created the pull request here, as suggested by @mikeferguson.

In my case RViz and move_group (the node providing the get_planning_scene service) are in the same namespace, say "/my_robot". If the text field is left empty the plugin tries to call "/get_planning_scene" and fails, instead of calling "get_planning_scene", which would evaluate to "/my_robot/get_planning_scene". If both nodes are in the global namespace the behaviour would not be recognized. I would expect two nodes in the same namespace to work together without explicitly configuring fully resolved namespaces.
