### PR TITLE
improved computation of interactive marker size

### DIFF
--- a/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
+++ b/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
@@ -185,7 +185,7 @@ private:
   void registerMoveInteractiveMarkerTopic(
     const std::string marker_name, const std::string& name);
   // return the diameter of the sphere that certainly can enclose the AABB of the link
-  double computeLinkMarkerSize(const std::string &group, const std::string &link);
+  double computeLinkMarkerSize(const std::string &link);
   // return the diameter of the sphere that certainly can enclose the AABB of
   // the links in this group
   double computeGroupMarkerSize(const std::string &group);

--- a/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
+++ b/robot_interaction/include/moveit/robot_interaction/robot_interaction.h
@@ -184,6 +184,8 @@ private:
   // interactive marker from other ROS nodes
   void registerMoveInteractiveMarkerTopic(
     const std::string marker_name, const std::string& name);
+  // return the diameter of the sphere that certainly can enclose the AABB of the link
+  double computeLinkMarkerSize(const std::string &group, const std::string &link);
   // return the diameter of the sphere that certainly can enclose the AABB of
   // the links in this group
   double computeGroupMarkerSize(const std::string &group);


### PR DESCRIPTION
- use parent_link if group == parent_group (instead of default)
- scale smaller than 5cm is clipped to 5cm (instead of falling back to default)
  If there is a really small end-effector group / link, we should rely on the computation too, shouldn't we?
- clarified size computation, using diameter of AABB
