### PR TITLE
F#276 add db state

### DIFF
--- a/perception/CMakeLists.txt
+++ b/perception/CMakeLists.txt
@@ -29,6 +29,7 @@ find_package(catkin REQUIRED COMPONENTS
   object_recognition_msgs
   cmake_modules
   sensor_msgs
+  moveit_msgs
 )
 find_package(Eigen REQUIRED)
 
@@ -55,7 +56,8 @@ catkin_package(
     ${OCTOMAP_LIBRARIES}
   CATKIN_DEPENDS
     moveit_core
-    image_transport)
+    image_transport
+    moveit_msgs)
 
 include_directories(mesh_filter/include
                     lazy_free_space_updater/include

--- a/perception/package.xml
+++ b/perception/package.xml
@@ -16,7 +16,7 @@
   <url type="bugtracker">https://github.com/ros-planning/moveit_ros/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit_ros</url>
 
-  <buildtool_depend>catkin</buildtool_depend> 
+  <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>moveit_core</build_depend>
   <build_depend>roscpp</build_depend>
@@ -34,6 +34,7 @@
   <build_depend>cv_bridge</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>moveit_msgs</build_depend>
 
   <run_depend>moveit_core</run_depend>
   <run_depend>roscpp</run_depend>
@@ -50,6 +51,7 @@
   <run_depend>opengl</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>moveit_msgs</run_depend>
 
   <export>
     <moveit_ros_perception plugin="${prefix}/pointcloud_octomap_updater_plugin_description.xml"/>

--- a/perception/semantic_world/CMakeLists.txt
+++ b/perception/semantic_world/CMakeLists.txt
@@ -2,7 +2,7 @@ set(CMAKE_BUILD_TYPE Debug)
 set(MOVEIT_LIB_NAME moveit_semantic_world)
 
 add_library(${MOVEIT_LIB_NAME} src/semantic_world.cpp)
-add_dependencies(${MOVEIT_LIB_NAME} moveit_msgs_generate_messages_cpp )
+add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OpenCV_LIBRARIES})
 
 install(DIRECTORY include/ DESTINATION include)

--- a/perception/semantic_world/CMakeLists.txt
+++ b/perception/semantic_world/CMakeLists.txt
@@ -2,6 +2,7 @@ set(CMAKE_BUILD_TYPE Debug)
 set(MOVEIT_LIB_NAME moveit_semantic_world)
 
 add_library(${MOVEIT_LIB_NAME} src/semantic_world.cpp)
+add_dependencies(${MOVEIT_LIB_NAME} moveit_msgs_generate_messages_cpp )
 target_link_libraries(${MOVEIT_LIB_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OpenCV_LIBRARIES})
 
 install(DIRECTORY include/ DESTINATION include)

--- a/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
+++ b/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
@@ -60,9 +60,9 @@ public:
     current_state_monitor_ = planning_interface::getSharedStateMonitor(robot_model_, planning_interface::getSharedTF());
   }
 
-  std::string getRobotName() const
+  const char *getRobotName() const
   {
-    return robot_model_->getName();
+    return robot_model_->getName().c_str();
   }
 
   bp::list getJointNames() const

--- a/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
+++ b/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp
@@ -60,6 +60,11 @@ public:
     current_state_monitor_ = planning_interface::getSharedStateMonitor(robot_model_, planning_interface::getSharedTF());
   }
 
+  std::string getRobotName() const
+  {
+    return robot_model_->getName();
+  }
+
   bp::list getJointNames() const
   {
     return py_bindings_tools::listFromString(robot_model_->getJointModelNames());
@@ -100,12 +105,12 @@ public:
     else
       return bp::list();
   }
-  
+
   bp::list getGroupNames() const
   {
     return py_bindings_tools::listFromString(robot_model_->getJointModelGroupNames());
   }
-  
+
   bp::list getJointLimits(const std::string &name) const
   {
     bp::list result;
@@ -123,12 +128,12 @@ public:
     }
     return result;
   }
