### PR TITLE
use /defult_planner_config to specify dfeault algorithm

### DIFF
--- a/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -127,6 +127,9 @@ public:
   /** \brief Get the name of the group this instance operates on */
   const std::string& getName() const;
 
+  /** \brief Get the ROS node handle of this instance operates on */
+  const ros::NodeHandle& getNodeHandle() const;
+
   /** \brief Get the name of the frame in which the robot is planning */
   const std::string& getPlanningFrame() const;
 

--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -1070,6 +1070,11 @@ const std::string& moveit::planning_interface::MoveGroup::getName() const
   return impl_->getOptions().group_name_;
 }
 
+const ros::NodeHandle& moveit::planning_interface::MoveGroup::getNodeHandle() const
+{
+  return impl_->getOptions().node_handle_;
+}
+
 bool moveit::planning_interface::MoveGroup::getInterfaceDescription(moveit_msgs::PlannerInterfaceDescription &desc)
 {
   return impl_->getInterfaceDescription(desc);

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -252,7 +252,19 @@ void MotionPlanningFrame::populatePlannersList(const moveit_msgs::PlannerInterfa
     for (std::size_t i = 0 ; i < desc.planner_ids.size() ; ++i)
       ui_->planning_algorithm_combo_box->addItem(QString::fromStdString(desc.planner_ids[i]));
   ui_->planning_algorithm_combo_box->insertItem(0, "<unspecified>");
-  ui_->planning_algorithm_combo_box->setCurrentIndex(0);
+
+  std::string _default_planner_config;
+  if (move_group_->getNodeHandle().getParam("default_planner_config", _default_planner_config)) {
+    int index = ui_->planning_algorithm_combo_box->findText(QString::fromStdString(_default_planner_config));
+    if (index > 0) {
+      ui_->planning_algorithm_combo_box->setCurrentIndex(index);
+    } else {
+      ui_->planning_algorithm_combo_box->setCurrentIndex(0);
+    }
+  } else {
+      std::cerr << "PlannerConfig  "<<  _default_planner_config << " is not found, use unspecified" <<  std::endl;
+    ui_->planning_algorithm_combo_box->setCurrentIndex(0);
+  }
 }
 
 void MotionPlanningFrame::populateConstraintsList()


### PR DESCRIPTION
At some point, MoveIt rviz interface uses LBKPIECE as default planner , which is very slow and hard to find the solution, in order to use more better algorithm such as RRT connect, this change enable users to specify default planner via rosparam
I'd like to use rosparma under /move_group namespace, but could not find the way to get that from rviz panel.

Yes this is very darty hack, so if someone know better solution please let me know
-  motion_planning_frame_planning: use /default_planner_config parma to specify default planning algorithm
- add getHandle to move_group_interface
