### PR TITLE
add ApplyPlanningSceneService capability

### DIFF
--- a/move_group/CMakeLists.txt
+++ b/move_group/CMakeLists.txt
@@ -54,6 +54,7 @@ add_library(moveit_move_group_default_capabilities
   src/default_capabilities/state_validation_service_capability.cpp
   src/default_capabilities/cartesian_path_service_capability.cpp
   src/default_capabilities/get_planning_scene_service_capability.cpp
+  src/default_capabilities/apply_planning_scene_service_capability.cpp
   src/default_capabilities/clear_octomap_service_capability.cpp
   )
 

--- a/move_group/default_capabilities_plugin_description.xml
+++ b/move_group/default_capabilities_plugin_description.xml
@@ -48,6 +48,12 @@
     </description>
   </class>
 
+  <class name="move_group/ApplyPlanningSceneService" type="move_group::ApplyPlanningSceneService" base_class_type="move_group::MoveGroupCapability">
+    <description>
+      Provide a ROS service for blocking updates to the planning scene
+    </description>
+  </class>
+
   <class name="move_group/ClearOctomapService" type="move_group::ClearOctomapService" base_class_type="move_group::MoveGroupCapability">
     <description>
       Provide a ROS service that allows for clearing the octomap

--- a/move_group/src/default_capabilities/apply_planning_scene_service_capability.cpp
+++ b/move_group/src/default_capabilities/apply_planning_scene_service_capability.cpp
@@ -55,7 +55,7 @@ bool move_group::ApplyPlanningSceneService::applyScene(moveit_msgs::ApplyPlannin
     return true;
   }
   context_->planning_scene_monitor_->updateFrameTransforms();
-  context_->planning_scene_monitor_->newPlanningSceneMessage(req.scene);
+  res.success = context_->planning_scene_monitor_->newPlanningSceneMessage(req.scene);
   return true;
 }
 

--- a/move_group/src/default_capabilities/apply_planning_scene_service_capability.cpp
+++ b/move_group/src/default_capabilities/apply_planning_scene_service_capability.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2012, Willow Garage, Inc.
+ *  Copyright (c) 2016, Michael 'v4hn' Goerner
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -32,28 +32,32 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Ioan Sucan */
+/* Author: Michael Goerner */
 
-#ifndef MOVEIT_MOVE_GROUP_DEFAULT_CAPABILITY_NAMES
-#define MOVEIT_MOVE_GROUP_DEFAULT_CAPABILITY_NAMES
+#include "apply_planning_scene_service_capability.h"
+#include <moveit/move_group/capability_names.h>
 
-#include <string>
-
-namespace move_group
+move_group::ApplyPlanningSceneService::ApplyPlanningSceneService():
+  MoveGroupCapability("ApplyPlanningSceneService")
 {
-
-static const std::string PLANNER_SERVICE_NAME = "plan_kinematic_path";    // name of the advertised service (within the ~ namespace)
-static const std::string EXECUTE_SERVICE_NAME = "execute_kinematic_path"; // name of the advertised service (within the ~ namespace)
-static const std::string QUERY_PLANNERS_SERVICE_NAME = "query_planner_interface"; // name of the advertised query planners service
-static const std::string MOVE_ACTION = "move_group"; // name of 'move' action
-static const std::string IK_SERVICE_NAME = "compute_ik"; // name of ik service
-static const std::string FK_SERVICE_NAME = "compute_fk"; // name of fk service
-static const std::string STATE_VALIDITY_SERVICE_NAME = "check_state_validity"; // name of the service that validates states
-static const std::string CARTESIAN_PATH_SERVICE_NAME = "compute_cartesian_path"; // name of the service that computes cartesian paths
-static const std::string GET_PLANNING_SCENE_SERVICE_NAME = "get_planning_scene"; // name of the service that can be used to query the planning scene
-static const std::string APPLY_PLANNING_SCENE_SERVICE_NAME = "apply_planning_scene"; // name of the service that applies a given planning scene
-static const std::string CLEAR_OCTOMAP_SERVICE_NAME = "clear_octomap"; // name of the service that can be used to clear the octomap
-
 }
 
