### PR TITLE
Adding tf dep fixes #572

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(Boost REQUIRED COMPONENTS date_time filesystem program_options syst
 find_package(catkin REQUIRED COMPONENTS
   moveit_ros_planning
   moveit_ros_warehouse
+  tf
   eigen_conversions
   roscpp
   rosconsole

--- a/benchmarks/package.xml
+++ b/benchmarks/package.xml
@@ -17,12 +17,14 @@
 
   <build_depend>moveit_ros_planning</build_depend>
   <build_depend>moveit_ros_warehouse</build_depend>
+  <build_depend>tf</build_depend>
   <build_depend>eigen_conversions</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rosconsole</build_depend>
 
   <run_depend>moveit_ros_planning</run_depend>
   <run_depend>moveit_ros_warehouse</run_depend>
+  <run_depend>tf</run_depend>
   <run_depend>eigen_conversions</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rosconsole</run_depend>


### PR DESCRIPTION
Not sure if the order matters, I've inserted it higher up to be sure, after the `moveit_ros*` deps.
