### PR TITLE
Added a max range to raytracing in PointCloudOctomapUpdater

### DIFF
--- a/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
+++ b/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
@@ -107,6 +107,8 @@ protected:
 
   static void readXmlParam(XmlRpc::XmlRpcValue &params, const std::string &param_name, double *value);
   static void readXmlParam(XmlRpc::XmlRpcValue &params, const std::string &param_name, unsigned int *value);
+  static void readXmlParam(XmlRpc::XmlRpcValue &params, const std::string &param_name, double *value, double default_value);
+  static void readXmlParam(XmlRpc::XmlRpcValue &params, const std::string &param_name, unsigned int *value, unsigned int default_value);
 
 };
 

--- a/perception/occupancy_map_monitor/src/occupancy_map_updater.cpp
+++ b/perception/occupancy_map_monitor/src/occupancy_map_updater.cpp
@@ -65,10 +65,31 @@ void OccupancyMapUpdater::readXmlParam(XmlRpc::XmlRpcValue &params, const std::s
   }
 }
 
+void OccupancyMapUpdater::readXmlParam(XmlRpc::XmlRpcValue &params, const std::string &param_name, double *value, double default_value)
+{
+  if (params.hasMember(param_name))
+  {
+    if (params[param_name].getType() == XmlRpc::XmlRpcValue::TypeInt)
+      *value = (int) params[param_name];
+    else
+      *value = (double) params[param_name];
+  }
+  else
+    *value = default_value;
+}
+
 void OccupancyMapUpdater::readXmlParam(XmlRpc::XmlRpcValue &params, const std::string &param_name, unsigned int *value)
 {
   if (params.hasMember(param_name))
     *value = (int) params[param_name];
+}
+
+void OccupancyMapUpdater::readXmlParam(XmlRpc::XmlRpcValue &params, const std::string &param_name, unsigned int *value, unsigned int default_value)
+{
+  if (params.hasMember(param_name))
+    *value = (int) params[param_name];
+  else
+    *value = default_value;
 }
 
 bool OccupancyMapUpdater::updateTransformCache(const std::string &target_frame, const ros::Time &target_time)

--- a/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
+++ b/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
@@ -81,7 +81,8 @@ private:
   std::string point_cloud_topic_;
   double scale_;
   double padding_;
-  double max_range_;
+  double obstacle_range_;
+  double raytrace_range_;
   unsigned int point_subsample_;
   std::string filtered_cloud_topic_;
   ros::Publisher filtered_cloud_publisher_;

