### PR TITLE
clear_octomap_service: fix runtime name

### DIFF
--- a/move_group/src/default_capabilities/clear_octomap_service_capability.cpp
+++ b/move_group/src/default_capabilities/clear_octomap_service_capability.cpp
@@ -38,7 +38,7 @@
 #include <moveit/move_group/capability_names.h>
 
 move_group::ClearOctomapService::ClearOctomapService():
-  MoveGroupCapability("ExecutePathService")
+  MoveGroupCapability("ClearOctomapService")
 {
 }
 


### PR DESCRIPTION
Looks like the author copy&pasted from a different capability
and forgot to change the name.