-#endif
+void move_group::ApplyPlanningSceneService::initialize()
+{
+  service_ = root_node_handle_.advertiseService(APPLY_PLANNING_SCENE_SERVICE_NAME, &ApplyPlanningSceneService::applyScene, this);
+}
+
+bool move_group::ApplyPlanningSceneService::applyScene(moveit_msgs::ApplyPlanningScene::Request &req, moveit_msgs::ApplyPlanningScene::Response &res)
+{
+  if (!context_->planning_scene_monitor_)
+  {
+    ROS_ERROR("Cannot apply PlanningScene as no scene is monitored.");
+    return true;
+  }
+  context_->planning_scene_monitor_->updateFrameTransforms();
+  context_->planning_scene_monitor_->newPlanningSceneMessage(req.scene);
+  return true;
+}
+
+#include <class_loader/class_loader.h>
+CLASS_LOADER_REGISTER_CLASS(move_group::ApplyPlanningSceneService, move_group::MoveGroupCapability)

--- a/move_group/src/default_capabilities/apply_planning_scene_service_capability.h
+++ b/move_group/src/default_capabilities/apply_planning_scene_service_capability.h
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2012, Willow Garage, Inc.
+ *  Copyright (c) 2016, Michael 'v4hn' Goerner
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -32,28 +32,36 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Ioan Sucan */
+/* Author: Michael 'v4hn' Goerner */
 
-#ifndef MOVEIT_MOVE_GROUP_DEFAULT_CAPABILITY_NAMES
-#define MOVEIT_MOVE_GROUP_DEFAULT_CAPABILITY_NAMES
+#ifndef MOVEIT_MOVE_GROUP_APPLY_PLANNING_SCENE_SERVICE_CAPABILITY_
+#define MOVEIT_MOVE_GROUP_APPLY_PLANNING_SCENE_SERVICE_CAPABILITY_
 
-#include <string>
+#include <moveit/move_group/move_group_capability.h>
+#include <moveit_msgs/ApplyPlanningScene.h>
 
 namespace move_group
 {
 
-static const std::string PLANNER_SERVICE_NAME = "plan_kinematic_path";    // name of the advertised service (within the ~ namespace)
-static const std::string EXECUTE_SERVICE_NAME = "execute_kinematic_path"; // name of the advertised service (within the ~ namespace)
-static const std::string QUERY_PLANNERS_SERVICE_NAME = "query_planner_interface"; // name of the advertised query planners service
-static const std::string MOVE_ACTION = "move_group"; // name of 'move' action
-static const std::string IK_SERVICE_NAME = "compute_ik"; // name of ik service
-static const std::string FK_SERVICE_NAME = "compute_fk"; // name of fk service
-static const std::string STATE_VALIDITY_SERVICE_NAME = "check_state_validity"; // name of the service that validates states
-static const std::string CARTESIAN_PATH_SERVICE_NAME = "compute_cartesian_path"; // name of the service that computes cartesian paths
-static const std::string GET_PLANNING_SCENE_SERVICE_NAME = "get_planning_scene"; // name of the service that can be used to query the planning scene
-static const std::string APPLY_PLANNING_SCENE_SERVICE_NAME = "apply_planning_scene"; // name of the service that applies a given planning scene
-static const std::string CLEAR_OCTOMAP_SERVICE_NAME = "clear_octomap"; // name of the service that can be used to clear the octomap
+/**
+ * Provides the ability to update the shared planning scene
+ * with a remote blocking call using a ROS-Service
+ */
+class ApplyPlanningSceneService : public MoveGroupCapability
+{
+public:
+
+  ApplyPlanningSceneService();
+
+  virtual void initialize();
+
+private:
+
+  bool applyScene(moveit_msgs::ApplyPlanningScene::Request &req, moveit_msgs::ApplyPlanningScene::Response &res);
+
+  ros::ServiceServer service_;
+};
 
 }
 
-#endif
+#endif // MOVEIT_MOVE_GROUP_APPLY_PLANNING_SCENE_SERVICE_CAPABILITY_

--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -350,6 +350,9 @@ public:
 
   void clearOctomap();
 
