### PR TITLE
Add retime_trajectory to moveit python wrapper

### DIFF
--- a/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -127,6 +127,9 @@ public:
   /** \brief Get the name of the group this instance operates on */
   const std::string& getName() const;
 
+  /** \brief Get the RobotModel object. */
+  robot_model::RobotModelConstPtr getRobotModel() const;
+
   /** \brief Get the name of the frame in which the robot is planning */
   const std::string& getPlanningFrame() const;
 

--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -1070,6 +1070,11 @@ const std::string& moveit::planning_interface::MoveGroup::getName() const
   return impl_->getOptions().group_name_;
 }
 
+robot_model::RobotModelConstPtr moveit::planning_interface::MoveGroup::getRobotModel() const
+{
+  return impl_->getRobotModel();
+}
+
 bool moveit::planning_interface::MoveGroup::getInterfaceDescription(moveit_msgs::PlannerInterfaceDescription &desc)
 {
   return impl_->getInterfaceDescription(desc);


### PR DESCRIPTION
This makes IterativeParabolicTimeParameterization available via the Python interface to move_group.

The changes to the MoveGroup class were just needed to get access to the RobotModel.  Without that I couldn't create a new RobotState instance.
