### PR TITLE
Fix MoveGroup::setStartStateToCurrentState() (issue 442)

### DIFF
--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -278,7 +278,7 @@ public:
 
   /** @brief Update the scene using the monitored state. This function is automatically called when an update to the current state is received (if startStateMonitor() has been called).
       The updates are throttled to a maximum update frequency however, which is set by setStateUpdateFrequency(). */
-  void updateSceneWithCurrentState();
+  void updateSceneWithCurrentState( bool triggerSceneUpdate= true);
 
   /** @brief Update the scene using the monitored state at a specified frequency, in Hz. This function has an effect only when updates from the CurrentStateMonitor are received at a higher frequency.
       In that case, the updates are throttled down, so that they do not exceed a maximum update frequency specified here.
@@ -329,6 +329,11 @@ public:
   const ros::Time& getLastUpdateTime() const
   {
     return last_update_time_;
+  }
+  /** \brief Return the time when the last robot state update was made to the planning scene (by \e any monitor) */
+  const ros::Time& getLastRobotStateUpdateTime() const
+  {
+    return last_robot_state_update_time_;
   }
 
   void publishDebugInformation(bool flag);
@@ -461,6 +466,7 @@ protected:
   boost::recursive_mutex update_lock_;
   std::vector<boost::function<void(SceneUpdateType)> > update_callbacks_; /// List of callbacks to trigger when updates are received
   ros::Time last_update_time_; /// Last time the state was updated
+  ros::Time last_robot_state_update_time_; /// Last time the robot state was updated
 
 private:
 


### PR DESCRIPTION
We ran into https://github.com/ros-planning/moveit_ros/issues/442 in our lab too and observed some very threatening and dangerous high-speed motions of our UR5 robotic arm. On a real industrial robot this issue is extremely safety-critical since it can lead to plans that start far away from the current robot joint position even though `MoveGroup::setStartStateToCurrentState()` has been called. I am personally quite shocked that this was not fixed by somebody else before since #442 is more than two years old. 

Some background details about the problem as understood by us:

Calling `MoveGroup::setStartStateToCurrentState()` internally nulls the `considered_start_state_` and sends a move-group planning request action goal with an empty start state (joint-names & positions arrays are emtpy). This makes MoveIt! directly use the RobotState which is stored inside the planning scene, e.g. when using OMPL `ModelBasedPlanningContext::setCompleteInitialState()` will be called from `ompl_interface::PlanningContextManager::getPlanningContext()` with a state generated by `robot_state::RobotStatePtr start_state = planning_scene->getCurrentStateUpdated(req.start_state);` .. when `req.start_state` is 'empty' this means effectively that the current state of the planning scene is is used.

Unfortunately the action server callback `MoveGroupMoveAction::executeMoveCallback` does not ensure that a robot state newer than the planning request is available. This leads to plans that use an outdated start state. Actually I am not quite sure how far back in time the invalid start state can be since from the motions that we saw it must have been significantly > 0.1s... maybe somebody from the MoveIt! team with more expertise in this specific area can explain why we saw such severe movements....

How we address the problem:

This PR makes sure that a new JointState message is received by CurrentStateMonitor and is indeed written to the RobotState of the PlanningScene before the planning request is being processed. In our tests this fixed the problem (which otherwise is quickly reproductible). In this PR the change is done only exemplary for the `MoveGroupMoveAction` .. other actions might be affected by an outdated current state too.

Since the MoveIt! source base is new to me and the project is quite large this PR is intended as a discussion basis on how to best address the problem. E.g. the sleep-based wait loop should better be replaced by a `boost::condition_variable` or some other more direct signalling mechanism, etc.

Special thanks to @alemme for debugging this issue together with me.
