### PR TITLE
adding set_num_planning_attempts to python interface

### DIFF
--- a/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -533,6 +533,7 @@ static void wrap_move_group_interface()
   MoveGroupClass.def("set_planning_time", &MoveGroupWrapper::setPlanningTime);
   MoveGroupClass.def("get_planning_time", &MoveGroupWrapper::getPlanningTime);
   MoveGroupClass.def("set_planner_id", &MoveGroupWrapper::setPlannerId);
+  MoveGroupClass.def("set_num_planning_attempts", &MoveGroupWrapper::setNumPlanningAttempts);
   MoveGroupClass.def("compute_plan", &MoveGroupWrapper::getPlanPython);
   MoveGroupClass.def("compute_cartesian_path", &MoveGroupWrapper::computeCartesianPathPython);
   MoveGroupClass.def("set_support_surface_name", &MoveGroupWrapper::setSupportSurfaceName);


### PR DESCRIPTION
This is a simple one line addition that allows the python interface to use the C++ setNumPlanningAttempts function. This is an extremely simple but useful feature that was missing from the python api. I've tested the change with a Baxter robot and it works fine. I will also create a pull request in the moveit_commander repository so that the python wrapper can use the new function. This pull request addresses issue https://github.com/ros-planning/moveit_commander/issues/34 . This pull request: https://github.com/ros-planning/moveit_commander/pull/35 also needs to be merged into moveit_commander for the api to work properly.
