### PR TITLE
fix segfault when disabling and re-enabling TrajectoryVisualization

### DIFF
--- a/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -265,7 +265,7 @@ void TrajectoryVisualization::onDisable()
   for (std::size_t i = 0 ; i < trajectory_trail_.size() ; ++i)
     trajectory_trail_[i]->setVisible(false);
   displaying_trajectory_message_.reset();
-
+  animating_path_ = false;
 }
 
 float TrajectoryVisualization::getStateDisplayTime()


### PR DESCRIPTION
animating_path_ was still true causing update() to access displaying_trajectory_message_, which was reset onDisable().
