### PR TITLE
Remove OpenMP parallelization, fixes #563 (jade-devel)

### DIFF
--- a/perception/point_containment_filter/src/shape_mask.cpp
+++ b/perception/point_containment_filter/src/shape_mask.cpp
@@ -148,7 +148,8 @@ void point_containment_filter::ShapeMask::maskContainment(const sensor_msgs::Poi
     sensor_msgs::PointCloud2ConstIterator<float> iter_z(data_in, "z");
 
     // Cloud iterators are not incremented in the for loop, because of the pragma
-#pragma omp parallel for schedule(dynamic)
+// Comment out below parallelization as it can result in very high CPU consumption    
+//#pragma omp parallel for schedule(dynamic)
     for (int i = 0 ; i < (int)np ; ++i)
     {
       Eigen::Vector3d pt = Eigen::Vector3d(*(iter_x+i), *(iter_y+i), *(iter_z+i));


### PR DESCRIPTION
Same pull request for jade-devel as https://github.com/ros-planning/moveit_ros/pull/644 for indigo-devel.
