### PR TITLE
Add rostest dependency

### DIFF
--- a/visualization/CMakeLists.txt
+++ b/visualization/CMakeLists.txt
@@ -33,6 +33,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   rosconsole
   object_recognition_msgs
+  rostest
 )
 find_package(Eigen REQUIRED)
 catkin_python_setup()

--- a/visualization/package.xml
+++ b/visualization/package.xml
@@ -31,6 +31,7 @@
   <build_depend>moveit_ros_perception</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>rospy</build_depend>
+  <build_depend>rostest</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rviz</run_depend>
   <run_depend>moveit_ros_planning_interface</run_depend>


### PR DESCRIPTION
- OS: ubuntu 14.04 - fresh installation
- ROS Indigo

When I try to compile the moveit packages as described in the [documentations](http://moveit.ros.org/install/), I get the error:

``` log
CMake Error at moveit_ros/visualization/CMakeLists.txt:89 (add_rostest):
  Unknown CMake command "add_rostest".
```

See the complete [catkin_make output](https://gist.github.com/ammarnajjar/6e53d340fc4b6a0afab4de93d46c70d0)
I summarized the setup steps in this [script](https://gist.github.com/ammarnajjar/19fa5fc3635b695b53b04c6a3ec73ac3).

The line `moveit_ros/visualization/CMakeLists.txt:89` requires `rostest`.

The patch applied here adds `rostest` to the dependencies for [moveit_ros](https://github.com/ros-planning/moveit_ros) package.
After applying this patch, the compilation (`catkin_make`) passed successfully.

Please have a look at this, and advise.
