### PR TITLE
Update frame transforms in PlanningScene callback as well

### DIFF
--- a/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -480,6 +480,7 @@ void planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneMessage(const
 {
   if (scene_)
   {
+    updateFrameTransforms();
     SceneUpdateType upd = UPDATE_SCENE;
     std::string old_scene_name;
     {


### PR DESCRIPTION
Sending a PlanningScene message which adds object to the environment does not trigger a call to updateFrameTransforms. The result can be an annoying error of the type as in the following topic:

http://answers.ros.org/question/166606/how-do-i-use-collision_objectheaderframe_id-can-i-use-it-for-frame-transformations/

Is there a reason why PlanningScene does not trigger it, while all other topic callbacks do? If not, this is a straight-forward bugfix.
