### PR TITLE
fixed segfault on shutdown

### DIFF
--- a/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -142,7 +142,7 @@ public:
         {
           try
           {
-            result.reset(kinematics_loader_->createUnmanagedInstance(it->second[i]));
+            result = kinematics_loader_->createInstance(it->second[i]);
             if (result)
             {
               const std::vector<const robot_model::LinkModel*> &links = jmg->getLinkModels();


### PR DESCRIPTION
rviz always crashed on shutdown with MotionPlanning display loaded.
Reason was, that Kinematics pointers were destroyed after the underlying library was unloaded.

Use of pluginlib's createUnmanagedInstance() is strongly discouraged:
http://wiki.ros.org/class_loader#Understanding_Loading_and_Unloading

There are several other locations in the source, where the discouraged createUnmanagedInstance() is used!
