### PR TITLE
Optional ability to copy velocity and effort to RobotState

### DIFF
--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -163,6 +163,14 @@ public:
     return error_;
   }
 
+  /** @brief Allow the joint_state arrrays velocity and effort to be copied into the robot state
+   *  this is useful in some but not all applications
+   */
+  void enableCopyDynamics(bool enabled)
+  {
+    copy_dynamics_ = enabled;
+  }
+
 private:
 
   void jointStateCallback(const sensor_msgs::JointStateConstPtr &joint_state);
@@ -174,6 +182,7 @@ private:
   robot_state::RobotState                      robot_state_;
   std::map<std::string, ros::Time>             joint_time_;
   bool                                         state_monitor_started_;
+  bool                                         copy_dynamics_;  // Copy velocity and effort from joint_state
   ros::Time                                    monitor_start_time_;
   double                                       error_;
   ros::Subscriber                              joint_state_subscriber_;

--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -262,6 +262,11 @@ public:
     return current_state_monitor_;
   }
 
+  CurrentStateMonitorPtr& getStateMonitorNonConst()
+  {
+    return current_state_monitor_;
+  }
+
   /** @brief Update the transforms for the frames that are not part of the kinematic model using tf.
    *  Examples of these frames are the "map" and "odom_combined" transforms. This function is automatically called when data that uses transforms is received.
    *  However, this function should also be called before starting a planning request, for example.


### PR DESCRIPTION
Does not change any default behavior of CurrentStateMonitor, but allows you to optionally turn on the ability to copy velocities and efforts from the `/joint_state` topic via:

```
planning_scene_monitor_->getStateMonitorNonConst()->copyDynamicsEnabled(true)
```

Also small fix I saw were `error_` is a double but it was being initialized as a float.
