### PR TITLE
planning_interface: Set is_diff true for empty start state

### DIFF
--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -856,6 +856,8 @@ public:
 
     if (considered_start_state_)
       robot_state::robotStateToRobotStateMsg(*considered_start_state_, goal.request.start_state);
+    else
+      goal.request.start_state.is_diff = true;
 
     if (active_target_ == JOINT)
     {

--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -693,6 +693,9 @@ public:
 
     if (considered_start_state_)
       robot_state::robotStateToRobotStateMsg(*considered_start_state_, req.start_state);
+    else
+      req.start_state.is_diff = true;
+
     req.group_name = opt_.group_name_;
     req.header.frame_id = getPoseReferenceFrame();
     req.header.stamp = ros::Time::now();


### PR DESCRIPTION
Executing a motion without setting the start state of the robot like
this:

```
group_arm.setNamedTarget("start_grab_pose");
success = group_arm.move();
```

throws the error: Execution of motions should always start at the robot's
current state. Ignoring the state supplied as start state in the motion
planning request.

The problem is, when considered_start_state_ is null, every data field of the start_state
in the submitted MotionPlanRequest is 0 or false. But we need is_diff to be
true, because otherwise move_group will not consider its current state as
actual start state without complaining.
