### PR TITLE
Fix Trajectory Display in Rviz Plugin when changing robot_description

### DIFF
--- a/visualization/trajectory_rviz_plugin/src/trajectory_display.cpp
+++ b/visualization/trajectory_rviz_plugin/src/trajectory_display.cpp
@@ -63,25 +63,23 @@ void TrajectoryDisplay::onInitialize()
   Display::onInitialize();
 
   trajectory_visual_->onInitialize(scene_node_, context_, update_nh_);
-
-  loadRobotModel();
-
-  trajectory_visual_->onRobotModelLoaded(robot_model_);
 }
 
 void TrajectoryDisplay::loadRobotModel()
 {
-  if (!rdf_loader_)
-    rdf_loader_.reset(new rdf_loader::RDFLoader(robot_description_property_->getStdString()));
+  rdf_loader_.reset(new rdf_loader::RDFLoader(robot_description_property_->getStdString()));
 
   if (!rdf_loader_->getURDF())
   {
-    ROS_ERROR_STREAM_NAMED("trajectory_display","Unable to load robot model");
+    ROS_DEBUG_STREAM_NAMED("trajectory_display","Unable to load robot model from parameter " << robot_description_property_->getStdString());
     return;
   }
 
   const boost::shared_ptr<srdf::Model> &srdf = rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : boost::shared_ptr<srdf::Model>(new srdf::Model());
   robot_model_.reset(new robot_model::RobotModel(rdf_loader_->getURDF(), srdf));
+
+  // Send to child class
+  trajectory_visual_->onRobotModelLoaded(robot_model_);
 }
 
 void TrajectoryDisplay::reset()


### PR DESCRIPTION
Currently the trajectory display plugin only works for the rosparam "robot_description", but will not reload properly for anything else such as "pr2/robot_description"

This also reduces the number of error messages it outputs unnecessarily
