### PR TITLE
Revert "Visualize convex mesh"

### DIFF
--- a/perception/point_containment_filter/include/moveit/point_containment_filter/shape_mask.h
+++ b/perception/point_containment_filter/include/moveit/point_containment_filter/shape_mask.h
@@ -48,7 +48,6 @@
 #include <boost/thread/mutex.hpp>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
-#include <ros/ros.h>
 
 namespace point_containment_filter
 {
@@ -123,9 +122,6 @@ private:
     }
   };
 
-  void visualizeScaledBodies(const bodies::Body* body, point_containment_filter::ShapeHandle sh, int id,
-          const std::string & frame_id);
-
   /** \brief Free memory. */
   void freeMemory();
 
@@ -137,10 +133,6 @@ private:
   std::set<SeeShape, SortBodies> bodies_;
   std::map<ShapeHandle, std::set<SeeShape, SortBodies>::iterator> used_handles_;
   std::vector<bodies::BoundingSphere> bspheres_;
-
-  bool visualize_scaled_bodies_;
-  ros::NodeHandle param_nh_;
-  ros::Publisher pub_vis_;
 };
 
 }


### PR DESCRIPTION
Reverts ros-planning/moveit_ros#574 - looks like some of the corresponding changes required in geometric_shapes were not put in. 
