### PR TITLE
add rviz_DEFAULT_PLUGIN_LIBRARIES

### DIFF
--- a/benchmarks_gui/CMakeLists.txt
+++ b/benchmarks_gui/CMakeLists.txt
@@ -70,6 +70,7 @@ add_executable(moveit_benchmark_gui ${SOURCES} ${MOC_FILES} ${UIC_FILES})
 
 target_link_libraries(moveit_benchmark_gui
   ${catkin_LIBRARIES}
+  ${rviz_DEFAULT_PLUGIN_LIBRARIES}
   ${OGRE_LIBRARIES}
   ${QT_LIBRARIES}
   ${Boost_LIBRARIES}


### PR DESCRIPTION
this is indio version of  #657, fixes #654
see https://github.com/ros-visualization/rviz/issues/964