+  // Called to update the planning scene with a new message.
+  void newPlanningSceneMessage(const moveit_msgs::PlanningScene& scene);
+
 protected:
 
   /** @brief Initialize the planning scene monitor
@@ -477,9 +480,6 @@ private:
 
   // Callback for a new planning scene msg
   void newPlanningSceneCallback(const moveit_msgs::PlanningSceneConstPtr &scene);
-
-  // Called to update the planning scene with a new message.
-  void newPlanningSceneMessage(const moveit_msgs::PlanningScene& scene);
 
 
   // Lock for state_update_pending_ and dt_state_update_

--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -351,7 +351,7 @@ public:
   void clearOctomap();
 
   // Called to update the planning scene with a new message.
-  void newPlanningSceneMessage(const moveit_msgs::PlanningScene& scene);
+  bool newPlanningSceneMessage(const moveit_msgs::PlanningScene& scene);
 
 protected:
 

--- a/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -476,10 +476,12 @@ void planning_scene_monitor::PlanningSceneMonitor::clearOctomap()
   octomap_monitor_->getOcTreePtr()->unlockWrite();
 }
 
-void planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneMessage(const moveit_msgs::PlanningScene& scene)
+bool planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneMessage(const moveit_msgs::PlanningScene& scene)
 {
   if (!scene_)
-    return;
+    return false;
+
+  bool result;
 
   SceneUpdateType upd = UPDATE_SCENE;
   std::string old_scene_name;
@@ -490,7 +492,7 @@ void planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneMessage(const
 
     last_update_time_ = ros::Time::now();
     old_scene_name = scene_->getName();
-    scene_->usePlanningSceneMsg(scene);
+    result = scene_->usePlanningSceneMsg(scene);
     if (octomap_monitor_)
     {
       if (!scene.is_diff && scene.world.octomap.octomap.data.empty())
@@ -544,6 +546,7 @@ void planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneMessage(const
     }
   }
   triggerSceneUpdateEvent(upd);
+  return result;
 }
 
 void planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneWorldCallback(const moveit_msgs::PlanningSceneWorldConstPtr &world)

--- a/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -478,71 +478,72 @@ void planning_scene_monitor::PlanningSceneMonitor::clearOctomap()
 
 void planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneMessage(const moveit_msgs::PlanningScene& scene)
 {
-  if (scene_)
+  if (!scene_)
+    return;
+
+  SceneUpdateType upd = UPDATE_SCENE;
+  std::string old_scene_name;
   {
-    SceneUpdateType upd = UPDATE_SCENE;
-    std::string old_scene_name;
+    boost::unique_lock<boost::shared_mutex> ulock(scene_update_mutex_);
+    // we don't want the transform cache to update while we are potentially changing attached bodies
+    boost::recursive_mutex::scoped_lock prevent_shape_cache_updates(shape_handles_lock_);
+
+    last_update_time_ = ros::Time::now();
+    old_scene_name = scene_->getName();
+    scene_->usePlanningSceneMsg(scene);
+    if (octomap_monitor_)
     {
-      boost::unique_lock<boost::shared_mutex> ulock(scene_update_mutex_);
-      boost::recursive_mutex::scoped_lock prevent_shape_cache_updates(shape_handles_lock_); // we don't want the transform cache to update while we are potentially changing attached bodies
-
-      last_update_time_ = ros::Time::now();
-      old_scene_name = scene_->getName();
-      scene_->usePlanningSceneMsg(scene);
-      if (octomap_monitor_)
+      if (!scene.is_diff && scene.world.octomap.octomap.data.empty())
       {
-        if (!scene.is_diff && scene.world.octomap.octomap.data.empty())
-        {
-          octomap_monitor_->getOcTreePtr()->lockWrite();
-          octomap_monitor_->getOcTreePtr()->clear();
-          octomap_monitor_->getOcTreePtr()->unlockWrite();
-        }
-      }
-      robot_model_ = scene_->getRobotModel();
-
-      // if we just reset the scene completely but we were maintaining diffs, we need to fix that
-      if (!scene.is_diff && parent_scene_)
-      {
-        // the scene is now decoupled from the parent, since we just reset it
-        scene_->setAttachedBodyUpdateCallback(robot_state::AttachedBodyCallback());
-        scene_->setCollisionObjectUpdateCallback(collision_detection::World::ObserverCallbackFn());
-        parent_scene_ = scene_;
-        scene_ = parent_scene_->diff();
-        scene_const_ = scene_;
-        scene_->setAttachedBodyUpdateCallback(boost::bind(&PlanningSceneMonitor::currentStateAttachedBodyUpdateCallback, this, _1, _2));
-        scene_->setCollisionObjectUpdateCallback(boost::bind(&PlanningSceneMonitor::currentWorldObjectUpdateCallback, this, _1, _2));
-      }
-      if (octomap_monitor_)
-      {
-        excludeAttachedBodiesFromOctree(); // in case updates have happened to the attached bodies, put them in
-        excludeWorldObjectsFromOctree(); // in case updates have happened to the attached bodies, put them in
+        octomap_monitor_->getOcTreePtr()->lockWrite();
+        octomap_monitor_->getOcTreePtr()->clear();
+        octomap_monitor_->getOcTreePtr()->unlockWrite();
       }
     }
+    robot_model_ = scene_->getRobotModel();
 
-    // if we have a diff, try to more accuratelly determine the update type
-    if (scene.is_diff)
+    // if we just reset the scene completely but we were maintaining diffs, we need to fix that
+    if (!scene.is_diff && parent_scene_)
     {
-      bool no_other_scene_upd = (scene.name.empty() || scene.name == old_scene_name) &&
-        scene.allowed_collision_matrix.entry_names.empty() && scene.link_padding.empty() && scene.link_scale.empty();
-      if (no_other_scene_upd)
-      {
-        upd = UPDATE_NONE;
-        if (!planning_scene::PlanningScene::isEmpty(scene.world))
-          upd = (SceneUpdateType) ((int)upd | (int)UPDATE_GEOMETRY);
-
-        if (!scene.fixed_frame_transforms.empty())
-          upd = (SceneUpdateType) ((int)upd | (int)UPDATE_TRANSFORMS);
-
-        if (!planning_scene::PlanningScene::isEmpty(scene.robot_state))
-        {
-          upd = (SceneUpdateType) ((int)upd | (int)UPDATE_STATE);
-          if (!scene.robot_state.attached_collision_objects.empty() || scene.robot_state.is_diff == false)
-            upd = (SceneUpdateType) ((int)upd | (int)UPDATE_GEOMETRY);
-        }
-      }
+      // the scene is now decoupled from the parent, since we just reset it
+      scene_->setAttachedBodyUpdateCallback(robot_state::AttachedBodyCallback());
+      scene_->setCollisionObjectUpdateCallback(collision_detection::World::ObserverCallbackFn());
+      parent_scene_ = scene_;
+      scene_ = parent_scene_->diff();
+      scene_const_ = scene_;
+      scene_->setAttachedBodyUpdateCallback(boost::bind(&PlanningSceneMonitor::currentStateAttachedBodyUpdateCallback, this, _1, _2));
+      scene_->setCollisionObjectUpdateCallback(boost::bind(&PlanningSceneMonitor::currentWorldObjectUpdateCallback, this, _1, _2));
     }
-    triggerSceneUpdateEvent(upd);
+    if (octomap_monitor_)
+    {
+      excludeAttachedBodiesFromOctree(); // in case updates have happened to the attached bodies, put them in
+      excludeWorldObjectsFromOctree(); // in case updates have happened to the attached bodies, put them in
+    }
   }
+
+  // if we have a diff, try to more accuratelly determine the update type
+  if (scene.is_diff)
+  {
+    bool no_other_scene_upd = (scene.name.empty() || scene.name == old_scene_name) &&
+      scene.allowed_collision_matrix.entry_names.empty() && scene.link_padding.empty() && scene.link_scale.empty();
+    if (no_other_scene_upd)
+    {
+      upd = UPDATE_NONE;
+      if (!planning_scene::PlanningScene::isEmpty(scene.world))
+        upd = (SceneUpdateType) ((int)upd | (int)UPDATE_GEOMETRY);
+
+      if (!scene.fixed_frame_transforms.empty())
+        upd = (SceneUpdateType) ((int)upd | (int)UPDATE_TRANSFORMS);
+
+      if (!planning_scene::PlanningScene::isEmpty(scene.robot_state))
+      {
+        upd = (SceneUpdateType) ((int)upd | (int)UPDATE_STATE);
+        if (!scene.robot_state.attached_collision_objects.empty() || scene.robot_state.is_diff == false)
+          upd = (SceneUpdateType) ((int)upd | (int)UPDATE_GEOMETRY);
+      }
+    }
+  }
+  triggerSceneUpdateEvent(upd);
 }
 
 void planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneWorldCallback(const moveit_msgs::PlanningSceneWorldConstPtr &world)


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/moveit-users/D7MWZEUSKLc
for a longer discussion on why this makes sense to have around.

The only thing I'm unsure about is whether the service should be
`~`-namespaced or not. There might be multiple monitored scenes
around, so I moved it to the namespace. On the other hand,
the ClearOctomap service is _not_ namespaced...