-  
+
   const char* getPlanningFrame() const
   {
     return robot_model_->getModelFrame().c_str();
   }
-  
+
   bp::list getLinkPose(const std::string &name)
   {
     bp::list l;
@@ -152,7 +157,7 @@ public:
     }
     return l;
   }
-  
+
   bp::list getCurrentJointValues(const std::string &name)
   {
     bp::list l;
@@ -167,10 +172,10 @@ public:
       for (unsigned int i = 0 ; i < sz ; ++i)
         l.append(pos[i]);
     }
-    
+
     return l;
   }
-  
+
   bool ensureCurrentState(double wait = 1.0)
   {
     if (!current_state_monitor_)
@@ -178,7 +183,7 @@ public:
       ROS_ERROR("Unable to get current robot state");
       return false;
     }
-    
+
     // if needed, start the monitor and wait up to 1 second for a full robot state
     if (!current_state_monitor_->isActive())
     {
@@ -198,14 +203,14 @@ public:
     robot_state::robotStateToRobotStateMsg(*s, msg);
     return py_bindings_tools::serializeMsg(msg);
   }
-  
+
   bp::dict getCurrentVariableValues()
   {
     bp::dict d;
-    
+
     if (!ensureCurrentState())
       return d;
-    
+
     const std::map<std::string, double> &vars = current_state_monitor_->getCurrentStateValues();
     for (std::map<std::string, double>::const_iterator it = vars.begin() ; it != vars.end() ; ++it)
       d[it->first] = it->second;
@@ -249,6 +254,7 @@ static void wrap_robot_interface()
   RobotClass.def("get_current_joint_values",  &RobotInterfacePython::getCurrentJointValues);
   RobotClass.def("get_robot_root_link", &RobotInterfacePython::getRobotRootLink);
   RobotClass.def("has_group", &RobotInterfacePython::hasGroup);
+  RobotClass.def("get_robot_name", &RobotInterfacePython::getRobotName);
 }
 
 BOOST_PYTHON_MODULE(_moveit_robot_interface)

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_states.cpp
@@ -148,7 +148,7 @@ void MotionPlanningFrame::saveRobotStateButtonClicked(const robot_state::RobotSt
         {
           try
           {
-            robot_state_storage_->addRobotState(msg, name);
+            robot_state_storage_->addRobotState(msg, name, planning_display_->getRobotModel()->getName());
           }
           catch (std::runtime_error &ex)
           {

--- a/warehouse/warehouse/CMakeLists.txt
+++ b/warehouse/warehouse/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(MOVEIT_LIB_NAME moveit_warehouse)
 
-add_library(${MOVEIT_LIB_NAME} 
+add_library(${MOVEIT_LIB_NAME}
   src/moveit_message_storage.cpp
   src/planning_scene_storage.cpp
   src/planning_scene_world_storage.cpp
@@ -25,14 +25,18 @@ target_link_libraries(moveit_warehouse_save_as_text ${catkin_LIBRARIES} ${MOVEIT
 add_executable(moveit_init_demo_warehouse src/initialize_demo_db.cpp)
 target_link_libraries(moveit_init_demo_warehouse ${catkin_LIBRARIES} ${MOVEIT_LIB_NAME} ${Boost_LIBRARIES})
 
+add_executable(moveit_warehouse_services src/warehouse_services.cpp)
+target_link_libraries(moveit_warehouse_services ${catkin_LIBRARIES} ${MOVEIT_LIB_NAME} ${Boost_LIBRARIES})
+
 install(
   TARGETS
-    ${MOVEIT_LIB_NAME} 
+    ${MOVEIT_LIB_NAME}
     moveit_save_to_warehouse
     moveit_warehouse_broadcast
     moveit_warehouse_import_from_text
     moveit_warehouse_save_as_text
     moveit_init_demo_warehouse
+    moveit_warehouse_services
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 install(DIRECTORY include/ DESTINATION include)

--- a/warehouse/warehouse/src/warehouse_services.cpp
+++ b/warehouse/warehouse/src/warehouse_services.cpp
@@ -50,7 +50,7 @@ bool storeState(moveit_msgs::SaveRobotStateToWarehouse::Request&  request,
                  moveit_warehouse::RobotStateStorage* rs)
 {
   const moveit_msgs::RobotState& state = request.state;
-  if ("" == request.name)
+  if (request.name.empty())
   {
     ROS_ERROR("You must specify a name to store a state");
     return response.success = false;
@@ -63,7 +63,7 @@ bool listStates(moveit_msgs::ListRobotStatesInWarehouse::Request&  request,
                   moveit_msgs::ListRobotStatesInWarehouse::Response& response,
                   moveit_warehouse::RobotStateStorage* rs)
 {
-  if ("" == request.regex)
+  if (request.regex.empty())
   {
     rs->getKnownRobotStates(response.states, request.robot);
   }

--- a/warehouse/warehouse/src/warehouse_services.cpp
+++ b/warehouse/warehouse/src/warehouse_services.cpp
@@ -1,0 +1,176 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Dan Greenwalducan */
+
+#include <moveit/warehouse/planning_scene_storage.h>
+#include <moveit/warehouse/constraints_storage.h>
+#include <moveit/warehouse/state_storage.h>
+#include <moveit/planning_scene_monitor/planning_scene_monitor.h>
+#include <boost/algorithm/string/join.hpp>
+#include <boost/program_options/cmdline.hpp>
+#include <boost/program_options/options_description.hpp>
+#include <boost/program_options/parsers.hpp>
+#include <boost/program_options/variables_map.hpp>
+#include <ros/ros.h>
+#include <moveit_msgs/SaveRobotStateToWarehouse.h>
+#include <moveit_msgs/ListRobotStatesInWarehouse.h>
+#include <moveit_msgs/GetRobotStateFromWarehouse.h>
+#include <moveit_msgs/CheckIfRobotStateExistsInWarehouse.h>
+
+static const std::string ROBOT_DESCRIPTION="robot_description";
+
+bool store_state(moveit_msgs::SaveRobotStateToWarehouse::Request&  request,
+                 moveit_msgs::SaveRobotStateToWarehouse::Response& response,
+                 moveit_warehouse::RobotStateStorage* rs)
+{
+  const moveit_msgs::RobotState& state = request.state;
+  if ("" == request.name)
+  {
+    ROS_ERROR("You must specify a name to store a state");
+    return response.success = false;
+  }
+  rs->addRobotState(request.state, request.name, request.robot);
+  return response.success = true;
+}
+
+bool list_states(moveit_msgs::ListRobotStatesInWarehouse::Request&  request,
+                  moveit_msgs::ListRobotStatesInWarehouse::Response& response,
+                  moveit_warehouse::RobotStateStorage* rs)
+{
+  if ("" == request.regex)
+  {
+    rs->getKnownRobotStates(response.states, request.robot);
+  }
+  else
+  {
+    rs->getKnownRobotStates(request.regex, response.states, request.robot);
+  }
+  return true;
+}
+
+bool has_state(moveit_msgs::CheckIfRobotStateExistsInWarehouse::Request&  request,
+               moveit_msgs::CheckIfRobotStateExistsInWarehouse::Response& response,
+               moveit_warehouse::RobotStateStorage* rs)
+{
+  response.exists = rs->hasRobotState(request.name, request.robot);
+  return true;
+}
+
+bool get_state(moveit_msgs::GetRobotStateFromWarehouse::Request&  request,
+               moveit_msgs::GetRobotStateFromWarehouse::Response& response,
+               moveit_warehouse::RobotStateStorage* rs)
+{
+  moveit_warehouse::RobotStateWithMetadata state_buffer;
+  rs->getRobotState(state_buffer, request.name, request.robot);
+  response.state = static_cast<const moveit_msgs::RobotState&>(*state_buffer);
+  return true;
+}
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "moveit_warehouse_services");
+
+  boost::program_options::options_description desc;
+  desc.add_options()
+    ("help", "Show help message")
+    ("host", boost::program_options::value<std::string>(), "Host for the MongoDB.")
+    ("port", boost::program_options::value<std::size_t>(), "Port for the MongoDB.");
+
+  boost::program_options::variables_map vm;
+  boost::program_options::store(boost::program_options::parse_command_line(argc, argv, desc), vm);
+  boost::program_options::notify(vm);
+
+  if (vm.count("help"))
+  {
+    std::cout << desc << std::endl;
+    return 1;
+  }
+
+  //  TODO(dg-shadow) check that host + port available. check db is working
+
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+
+  moveit_warehouse::RobotStateStorage rs(vm.count("host") ? vm["host"].as<std::string>() : "",
+                                         vm.count("port") ? vm["port"].as<std::size_t>() : 0);
+  std::vector<std::string> names;
+  rs.getKnownRobotStates(names);
+  if (names.empty())
+    ROS_INFO("There are no previously stored robot states");
+  else
+  {
+    ROS_INFO("Previously stored robot states:");
+    for (std::size_t i = 0 ; i < names.size() ; ++i)
+      ROS_INFO(" * %s", names[i].c_str());
+  }
+
+  boost::function<bool(moveit_msgs::SaveRobotStateToWarehouse::Request&  request,
+                       moveit_msgs::SaveRobotStateToWarehouse::Response& response)>
+    save_cb = boost::bind(&store_state, _1, _2, &rs);
+
+  boost::function<bool(moveit_msgs::ListRobotStatesInWarehouse::Request&  request,
+                       moveit_msgs::ListRobotStatesInWarehouse::Response& response)>
+    list_cb = boost::bind(&list_states, _1, _2, &rs);
+
+  boost::function<bool(moveit_msgs::GetRobotStateFromWarehouse::Request&  request,
+                       moveit_msgs::GetRobotStateFromWarehouse::Response& response)>
+    get_cb = boost::bind(&get_state, _1, _2, &rs);
+
+  boost::function<bool(moveit_msgs::CheckIfRobotStateExistsInWarehouse::Request&  request,
+                       moveit_msgs::CheckIfRobotStateExistsInWarehouse::Response& response)>
+    has_cb = boost::bind(&has_state, _1, _2, &rs);
+
+
+
+  ros::NodeHandle node("~");
+  ros::ServiceServer save_state_server  = node.advertiseService("save_robot_state",  save_cb);
+  ros::ServiceServer list_states_server = node.advertiseService("list_robot_states", list_cb);
+  ros::ServiceServer get_state_server   = node.advertiseService("get_robot_state",   get_cb);
+  ros::ServiceServer has_state_server   = node.advertiseService("has_robot_state",   has_cb);
+
+//  ros::Subscriber state_sub = nh.subscribe("robot_state", 100, save_cb);
+/*
+  std::vector<std::string> topics; psm.getMonitoredTopics(topics);
+  ROS_INFO_STREAM("Listening for scene updates on topics " <<
+  boost::algorithm::join(topics, ", ")); ROS_INFO_STREAM("Listening
+  for planning requests on topic " << mplan_req_sub.getTopic());
+  ROS_INFO_STREAM("Listening for named constraints on topic " <<
+  constr_sub.getTopic()); ROS_INFO_STREAM("Listening for states on
+  topic " << state_sub.getTopic());
+
+*/
+  ros::waitForShutdown();
+  return 0;
+}

--- a/warehouse/warehouse/src/warehouse_services.cpp
+++ b/warehouse/warehouse/src/warehouse_services.cpp
@@ -34,14 +34,8 @@
 
 /* Author: Dan Greenwald */
 
-
-#include <moveit/warehouse/state_storage.h>
-#include <boost/program_options/cmdline.hpp>
-#include <boost/program_options/options_description.hpp>
-#include <boost/program_options/parsers.hpp>
-#include <boost/program_options/variables_map.hpp>
-
 #include <ros/ros.h>
+#include <moveit/warehouse/state_storage.h>
 #include <moveit_msgs/SaveRobotStateToWarehouse.h>
 #include <moveit_msgs/ListRobotStatesInWarehouse.h>
 #include <moveit_msgs/GetRobotStateFromWarehouse.h>

--- a/warehouse/warehouse/src/warehouse_services.cpp
+++ b/warehouse/warehouse/src/warehouse_services.cpp
@@ -45,7 +45,7 @@
 
 static const std::string ROBOT_DESCRIPTION="robot_description";
 
-bool store_state(moveit_msgs::SaveRobotStateToWarehouse::Request&  request,
+bool storeState(moveit_msgs::SaveRobotStateToWarehouse::Request&  request,
                  moveit_msgs::SaveRobotStateToWarehouse::Response& response,
                  moveit_warehouse::RobotStateStorage* rs)
 {
@@ -59,7 +59,7 @@ bool store_state(moveit_msgs::SaveRobotStateToWarehouse::Request&  request,
   return response.success = true;
 }
 
-bool list_states(moveit_msgs::ListRobotStatesInWarehouse::Request&  request,
+bool listStates(moveit_msgs::ListRobotStatesInWarehouse::Request&  request,
                   moveit_msgs::ListRobotStatesInWarehouse::Response& response,
                   moveit_warehouse::RobotStateStorage* rs)
 {
@@ -74,7 +74,7 @@ bool list_states(moveit_msgs::ListRobotStatesInWarehouse::Request&  request,
   return true;
 }
 
-bool has_state(moveit_msgs::CheckIfRobotStateExistsInWarehouse::Request&  request,
+bool hasState(moveit_msgs::CheckIfRobotStateExistsInWarehouse::Request&  request,
                moveit_msgs::CheckIfRobotStateExistsInWarehouse::Response& response,
                moveit_warehouse::RobotStateStorage* rs)
 {
@@ -82,7 +82,7 @@ bool has_state(moveit_msgs::CheckIfRobotStateExistsInWarehouse::Request&  reques
   return true;
 }
 
-bool get_state(moveit_msgs::GetRobotStateFromWarehouse::Request&  request,
+bool getState(moveit_msgs::GetRobotStateFromWarehouse::Request&  request,
                moveit_msgs::GetRobotStateFromWarehouse::Response& response,
                moveit_warehouse::RobotStateStorage* rs)
 {
@@ -92,7 +92,7 @@ bool get_state(moveit_msgs::GetRobotStateFromWarehouse::Request&  request,
   return true;
 }
 
-bool rename_state(moveit_msgs::RenameRobotStateInWarehouse::Request&  request,
+bool renameState(moveit_msgs::RenameRobotStateInWarehouse::Request&  request,
                   moveit_msgs::RenameRobotStateInWarehouse::Response& response,
                   moveit_warehouse::RobotStateStorage* rs)
 {
@@ -100,7 +100,7 @@ bool rename_state(moveit_msgs::RenameRobotStateInWarehouse::Request&  request,
   return true;
 }
 
-bool delete_state(moveit_msgs::DeleteRobotStateFromWarehouse::Request&  request,
+bool deleteState(moveit_msgs::DeleteRobotStateFromWarehouse::Request&  request,
                   moveit_msgs::DeleteRobotStateFromWarehouse::Response& response,
                   moveit_warehouse::RobotStateStorage* rs)
 {
@@ -117,8 +117,8 @@ int main(int argc, char **argv)
 
   ros::NodeHandle node("~");
   std::string host; int port;
-  node.param<std::string>("/warehouse_host", host, "");
-  node.param<int>("/warehouse_port", port, 0);
+  node.param<std::string>("warehouse_host", host, "localhost");
+  node.param<int>("warehouse_port", port, 33829);
 
   ROS_INFO("Connecting to warehouse on %s:%d", host.c_str(), port);
   moveit_warehouse::RobotStateStorage rs(host, port);
@@ -136,28 +136,27 @@ int main(int argc, char **argv)
 
   boost::function<bool(moveit_msgs::SaveRobotStateToWarehouse::Request&  request,
                        moveit_msgs::SaveRobotStateToWarehouse::Response& response)>
-    save_cb = boost::bind(&store_state, _1, _2, &rs);
+    save_cb = boost::bind(&storeState, _1, _2, &rs);
 
   boost::function<bool(moveit_msgs::ListRobotStatesInWarehouse::Request&  request,
                        moveit_msgs::ListRobotStatesInWarehouse::Response& response)>
-    list_cb = boost::bind(&list_states, _1, _2, &rs);
+    list_cb = boost::bind(&listStates, _1, _2, &rs);
 
   boost::function<bool(moveit_msgs::GetRobotStateFromWarehouse::Request&  request,
                        moveit_msgs::GetRobotStateFromWarehouse::Response& response)>
-    get_cb = boost::bind(&get_state, _1, _2, &rs);
+    get_cb = boost::bind(&getState, _1, _2, &rs);
 
   boost::function<bool(moveit_msgs::CheckIfRobotStateExistsInWarehouse::Request&  request,
                        moveit_msgs::CheckIfRobotStateExistsInWarehouse::Response& response)>
-    has_cb = boost::bind(&has_state, _1, _2, &rs);
+    has_cb = boost::bind(&hasState, _1, _2, &rs);
 
   boost::function<bool(moveit_msgs::RenameRobotStateInWarehouse::Request&  request,
                        moveit_msgs::RenameRobotStateInWarehouse::Response& response)>
-    rename_cb = boost::bind(&rename_state, _1, _2, &rs);
+    rename_cb = boost::bind(&renameState, _1, _2, &rs);
 
   boost::function<bool(moveit_msgs::DeleteRobotStateFromWarehouse::Request&  request,
                        moveit_msgs::DeleteRobotStateFromWarehouse::Response& response)>
-    delete_cb = boost::bind(&delete_state, _1, _2, &rs);
-
+    delete_cb = boost::bind(&deleteState, _1, _2, &rs);
 
   ros::ServiceServer save_state_server   = node.advertiseService("save_robot_state",   save_cb);
   ros::ServiceServer list_states_server  = node.advertiseService("list_robot_states",  list_cb);

--- a/warehouse/warehouse/src/warehouse_services.cpp
+++ b/warehouse/warehouse/src/warehouse_services.cpp
@@ -169,17 +169,6 @@ int main(int argc, char **argv)
   ros::ServiceServer get_state_server   = node.advertiseService("get_robot_state",   get_cb);
   ros::ServiceServer has_state_server   = node.advertiseService("has_robot_state",   has_cb);
 
-//  ros::Subscriber state_sub = nh.subscribe("robot_state", 100, save_cb);
-/*
-  std::vector<std::string> topics; psm.getMonitoredTopics(topics);
-  ROS_INFO_STREAM("Listening for scene updates on topics " <<
-  boost::algorithm::join(topics, ", ")); ROS_INFO_STREAM("Listening
-  for planning requests on topic " << mplan_req_sub.getTopic());
-  ROS_INFO_STREAM("Listening for named constraints on topic " <<
-  constr_sub.getTopic()); ROS_INFO_STREAM("Listening for states on
-  topic " << state_sub.getTopic());
-
-*/
   ros::waitForShutdown();
   return 0;
 }

--- a/warehouse/warehouse/src/warehouse_services.cpp
+++ b/warehouse/warehouse/src/warehouse_services.cpp
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
   ros::AsyncSpinner spinner(1);
   spinner.start();
 
-  ros::NodeHandle node("~");
+  ros::NodeHandle node;
   std::string host; int port;
   node.param<std::string>("warehouse_host", host, "localhost");
   node.param<int>("warehouse_port", port, 33829);


### PR DESCRIPTION
Adds service interface for access to robots_states in Warehouse. Requires service definitions added to moveit_msgs in https://github.com/ros-planning/moveit_msgs/pull/14

Modifies moveit motion planning plugin to fill the ROBOT_NAME field in robot_states in the Warehouse.

Also adds python method to find the name of the current robot model.
