### PR TITLE
update pose of all markers when any marker moved

### DIFF
--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -868,8 +868,7 @@ void MotionPlanningDisplay::scheduleDrawQueryStartState(robot_interaction::Robot
 {
   if (!planning_scene_monitor_)
     return;
-  if (error_state_changed)
-    addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, false), "publishInteractiveMarkers");
+  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, !error_state_changed), "publishInteractiveMarkers");
   recomputeQueryStartStateMetrics();
   addMainLoopJob(boost::bind(&MotionPlanningDisplay::drawQueryStartState, this));
   context_->queueRender();
@@ -879,8 +878,7 @@ void MotionPlanningDisplay::scheduleDrawQueryGoalState(robot_interaction::RobotI
 {
   if (!planning_scene_monitor_)
     return;
-  if (error_state_changed)
-    addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, false), "publishInteractiveMarkers");
+  addBackgroundJob(boost::bind(&MotionPlanningDisplay::publishInteractiveMarkers, this, !error_state_changed), "publishInteractiveMarkers");
   recomputeQueryGoalStateMetrics();
   addMainLoopJob(boost::bind(&MotionPlanningDisplay::drawQueryGoalState, this));
   context_->queueRender();


### PR DESCRIPTION
Having several end-effector markers attached to a group (e.g. a multi-
fingered hand having an end-effector per fingertip and an end-effector
for the hand base), all markers need to update their pose on any motion
of any marker. In the example: if the hand base is moved, the fingertip
markers should be moved too.

I'm not sure, whether this will create an infinite loop of marker updates.
