### PR TITLE
Add library moveit_collision_plugin_loader as an exported catkin library

### DIFF
--- a/planning/CMakeLists.txt
+++ b/planning/CMakeLists.txt
@@ -56,6 +56,7 @@ catkin_package(
     moveit_trajectory_execution_manager
     moveit_plan_execution
     moveit_planning_scene_monitor
+    moveit_collision_plugin_loader
   INCLUDE_DIRS
     ${THIS_PACKAGE_INCLUDE_DIRS}
   CATKIN_DEPENDS


### PR DESCRIPTION
For other catkin package to link against library moveit_collision_plugin_loader it must be added as a catkin library to be exported.
