### PR TITLE
explicitly link rviz' default_plugin library - indigo request

### DIFF
--- a/benchmarks_gui/CMakeLists.txt
+++ b/benchmarks_gui/CMakeLists.txt
@@ -70,6 +70,7 @@ add_executable(moveit_benchmark_gui ${SOURCES} ${MOC_FILES} ${UIC_FILES})
 
 target_link_libraries(moveit_benchmark_gui
   ${catkin_LIBRARIES}
+  ${rviz_DEFAULT_PLUGIN_LIBRARIES}
   ${OGRE_LIBRARIES}
   ${QT_LIBRARIES}
   ${Boost_LIBRARIES}

--- a/visualization/motion_planning_rviz_plugin/CMakeLists.txt
+++ b/visualization/motion_planning_rviz_plugin/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(${MOVEIT_LIB_NAME}_core ${SOURCE_FILES} ${MOC_SOURCES} ${UIC_FILES})
 target_link_libraries(${MOVEIT_LIB_NAME}_core
   moveit_rviz_plugin_render_tools
   moveit_planning_scene_rviz_plugin_core
-  ${catkin_LIBRARIES} ${OGRE_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES})
+  ${catkin_LIBRARIES} ${rviz_DEFAULT_PLUGIN_LIBRARIES} ${OGRE_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(${MOVEIT_LIB_NAME} src/plugin_init.cpp)
 target_link_libraries(${MOVEIT_LIB_NAME} ${MOVEIT_LIB_NAME}_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})


### PR DESCRIPTION
This is the indigo version of #657. Feel free to cherry-pick
the commit to indigo instead of merging this request.

The library is not exported anymore and now is provided separately from
rviz_LIBRARIES. See https://github.com/ros-visualization/rviz/pull/979 for
details.
