### PR TITLE
  Kinematics Base changes in moveit_core

### DIFF
--- a/robot_interaction/include/moveit/robot_interaction/kinematic_options.h
+++ b/robot_interaction/include/moveit/robot_interaction/kinematic_options.h
@@ -62,9 +62,11 @@ struct KinematicOptions
     STATE_VALIDITY_CALLBACK     = 0x00000004, // state_validity_callback_
     LOCK_REDUNDANT_JOINTS       = 0x00000008, // options_.lock_redundant_joints
     RETURN_APPROXIMATE_SOLUTION = 0x00000010, // options_.return_approximate_solution
+    DISCRETIZATION_METHOD       = 0x00000020, // options_.discretization_method
 
     ALL_QUERY_OPTIONS           = LOCK_REDUNDANT_JOINTS |
-                                  RETURN_APPROXIMATE_SOLUTION,
+                                  RETURN_APPROXIMATE_SOLUTION |
+                                  DISCRETIZATION_METHOD,
     ALL                         = 0x7fffffff
   };
 

--- a/robot_interaction/src/kinematic_options.cpp
+++ b/robot_interaction/src/kinematic_options.cpp
@@ -90,7 +90,8 @@ void robot_interaction::KinematicOptions::setOptions(
   // kinematics::KinematicsQueryOptions
   #define QO_FIELDS(F) \
     F(bool, lock_redundant_joints, LOCK_REDUNDANT_JOINTS) \
-    F(bool, return_approximate_solution, RETURN_APPROXIMATE_SOLUTION)
+    F(bool, return_approximate_solution, RETURN_APPROXIMATE_SOLUTION) \
+    F(int, discretization_method, DISCRETIZATION_METHOD)
 
 
   // This structure should be identical to kinematics::KinematicsQueryOptions


### PR DESCRIPTION
This PR adds a **discretization method** entry to the **kinematic_options** struct in robot_interaction in order to accommodate the corresponding changes made to the **kinematics::KinematicsBase** interface found under moveit_core, [see here for more details on this change](https://github.com/ros-planning/moveit_core/pull/231)
