### PR TITLE
Fixed bug(?) in move_group::MoveGroupKinematicsService::computeIK link name selection

### DIFF
--- a/move_group/src/default_capabilities/kinematics_service_capability.cpp
+++ b/move_group/src/default_capabilities/kinematics_service_capability.cpp
@@ -81,7 +81,7 @@ void move_group::MoveGroupKinematicsService::computeIK(moveit_msgs::PositionIKRe
     if (req.pose_stamped_vector.empty() || req.pose_stamped_vector.size() == 1)
     {
       geometry_msgs::PoseStamped req_pose = req.pose_stamped_vector.empty() ? req.pose_stamped : req.pose_stamped_vector[0];
-      std::string ik_link = req.pose_stamped_vector.empty() ? (req.ik_link_names.empty() ? "" : req.ik_link_names[0]) : req.ik_link_name;
+      std::string ik_link = (!req.pose_stamped_vector.empty()) ? (req.ik_link_names.empty() ? "" : req.ik_link_names[0]) : req.ik_link_name;
 
       if (performTransform(req_pose, default_frame))
       {


### PR DESCRIPTION
In the master version, if the pose_stamped_vector is empty then the link_names vector is used (and vice-versa, if the pose_stamped vector is non-empty then the link_name field is used), which seems wrong.

I noticed this while sending a request with one pose in the pose vector and a dummy name in the link_names vector. I expected MoveIt! to signal an error, but it didn't; it treated the IK request as referring to the tip of the planning group, regardless of what I had in the link_names vector (which, if I have an attached body, may not be consistent with defaulting to the planning group tip).

As a result of the proposed change, MoveIt! will now return an IK solution not found error-- should this be an invalid link name instead, or should it default, in case of an unrecognized link/attached object name, default to the planning group tip?