--- a/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -48,7 +48,8 @@ PointCloudOctomapUpdater::PointCloudOctomapUpdater() : OccupancyMapUpdater("Poin
                                                        private_nh_("~"),
                                                        scale_(1.0),
                                                        padding_(0.0),
-                                                       max_range_(std::numeric_limits<double>::infinity()),
+                                                       obstacle_range_(std::numeric_limits<double>::infinity()),
+                                                       raytrace_range_(std::numeric_limits<double>::infinity()),
                                                        point_subsample_(1),
                                                        point_cloud_subscriber_(NULL),
                                                        point_cloud_filter_(NULL)
@@ -68,7 +69,13 @@ bool PointCloudOctomapUpdater::setParams(XmlRpc::XmlRpcValue &params)
       return false;
     point_cloud_topic_ = static_cast<const std::string&>(params["point_cloud_topic"]);
 
-    readXmlParam(params, "max_range", &max_range_);
+    if (params.hasMember("max_range"))
+    {
+      ROS_WARN("max_range is deprecated, use obstacle_range instead");
+      readXmlParam(params, "max_range", &obstacle_range_);
+    }
+    readXmlParam(params, "obstacle_range", &obstacle_range_);
+    readXmlParam(params, "raytrace_range", &raytrace_range_);
     readXmlParam(params, "padding_offset", &padding_);
     readXmlParam(params, "padding_scale", &scale_);
     readXmlParam(params, "point_subsample", &point_subsample_);
@@ -200,7 +207,7 @@ void PointCloudOctomapUpdater::cloudMsgCallback(const sensor_msgs::PointCloud2::
   }
 
   /* mask out points on the robot */
-  shape_mask_->maskContainment(*cloud_msg, sensor_origin_eigen, 0.0, max_range_, mask_);
+  shape_mask_->maskContainment(*cloud_msg, sensor_origin_eigen, 0.0, obstacle_range_, mask_);
   updateMask(*cloud_msg, sensor_origin_eigen, mask_);
 
   octomap::KeySet free_cells, occupied_cells, model_cells, clip_cells;
@@ -233,6 +240,7 @@ void PointCloudOctomapUpdater::cloudMsgCallback(const sensor_msgs::PointCloud2::
   {
     /* do ray tracing to find which cells this point cloud indicates should be free, and which it indicates
      * should be occupied */
+    double raytrace_range_2 = raytrace_range_ * raytrace_range_;
     for (unsigned int row = 0; row < cloud_msg->height; row += point_subsample_)
     {
       unsigned int row_c = row * cloud_msg->width;
@@ -258,7 +266,12 @@ void PointCloudOctomapUpdater::cloudMsgCallback(const sensor_msgs::PointCloud2::
           if (mask_[row_c + col] == point_containment_filter::ShapeMask::INSIDE)
             model_cells.insert(tree_->coordToKey(point_tf.getX(), point_tf.getY(), point_tf.getZ()));
           else if (mask_[row_c + col] == point_containment_filter::ShapeMask::CLIP)
-            clip_cells.insert(tree_->coordToKey(point_tf.getX(), point_tf.getY(), point_tf.getZ()));
+          {
+            octomap::point3d clip_end(point_tf.getX(), point_tf.getY(), point_tf.getZ());
+            if (point_tf.length2() > raytrace_range_2)
+              clip_end = sensor_origin + (clip_end - sensor_origin).normalized() * (float)raytrace_range_;
+            clip_cells.insert(tree_->coordToKey(clip_end));
+          }
           else
           {
             occupied_cells.insert(tree_->coordToKey(point_tf.getX(), point_tf.getY(), point_tf.getZ()));

--- a/robot_interaction/include/moveit/robot_interaction/kinematic_options.h
+++ b/robot_interaction/include/moveit/robot_interaction/kinematic_options.h
@@ -62,11 +62,9 @@ struct KinematicOptions
     STATE_VALIDITY_CALLBACK     = 0x00000004, // state_validity_callback_
     LOCK_REDUNDANT_JOINTS       = 0x00000008, // options_.lock_redundant_joints
     RETURN_APPROXIMATE_SOLUTION = 0x00000010, // options_.return_approximate_solution
-    DISCRETIZATION_METHOD       = 0x00000020, // options_.discretization_method
 
     ALL_QUERY_OPTIONS           = LOCK_REDUNDANT_JOINTS |
-                                  RETURN_APPROXIMATE_SOLUTION |
-                                  DISCRETIZATION_METHOD,
+                                  RETURN_APPROXIMATE_SOLUTION,
     ALL                         = 0x7fffffff
   };
 

--- a/robot_interaction/src/kinematic_options.cpp
+++ b/robot_interaction/src/kinematic_options.cpp
@@ -90,8 +90,7 @@ void robot_interaction::KinematicOptions::setOptions(
   // kinematics::KinematicsQueryOptions
   #define QO_FIELDS(F) \
     F(bool, lock_redundant_joints, LOCK_REDUNDANT_JOINTS) \
-    F(bool, return_approximate_solution, RETURN_APPROXIMATE_SOLUTION) \
-    F(int, discretization_method, DISCRETIZATION_METHOD)
+    F(bool, return_approximate_solution, RETURN_APPROXIMATE_SOLUTION)
 
 
   // This structure should be identical to kinematics::KinematicsQueryOptions


### PR DESCRIPTION
This will limit how far out the updater will raytrace clipped cells, reducing the amount of time spent raytracing.  This range can be set in the YAML for the updater with the name raytrace_range.  The max range for the filter has been renamed from max_range to obstacle_range and max_range has been deprecated.  Setting raytrace_range to a value slightly larger than obstacle_range is recommended.  I also added functions to parse the YAML with default values so that raytrace_range could default to obstacle_range but decided to make raytrace_range behavior opt in for now so the new functions are not currently used.
