### PR TITLE
Fix broken frame transforms in moveit's rviz displays

### DIFF
--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -200,7 +200,7 @@ void MotionPlanningDisplay::onInitialize()
   PlanningSceneDisplay::onInitialize();
 
   // Planned Path Display
-  trajectory_visual_->onInitialize(scene_node_, context_, update_nh_);
+  trajectory_visual_->onInitialize(planning_scene_node_, context_, update_nh_);
 
   query_robot_start_.reset(new RobotStateVisualization(planning_scene_node_, context_, "Planning Request Start", NULL));
   query_robot_start_->setCollisionVisible(false);


### PR DESCRIPTION
This makes using the displays with rviz a much nicer experience. :)

Now all moveit displays behave correctly when changing the fixed-frame
in rviz to an end-effector.

The more common use-case where problems occurred is when
moveit's planning frame is base_link of a mobile base,
but the fixed-frame is map. Because this transform usually
changes as the robot localizes itself, assuming a static transform
is broke.

Please cherry-pick and release this fix into indigo as well!
(If you prefer I can also create an additional pull request for that..)
