### PR TITLE
interrupt trajectory visualization on arrival of new display trajectory

### DIFF
--- a/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -127,6 +127,9 @@ protected:
   typedef std::pair<std::string, moveit_msgs::RobotState> RobotStatePair;
   RobotStateMap robot_states_;
 
+Q_SIGNALS:
+  void planningFinished();
+
 private Q_SLOTS:
 
   //Context tab

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -223,6 +223,9 @@ void MotionPlanningDisplay::onInitialize()
   resetStatusTextColor();
   addStatusText("Initialized.");
 
+  // immediately switch to next trajectory display after planning
+  connect(frame_, SIGNAL(planningFinished()), trajectory_visual_.get(), SLOT(interruptCurrentDisplay()));
+
   if (window_context)
     frame_dock_ = window_context->addPane("Motion Planning", frame_);
 

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -123,6 +123,7 @@ void MotionPlanningFrame::computePlanButtonClicked()
     // Failure
     ui_->result_label->setText("Failed");
   }
+  Q_EMIT planningFinished();
 }
 
 void MotionPlanningFrame::computeExecuteButtonClicked()

--- a/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -146,6 +146,7 @@ protected:
   rviz::FloatProperty* robot_path_alpha_property_;
   rviz::BoolProperty* loop_display_property_;
   rviz::BoolProperty* trail_display_property_;
+  rviz::BoolProperty* interrupt_display_property_;
 
 };
 

--- a/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -92,6 +92,9 @@ public:
 Q_SIGNALS:
   void timeToShowNewTrail();
 
+public Q_SLOTS:
+  void interruptCurrentDisplay();
+
 private Q_SLOTS:
 
   /**

--- a/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
+++ b/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
@@ -89,9 +89,6 @@ public:
   void onEnable();
   void onDisable();
 
-Q_SIGNALS:
-  void timeToShowNewTrail();
-
 public Q_SLOTS:
   void interruptCurrentDisplay();
 
@@ -127,6 +124,7 @@ protected:
   bool animating_path_;
   int current_state_;
   float current_state_time_;
+  boost::mutex update_trajectory_message_;
 
   robot_model::RobotModelConstPtr robot_model_;
   robot_state::RobotStatePtr robot_state_;

--- a/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -312,7 +312,8 @@ void TrajectoryVisualization::update(float wall_dt, float ros_dt)
       animating_path_ = true;
       displaying_trajectory_message_ = trajectory_message_to_display_;
       changedShowTrail();
-    } else if (loop_display_property_->getBool()) { // do loop? -> start over too
+    } else if (loop_display_property_->getBool() &&
+               displaying_trajectory_message_) { // do loop? -> start over too
       animating_path_ = true;
     }
     trajectory_message_to_display_.reset();

--- a/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -56,6 +56,7 @@ TrajectoryVisualization::TrajectoryVisualization(rviz::Property *widget, rviz::D
   : display_(display)
   , widget_(widget)
   , animating_path_(false)
+  , current_state_(-1)
 {
   trajectory_topic_property_ =
     new rviz::RosTopicProperty("Trajectory Topic", "/move_group/display_planned_path",

--- a/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -196,6 +196,7 @@ void TrajectoryVisualization::changedShowTrail()
     r->load(*robot_model_->getURDF());
     r->setVisualVisible(display_path_visual_enabled_property_->getBool());
     r->setCollisionVisible(display_path_collision_enabled_property_->getBool());
+    r->setAlpha(robot_path_alpha_property_->getFloat());
     r->update(PlanningLinkUpdater(t->getWayPointPtr(i)));
     r->setVisible(display_->isEnabled() && (!animating_path_ || i <= current_state_));
     trajectory_trail_[i] = r;

--- a/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -100,6 +100,10 @@ TrajectoryVisualization::TrajectoryVisualization(rviz::Property *widget, rviz::D
                            widget,
                            SLOT(changedShowTrail()), this);
 
+  interrupt_display_property_ =
+    new rviz::BoolProperty("Interrupt Display", false, "Immediately show newly planned trajectory, interrupting the currently displayed one.",
+                           widget);
+
   connect(this, SIGNAL(timeToShowNewTrail()), this, SLOT(changedShowTrail()));
 }
 
@@ -374,6 +378,8 @@ void TrajectoryVisualization::incomingDisplayTrajectory(const moveit_msgs::Displ
   if (!t->empty())
   {
     trajectory_message_to_display_.swap(t);
+    if (interrupt_display_property_->getBool())
+      interruptCurrentDisplay();
   }
   if (trail_display_property_->getBool())
   {

--- a/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -300,24 +300,23 @@ float TrajectoryVisualization::getStateDisplayTime()
 
 void TrajectoryVisualization::update(float wall_dt, float ros_dt)
 {
-  // Check if starting new trajectory
-  if (!animating_path_ && !trajectory_message_to_display_ && loop_display_property_->getBool() && displaying_trajectory_message_)
-  {
-    animating_path_ = true;
-    current_state_ = -1;
-    current_state_time_ = std::numeric_limits<float>::infinity();
-    display_path_robot_->setVisible(display_->isEnabled());
-  }
-
-  if (!animating_path_ && trajectory_message_to_display_ && !trajectory_message_to_display_->empty())
-  {
-    displaying_trajectory_message_ = trajectory_message_to_display_;
-    display_path_robot_->setVisible(display_->isEnabled());
+  if (!animating_path_) { // finished last animation?
+    // new trajectory available to display?
+    if (trajectory_message_to_display_ && !trajectory_message_to_display_->empty()) {
+      animating_path_ = true;
+      displaying_trajectory_message_ = trajectory_message_to_display_;
+      changedShowTrail();
+    } else if (loop_display_property_->getBool()) { // do loop? -> start over too
+      animating_path_ = true;
+    }
     trajectory_message_to_display_.reset();
-    animating_path_ = true;
-    current_state_ = -1;
-    current_state_time_ = std::numeric_limits<float>::infinity();
-    display_path_robot_->update(displaying_trajectory_message_->getFirstWayPointPtr());
+
+    if (animating_path_) {
+      current_state_ = -1;
+      current_state_time_ = std::numeric_limits<float>::infinity();
+      display_path_robot_->update(displaying_trajectory_message_->getFirstWayPointPtr());
+      display_path_robot_->setVisible(display_->isEnabled());
+    }
   }
 
   if (animating_path_)
@@ -336,7 +335,7 @@ void TrajectoryVisualization::update(float wall_dt, float ros_dt)
       }
       else
       {
-        animating_path_ = false;
+        animating_path_ = false; // animation finished
         display_path_robot_->setVisible(loop_display_property_->getBool());
       }
       current_state_time_ = 0.0f;

--- a/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -268,6 +268,10 @@ void TrajectoryVisualization::onDisable()
 
 }
 
+void TrajectoryVisualization::interruptCurrentDisplay() {
+  animating_path_ = false;
+}
+
 float TrajectoryVisualization::getStateDisplayTime()
 {
   std::string tm = state_display_time_property_->getStdString();


### PR DESCRIPTION
A failed planning request often results in a rather long display trajectory. However, the next trajectory was only displayed, when the current one has finished.
The first patch immediately displays this trajectory when the planner was invoked from rviz - for responsive user interaction.
The second patch introduces a new display property to allow the user to switch on/off this interruption behavior in all other cases too.
