### PR TITLE
Fix compilation with C++11.

### DIFF
--- a/planning/planning_scene_monitor/src/trajectory_monitor.cpp
+++ b/planning/planning_scene_monitor/src/trajectory_monitor.cpp
@@ -62,7 +62,7 @@ void planning_scene_monitor::TrajectoryMonitor::setSamplingFrequency(double samp
 
 bool planning_scene_monitor::TrajectoryMonitor::isActive() const
 {
-  return record_states_thread_;
+  return static_cast<bool>(record_states_thread_);
 }
 
 void planning_scene_monitor::TrajectoryMonitor::startTrajectoryMonitor()


### PR DESCRIPTION
Same as ros-planning/moveit_plugins#18:

> C++11 supports explicit conversion operators, and `boost::shared_ptr` adopted them (when available) for `operator bool() const`. The `ActionBasedControllerHandle` relies on an implicit conversion to `bool`. Since GCC 6 now compiles with C++11 support enabled by default, the `simple_controller_manager` package no longer compiles with that version onwards.
> 
> The fix is very simple: add an explicit cast.
