### PR TITLE
benchmark_gui: Fix conversion of shared_ptr to bool for C++11

### DIFF
--- a/benchmarks_gui/include/frame_marker.h
+++ b/benchmarks_gui/include/frame_marker.h
@@ -155,7 +155,7 @@ public:
 
   bool isVisible()
   {
-    return (imarker);
+    return static_cast<bool>(imarker);
   }
 
   void connect(const QObject * receiver, const char * method)

--- a/benchmarks_gui/src/main_window.cpp
+++ b/benchmarks_gui/src/main_window.cpp
@@ -244,7 +244,7 @@ bool MainWindow::waitForPlanningSceneMonitor(moveit_rviz_plugin::PlanningSceneDi
     scene_display->update(0.1, 0.1);
   }
 
-  return scene_display->getPlanningSceneMonitor();
+  return static_cast<bool>(scene_display->getPlanningSceneMonitor());
 }
 
 void MainWindow::exitActionTriggered(bool)


### PR DESCRIPTION
Found another implicit `shared_ptr` to `bool` conversion.

This is the last one I found for now. I'm not compiling all move-it packages though, so there could be more out there.
