### PR TITLE
Enable optional build against Qt5

### DIFF
--- a/benchmarks_gui/CMakeLists.txt
+++ b/benchmarks_gui/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 2.8.12)
 project(moveit_ros_benchmarks_gui)
 
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
@@ -12,8 +12,18 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(OGRE OGRE)
 link_directories(${OGRE_LIBRARY_DIRS})
 
-find_package(Qt4 REQUIRED)
-include(${QT_USE_FILE})
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+option(UseQt5 "UseQt5" OFF)
+if(UseQt5)
+  find_package(Qt5Widgets REQUIRED)
+  find_package(Qt5Core REQUIRED)
+else()
+  find_package(Qt4 REQUIRED)
+  include(${QT_USE_FILE})
+endif()
+
 add_definitions(-DQT_NO_KEYWORDS)
 
 find_package(catkin REQUIRED COMPONENTS
@@ -41,13 +51,17 @@ include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
 
-qt4_wrap_cpp(MOC_FILES include/main_window.h include/trajectory.h include/benchmark_processing_thread.h)
-qt4_wrap_ui(UIC_FILES
-  src/ui/main_window.ui
+set(MOC_FILES include/main_window.h include/trajectory.h include/benchmark_processing_thread.h)
+set(UI_FILES src/ui/main_window.ui
   src/ui/run_benchmark_dialog.ui
   src/ui/robot_loader.ui
   src/ui/bounding_box_goals.ui
 )
+if(UseQt5)
+  qt5_wrap_ui(UIC_FILES ${UI_FILES})
+else()
+  qt4_wrap_ui(UIC_FILES ${UI_FILES})
+endif()
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(SYSTEM
@@ -75,6 +89,9 @@ target_link_libraries(moveit_benchmark_gui
   ${QT_LIBRARIES}
   ${Boost_LIBRARIES}
 )
+if(UseQt5)
+  target_link_libraries(moveit_benchmark_gui Qt5::Widgets)
+endif()
 
 install(
   TARGETS

--- a/benchmarks_gui/include/main_window.h
+++ b/benchmarks_gui/include/main_window.h
@@ -37,7 +37,7 @@
 #ifndef BT_MAIN_WINDOW_
 #define BT_MAIN_WINDOW_
 
-#include <QtGui/QMainWindow>
+#include <QMainWindow>
 #include <QTimer>
 #include <QSettings>
 

--- a/planning/CMakeLists.txt
+++ b/planning/CMakeLists.txt
@@ -22,9 +22,6 @@ find_package(catkin REQUIRED COMPONENTS
   tf_conversions
 )
 find_package(Eigen REQUIRED)
-find_package(Qt4 COMPONENTS QtCore QtGui REQUIRED)
-
-include(${QT_USE_FILE})
 
 generate_dynamic_reconfigure_options(
   "planning_scene_monitor/cfg/PlanningSceneMonitorDynamicReconfigure.cfg"

--- a/visualization/CMakeLists.txt
+++ b/visualization/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 2.8.12)
 project(moveit_ros_visualization)
 
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
@@ -14,8 +14,19 @@ pkg_check_modules(OGRE OGRE)
 link_directories( ${OGRE_LIBRARY_DIRS} )
 
 # Qt Stuff
-find_package(Qt4 REQUIRED)
-include(${QT_USE_FILE})
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+option(UseQt5 "UseQt5" OFF)
+if(UseQt5)
+  find_package(Qt5Widgets REQUIRED)
+  find_package(Qt5Core REQUIRED)
+else()
+  find_package(Qt4 REQUIRED)
+  include(${QT_USE_FILE})
+endif()
+
 add_definitions(-DQT_NO_KEYWORDS)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/visualization/motion_planning_rviz_plugin/CMakeLists.txt
+++ b/visualization/motion_planning_rviz_plugin/CMakeLists.txt
@@ -6,12 +6,15 @@ set( headers
   include/moveit/motion_planning_rviz_plugin/motion_planning_param_widget.h
 )
 
-# Convert the Qt Signals and Slots for QWidget events
-qt4_wrap_cpp(MOC_SOURCES ${headers})
-
-qt4_wrap_ui(UIC_FILES
-  src/ui/motion_planning_rviz_plugin_frame.ui
-)
+if(UseQt5)
+  qt5_wrap_ui(UIC_FILES
+    src/ui/motion_planning_rviz_plugin_frame.ui
+  )
+else()
+  qt4_wrap_ui(UIC_FILES
+    src/ui/motion_planning_rviz_plugin_frame.ui
+  )
+endif()
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
@@ -29,14 +32,20 @@ set(SOURCE_FILES
 )
 
 set(MOVEIT_LIB_NAME moveit_motion_planning_rviz_plugin)
-add_library(${MOVEIT_LIB_NAME}_core ${SOURCE_FILES} ${MOC_SOURCES} ${UIC_FILES})
+add_library(${MOVEIT_LIB_NAME}_core ${SOURCE_FILES} ${headers} ${UIC_FILES})
 target_link_libraries(${MOVEIT_LIB_NAME}_core
   moveit_rviz_plugin_render_tools
   moveit_planning_scene_rviz_plugin_core
   ${catkin_LIBRARIES} ${rviz_DEFAULT_PLUGIN_LIBRARIES} ${OGRE_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES})
+if (UseQt5)
+  target_link_libraries(${MOVEIT_LIB_NAME}_core Qt5::Widgets)
+endif (UseQt5)
 
 add_library(${MOVEIT_LIB_NAME} src/plugin_init.cpp)
 target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+if(UseQt5)
+  target_link_libraries(${MOVEIT_LIB_NAME} Qt5::Widgets)
+endif()
 
 install(DIRECTORY include/ DESTINATION include)
 

--- a/visualization/planning_scene_rviz_plugin/CMakeLists.txt
+++ b/visualization/planning_scene_rviz_plugin/CMakeLists.txt
@@ -1,15 +1,18 @@
 
-# Convert the Qt Signals and Slots for QWidget events
-qt4_wrap_cpp(MOC_SOURCES include/moveit/planning_scene_rviz_plugin/planning_scene_display.h)
-
 set(MOVEIT_LIB_NAME moveit_planning_scene_rviz_plugin)
 add_library(${MOVEIT_LIB_NAME}_core
   src/planning_scene_display.cpp
-  ${MOC_SOURCES})
+  include/moveit/planning_scene_rviz_plugin/planning_scene_display.h)
 target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_rviz_plugin_render_tools ${catkin_LIBRARIES} ${OGRE_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES})
+if(UseQt5)
+  target_link_libraries(${MOVEIT_LIB_NAME}_core Qt5::Widgets)
+endif()
 
 add_library(${MOVEIT_LIB_NAME} src/plugin_init.cpp)
 target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+if(UseQt5)
+  target_link_libraries(${MOVEIT_LIB_NAME} Qt5::Widgets)
+endif()
 
 install(DIRECTORY include/ DESTINATION include)
 

--- a/visualization/robot_state_rviz_plugin/CMakeLists.txt
+++ b/visualization/robot_state_rviz_plugin/CMakeLists.txt
@@ -1,10 +1,10 @@
 
-# Convert the Qt Signals and Slots for QWidget events
-qt4_wrap_cpp(MOC_SOURCES include/moveit/robot_state_rviz_plugin/robot_state_display.h)
-
 set(MOVEIT_LIB_NAME moveit_robot_state_rviz_plugin)
-add_library(${MOVEIT_LIB_NAME}_core src/robot_state_display.cpp ${MOC_SOURCES})
+add_library(${MOVEIT_LIB_NAME}_core src/robot_state_display.cpp ${MOC_SOURCES} include/moveit/robot_state_rviz_plugin/robot_state_display.h)
 target_link_libraries(${MOVEIT_LIB_NAME}_core moveit_rviz_plugin_render_tools ${catkin_LIBRARIES} ${OGRE_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES})
+if(UseQt5)
+  target_link_libraries(${MOVEIT_LIB_NAME}_core Qt5::Widgets)
+endif()
 
 add_library(${MOVEIT_LIB_NAME} src/plugin_init.cpp)
 target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/visualization/rviz_plugin_render_tools/CMakeLists.txt
+++ b/visualization/rviz_plugin_render_tools/CMakeLists.txt
@@ -5,9 +5,6 @@ set( headers
   include/moveit/rviz_plugin_render_tools/trajectory_visualization.h
 )
 
-# Convert the Qt Signals and Slots for QWidget events
-qt4_wrap_cpp(MOC_SOURCES ${headers})
-
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_library(${MOVEIT_LIB_NAME}
@@ -17,7 +14,7 @@ add_library(${MOVEIT_LIB_NAME}
   src/planning_link_updater.cpp
   src/octomap_render.cpp
   src/trajectory_visualization.cpp
-  ${MOC_SOURCES}
+  ${headers}
 )
 
 target_link_libraries(${MOVEIT_LIB_NAME}
@@ -26,6 +23,9 @@ target_link_libraries(${MOVEIT_LIB_NAME}
   ${QT_LIBRARIES}
   ${Boost_LIBRARIES}
 )
+if(UseQt5)
+  target_link_libraries(${MOVEIT_LIB_NAME} Qt5::Widgets)
+endif()
 
 install(DIRECTORY include/ DESTINATION include)
 

--- a/visualization/trajectory_rviz_plugin/CMakeLists.txt
+++ b/visualization/trajectory_rviz_plugin/CMakeLists.txt
@@ -5,21 +5,21 @@ set( headers
   include/moveit/trajectory_rviz_plugin/trajectory_display.h
 )
 
-# Convert the Qt Signals and Slots for QWidget events
-qt4_wrap_cpp(MOC_SOURCES ${headers})
-
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 # Trajectory Display
 add_library(${MOVEIT_LIB_NAME}_core
   src/trajectory_display.cpp
-  ${MOC_SOURCES}
+  ${headers}
 )
 target_link_libraries(${MOVEIT_LIB_NAME}_core
   moveit_rviz_plugin_render_tools
   moveit_planning_scene_rviz_plugin_core
   ${catkin_LIBRARIES} ${OGRE_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES}
 )
+if(UseQt5)
+  target_link_libraries(${MOVEIT_LIB_NAME}_core Qt5::Widgets)
+endif()
 
 # Plugin Initializer
 add_library(${MOVEIT_LIB_NAME} src/plugin_init.cpp)


### PR DESCRIPTION
Enable optional build against Qt5, use -DUseQt5=On to enable it. Requires Qt5 PR against rviz.

There were no changes to the code needed, just build system magic. For Qt4 the automoc feature of CMake is now used as well.

Requires CMake >= 2.8.12, which is included in Ubuntu 14.04, for slim Qt5 support using pseudo-targets

There is still no way to tell if the qt-Version of rviz and its plugins match, will crash if it doesn't
