### PR TITLE
Cleaned up locks and callbacks in perception so OcTree subclass is not needed

### DIFF
--- a/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
+++ b/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
@@ -105,7 +105,7 @@ bool DepthImageOctomapUpdater::setParams(XmlRpc::XmlRpcValue &params)
 bool DepthImageOctomapUpdater::initialize()
 {
   tf_ = monitor_->getTFClient();
-  free_space_updater_.reset(new LazyFreeSpaceUpdater(tree_));
+  free_space_updater_.reset(new LazyFreeSpaceUpdater(tree_, boost::bind(&OccupancyMapMonitor::triggerUpdateCallback, monitor_)));
 
   // create our mesh filter
   mesh_filter_.reset(new mesh_filter::MeshFilter<mesh_filter::StereoCameraModel>(mesh_filter::MeshFilterBase::TransformCallback(),
@@ -513,7 +513,7 @@ void DepthImageOctomapUpdater::depthImageCallback(const sensor_msgs::ImageConstP
     ROS_ERROR("Internal error while updating octree");
   }
   tree_->unlockWrite();
-  tree_->triggerUpdateCallback();
+  monitor_->triggerUpdateCallback();
 
   // at this point we still have not freed the space
   free_space_updater_->pushLazyUpdate(occupied_cells_ptr, model_cells_ptr, sensor_origin);

--- a/perception/lazy_free_space_updater/include/moveit/lazy_free_space_updater/lazy_free_space_updater.h
+++ b/perception/lazy_free_space_updater/include/moveit/lazy_free_space_updater/lazy_free_space_updater.h
@@ -48,7 +48,7 @@ class LazyFreeSpaceUpdater
 {
 public:
 
-  LazyFreeSpaceUpdater(const OccMapTreePtr &tree, unsigned int max_batch_size = 10);
+  LazyFreeSpaceUpdater(const OccMapTreePtr &tree, const boost::function<void()> &update_callback, unsigned int max_batch_size = 10);
   ~LazyFreeSpaceUpdater();
 
   void pushLazyUpdate(octomap::KeySet *occupied_cells, octomap::KeySet *model_cells, const octomap::point3d &sensor_origin);
@@ -66,10 +66,23 @@ private:
   void lazyUpdateThread();
   void processThread();
 
+  void triggerUpdateCallback()
+  {
+    if (update_callback_)
+      update_callback_();
+  }
+
+  /** @brief Set the callback to trigger when updates are received */
+  void setUpdateCallback(const boost::function<void()> &update_callback)
+  {
+    update_callback_ = update_callback;
+  }
+
   OccMapTreePtr tree_;
   bool running_;
   std::size_t max_batch_size_;
   double max_sensor_delta_;
+  boost::function<void()> update_callback_;
 
   std::deque<octomap::KeySet*> occupied_cells_sets_;
   std::deque<octomap::KeySet*> model_cells_sets_;

--- a/perception/lazy_free_space_updater/include/moveit/lazy_free_space_updater/lazy_free_space_updater.h
+++ b/perception/lazy_free_space_updater/include/moveit/lazy_free_space_updater/lazy_free_space_updater.h
@@ -38,6 +38,7 @@
 #define MOVEIT_OCCUPANCY_MAP_MONITOR_LAZY_FREE_SPACE_UPDATER_
 
 #include <moveit/occupancy_map_monitor/occupancy_map.h>
+#include <moveit/occupancy_map_monitor/occupancy_map_monitor.h>
 #include <boost/thread.hpp>
 #include <deque>
 
@@ -48,7 +49,7 @@ class LazyFreeSpaceUpdater
 {
 public:
 
-  LazyFreeSpaceUpdater(const OccMapTreePtr &tree, const boost::function<void()> &update_callback, unsigned int max_batch_size = 10);
+  LazyFreeSpaceUpdater(const OccMapTreePtr &tree, OccupancyMapMonitor *monitor, unsigned int max_batch_size = 10);
   ~LazyFreeSpaceUpdater();
 
   void pushLazyUpdate(octomap::KeySet *occupied_cells, octomap::KeySet *model_cells, const octomap::point3d &sensor_origin);
@@ -66,23 +67,11 @@ private:
   void lazyUpdateThread();
   void processThread();
 
-  void triggerUpdateCallback()
-  {
-    if (update_callback_)
-      update_callback_();
-  }
-
-  /** @brief Set the callback to trigger when updates are received */
-  void setUpdateCallback(const boost::function<void()> &update_callback)
-  {
-    update_callback_ = update_callback;
-  }
-
   OccMapTreePtr tree_;
+  OccupancyMapMonitor *monitor_;
   bool running_;
   std::size_t max_batch_size_;
   double max_sensor_delta_;
-  boost::function<void()> update_callback_;
 
   std::deque<octomap::KeySet*> occupied_cells_sets_;
   std::deque<octomap::KeySet*> model_cells_sets_;

--- a/perception/lazy_free_space_updater/src/lazy_free_space_updater.cpp
+++ b/perception/lazy_free_space_updater/src/lazy_free_space_updater.cpp
@@ -40,11 +40,12 @@
 namespace occupancy_map_monitor
 {
 
-LazyFreeSpaceUpdater::LazyFreeSpaceUpdater(const OccMapTreePtr &tree, unsigned int max_batch_size) :
+LazyFreeSpaceUpdater::LazyFreeSpaceUpdater(const OccMapTreePtr &tree, const boost::function<void()> &update_callback, unsigned int max_batch_size) :
   tree_(tree),
   running_(true),
   max_batch_size_(max_batch_size),
   max_sensor_delta_(1e-3), // 1mm
+  update_callback_(update_callback),
   process_occupied_cells_set_(NULL),
   process_model_cells_set_(NULL),
   update_thread_(boost::bind(&LazyFreeSpaceUpdater::lazyUpdateThread, this)),
@@ -179,7 +180,7 @@ void LazyFreeSpaceUpdater::processThread()
       ROS_ERROR("Internal error while updating octree");
     }
     tree_->unlockWrite();
-    tree_->triggerUpdateCallback();
+    triggerUpdateCallback();
 
     ROS_DEBUG("Marked free cells in %lf ms", (ros::WallTime::now() - start).toSec() * 1000.0);
 

--- a/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map.h
+++ b/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map.h
@@ -39,72 +39,13 @@
 
 #include <octomap/octomap.h>
 #include <boost/shared_ptr.hpp>
-#include <boost/thread/shared_mutex.hpp>
-#include <boost/function.hpp>
 
 namespace occupancy_map_monitor
 {
 
 typedef octomap::OcTreeNode OccMapNode;
-
-class OccMapTree : public octomap::OcTree
-{
-public:
-
-  OccMapTree(double resolution) : octomap::OcTree(resolution)
-  {
-  }
-
-  OccMapTree(const std::string &filename) : octomap::OcTree(filename)
-  {
-  }
-
-  /** @brief lock the underlying octree. it will not be read or written by the
-   *  monitor until unlockTree() is called */
-  void lockRead()
-  {
-    tree_mutex_.lock_shared();
-  }
-
-  /** @brief unlock the underlying octree. */
-  void unlockRead()
-  {
-    tree_mutex_.unlock_shared();
-  }
-
-  /** @brief lock the underlying octree. it will not be read or written by the
-   *  monitor until unlockTree() is called */
-  void lockWrite()
-  {
-    tree_mutex_.lock();
-  }
-
-  /** @brief unlock the underlying octree. */
-  void unlockWrite()
-  {
-    tree_mutex_.unlock();
-  }
-
-  typedef boost::shared_lock<boost::shared_mutex> ReadLock;
-  typedef boost::unique_lock<boost::shared_mutex> WriteLock;
-
-  ReadLock reading()
-  {
-    return ReadLock(tree_mutex_);
-  }
-
-  WriteLock writing()
-  {
-    return WriteLock(tree_mutex_);
-  }
-
-private:
-  boost::shared_mutex tree_mutex_;
-  
-};
-
-typedef boost::shared_ptr<OccMapTree> OccMapTreePtr;
-typedef boost::shared_ptr<const OccMapTree> OccMapTreeConstPtr;
+typedef boost::shared_ptr<octomap::OcTree> OccMapTreePtr;
+typedef boost::shared_ptr<const octomap::OcTree> OccMapTreeConstPtr;
 
 }
 

--- a/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map.h
+++ b/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map.h
@@ -98,21 +98,9 @@ public:
     return WriteLock(tree_mutex_);
   }
 
-  void triggerUpdateCallback(void)
-  {
-    if (update_callback_)
-      update_callback_();
-  }
-
-  /** @brief Set the callback to trigger when updates are received */
-  void setUpdateCallback(const boost::function<void()> &update_callback)
-  {
-    update_callback_ = update_callback;
-  }
-
 private:
   boost::shared_mutex tree_mutex_;
-  boost::function<void()> update_callback_;
+  
 };
 
 typedef boost::shared_ptr<OccMapTree> OccMapTreePtr;

--- a/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
+++ b/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
@@ -107,10 +107,17 @@ public:
   /** \brief Forget about this shape handle and the shapes it corresponds to */
   void forgetShape(ShapeHandle handle);
 
+  /** @brief Signal that the occupancy map has been updated */
+  void triggerUpdateCallback()
+  {
+    if (update_callback_)
+      update_callback_();
+  }
+
   /** @brief Set the callback to trigger when updates to the maintained octomap are received */
   void setUpdateCallback(const boost::function<void()> &update_callback)
   {
-    tree_->setUpdateCallback(update_callback);
+    update_callback_ = update_callback;
   }
 
   void setTransformCacheCallback(const TransformCacheProvider &transform_cache_callback);
@@ -146,6 +153,7 @@ private:
   std::vector<OccupancyMapUpdaterPtr> map_updaters_;
   std::vector<std::map<ShapeHandle, ShapeHandle> > mesh_handles_;
   TransformCacheProvider transform_cache_callback_;
+  boost::function<void()> update_callback_;
   bool debug_info_;
 
   std::size_t mesh_handle_count_;

--- a/perception/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/perception/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -84,7 +84,7 @@ void OccupancyMapMonitor::initialize()
   if (!tf_ && !map_frame_.empty())
     ROS_WARN("Target frame specified but no TF instance specified. No transforms will be applied to received data.");
 
-  tree_.reset(new OccMapTree(map_resolution_));
+  tree_.reset(new octomap::OcTree(map_resolution_));
   tree_const_ = tree_;
 
   XmlRpc::XmlRpcValue sensor_list;
@@ -283,16 +283,15 @@ bool OccupancyMapMonitor::getShapeTransformCache(std::size_t index, const std::s
 bool OccupancyMapMonitor::saveMapCallback(moveit_msgs::SaveMap::Request& request, moveit_msgs::SaveMap::Response& response)
 {
   ROS_INFO("Writing map to %s", request.filename.c_str());
-  tree_->lockRead();
   try
   {
+    ReadLock lock = readingMap();
     response.success = tree_->writeBinary(request.filename);
   }
   catch (...)
   {
     response.success = false;
   }
-  tree_->unlockRead();
   return true;
 }
 
@@ -301,9 +300,9 @@ bool OccupancyMapMonitor::loadMapCallback(moveit_msgs::LoadMap::Request& request
   ROS_INFO("Reading map from %s", request.filename.c_str());
 
   /* load the octree from disk */
-  tree_->lockWrite();
   try
   {
+    WriteLock lock = writingMap();
     response.success = tree_->readBinary(request.filename);
   }
   catch (...)
@@ -311,7 +310,6 @@ bool OccupancyMapMonitor::loadMapCallback(moveit_msgs::LoadMap::Request& request
     ROS_ERROR("Failed to load map from file");
     response.success = false;
   }
-  tree_->unlockWrite();
 
   return true;
 }

--- a/perception/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/perception/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -174,6 +174,7 @@ void OccupancyMapMonitor::addUpdater(const OccupancyMapUpdaterPtr &updater)
   {
     map_updaters_.push_back(updater);
     updater->publishDebugInformation(debug_info_);
+    updater->publishDebugInformation(debug_info_);
     if (map_updaters_.size() > 1)
     {
       mesh_handles_.resize(map_updaters_.size());

--- a/perception/occupancy_map_monitor/src/occupancy_map_server.cpp
+++ b/perception/occupancy_map_monitor/src/occupancy_map_server.cpp
@@ -48,9 +48,9 @@ static void publishOctomap(ros::Publisher *octree_binary_pub, occupancy_map_moni
   map.header.frame_id = server->getMapFrame();
   map.header.stamp = ros::Time::now();
 
-  server->getOcTreePtr()->lockRead();
   try
   {
+    occupancy_map_monitor::ReadLock lock = server->readingMap();
     if (!octomap_msgs::binaryMapToMsgData(*server->getOcTreePtr(), map.data))
       ROS_ERROR_THROTTLE(1, "Could not generate OctoMap message");
   }
@@ -58,7 +58,6 @@ static void publishOctomap(ros::Publisher *octree_binary_pub, occupancy_map_moni
   {
     ROS_ERROR_THROTTLE(1, "Exception thrown while generating OctoMap message");
   }
-  server->getOcTreePtr()->unlockRead();
 
   octree_binary_pub->publish(map);
 }

--- a/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -332,7 +332,7 @@ void PointCloudOctomapUpdater::cloudMsgCallback(const sensor_msgs::PointCloud2::
   }
   tree_->unlockWrite();
   ROS_DEBUG("Processed point cloud in %lf ms", (ros::WallTime::now() - start).toSec() * 1000.0);
-  tree_->triggerUpdateCallback();
+  monitor_->triggerUpdateCallback();
 
   if (filtered_cloud)
   {

--- a/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -311,8 +311,8 @@ void planning_scene_monitor::PlanningSceneMonitor::scenePublishingThread()
   // publish the full planning scene
   moveit_msgs::PlanningScene msg;
   {
-    occupancy_map_monitor::OccMapTree::ReadLock lock;
-    if (octomap_monitor_) lock = octomap_monitor_->getOcTreePtr()->reading();
+    occupancy_map_monitor::ReadLock lock;
+    if (octomap_monitor_) lock = octomap_monitor_->readingMap();
     scene_->getPlanningSceneMsg(msg);
   }
   planning_scene_publisher_.publish(msg);
@@ -336,8 +336,8 @@ void planning_scene_monitor::PlanningSceneMonitor::scenePublishingThread()
             is_full = true;
           else
           {
-            occupancy_map_monitor::OccMapTree::ReadLock lock;
-            if (octomap_monitor_) lock = octomap_monitor_->getOcTreePtr()->reading();
+            occupancy_map_monitor::ReadLock lock;
+            if (octomap_monitor_) lock = octomap_monitor_->readingMap();
             scene_->getPlanningSceneDiffMsg(msg);
           }
           boost::recursive_mutex::scoped_lock prevent_shape_cache_updates(shape_handles_lock_); // we don't want the transform cache to update while we are potentially changing attached bodies
@@ -354,8 +354,8 @@ void planning_scene_monitor::PlanningSceneMonitor::scenePublishingThread()
           }
           if (is_full) 
           {
-            occupancy_map_monitor::OccMapTree::ReadLock lock;
-            if (octomap_monitor_) lock = octomap_monitor_->getOcTreePtr()->reading();
+            occupancy_map_monitor::ReadLock lock;
+            if (octomap_monitor_) lock = octomap_monitor_->readingMap();
             scene_->getPlanningSceneMsg(msg);
           }
           publish_msg = true;
@@ -471,9 +471,10 @@ void planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneCallback(cons
 
 void planning_scene_monitor::PlanningSceneMonitor::clearOctomap()
 {
-  octomap_monitor_->getOcTreePtr()->lockWrite();
-  octomap_monitor_->getOcTreePtr()->clear();
-  octomap_monitor_->getOcTreePtr()->unlockWrite();
+  if (octomap_monitor_){
+    occupancy_map_monitor::WriteLock lock = octomap_monitor_->writingMap();
+    octomap_monitor_->getOcTreePtr()->clear();
+  }
 }
 
 void planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneMessage(const moveit_msgs::PlanningScene& scene)
@@ -489,14 +490,9 @@ void planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneMessage(const
       last_update_time_ = ros::Time::now();
       old_scene_name = scene_->getName();
       scene_->usePlanningSceneMsg(scene);
-      if (octomap_monitor_)
+      if (!scene.is_diff && scene.world.octomap.octomap.data.empty())
       {
-        if (!scene.is_diff && scene.world.octomap.octomap.data.empty())
-        {
-          octomap_monitor_->getOcTreePtr()->lockWrite();
-          octomap_monitor_->getOcTreePtr()->clear();
-          octomap_monitor_->getOcTreePtr()->unlockWrite();
-        }
+        clearOctomap();
       }
       robot_model_ = scene_->getRobotModel();
 
@@ -555,14 +551,9 @@ void planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneWorldCallback
       last_update_time_ = ros::Time::now();
       scene_->getWorldNonConst()->clearObjects();
       scene_->processPlanningSceneWorldMsg(*world);
-      if (octomap_monitor_)
+      if (world->octomap.octomap.data.empty())
       {
-        if (world->octomap.octomap.data.empty())
-        {
-          octomap_monitor_->getOcTreePtr()->lockWrite();
-          octomap_monitor_->getOcTreePtr()->clear();
-          octomap_monitor_->getOcTreePtr()->unlockWrite();
-        }
+        clearOctomap();
       }
     }
     triggerSceneUpdateEvent(UPDATE_SCENE);
@@ -808,28 +799,28 @@ void planning_scene_monitor::PlanningSceneMonitor::lockSceneRead()
 {
   scene_update_mutex_.lock_shared();
   if (octomap_monitor_)
-    octomap_monitor_->getOcTreePtr()->lockRead();
+    octomap_monitor_->lockMapRead();
 }
 
 void planning_scene_monitor::PlanningSceneMonitor::unlockSceneRead()
 {
   scene_update_mutex_.unlock_shared();
   if (octomap_monitor_)
-    octomap_monitor_->getOcTreePtr()->unlockRead();
+    octomap_monitor_->unlockMapRead();
 }
 
 void planning_scene_monitor::PlanningSceneMonitor::lockSceneWrite()
 {
   scene_update_mutex_.lock();
   if (octomap_monitor_)
-    octomap_monitor_->getOcTreePtr()->lockWrite();
+    octomap_monitor_->lockMapWrite();
 }
 
 void planning_scene_monitor::PlanningSceneMonitor::unlockSceneWrite()
 {
   scene_update_mutex_.unlock();
   if (octomap_monitor_)
-    octomap_monitor_->getOcTreePtr()->unlockWrite();
+    octomap_monitor_->unlockMapWrite();
 }
 
 void planning_scene_monitor::PlanningSceneMonitor::startSceneMonitor(const std::string &scene_topic)
@@ -1072,16 +1063,9 @@ void planning_scene_monitor::PlanningSceneMonitor::octomapUpdateCallback()
   {
     boost::unique_lock<boost::shared_mutex> ulock(scene_update_mutex_);
     last_update_time_ = ros::Time::now();
-    octomap_monitor_->getOcTreePtr()->lockRead();
-    try
     {
+      occupancy_map_monitor::ReadLock lock = octomap_monitor_->readingMap();
       scene_->processOctomapPtr(octomap_monitor_->getOcTreePtr(), Eigen::Affine3d::Identity());
-      octomap_monitor_->getOcTreePtr()->unlockRead();
-    }
-    catch(...)
-    {
-      octomap_monitor_->getOcTreePtr()->unlockRead(); // unlock and rethrow
-      throw;
     }
   }
   triggerSceneUpdateEvent(UPDATE_GEOMETRY);


### PR DESCRIPTION
I moved the map mutex and update callback to the map monitor so that a subclass of OcTree is not needed.  I also updated perception to use the RAII style locks.
