### PR TITLE
update frame transforms on new PlanningSceneMessage (updated #652)

### DIFF
--- a/move_group/src/default_capabilities/apply_planning_scene_service_capability.cpp
+++ b/move_group/src/default_capabilities/apply_planning_scene_service_capability.cpp
@@ -54,7 +54,6 @@ bool move_group::ApplyPlanningSceneService::applyScene(moveit_msgs::ApplyPlannin
     ROS_ERROR("Cannot apply PlanningScene as no scene is monitored.");
     return true;
   }
-  context_->planning_scene_monitor_->updateFrameTransforms();
   res.success = context_->planning_scene_monitor_->newPlanningSceneMessage(req.scene);
   return true;
 }

--- a/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -483,6 +483,8 @@ bool planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneMessage(const
 
   bool result;
 
+  updateFrameTransforms();
+
   SceneUpdateType upd = UPDATE_SCENE;
   std::string old_scene_name;
   {


### PR DESCRIPTION
This fixes some issues where objects are added w.r.t. some frame but moveit
didn't know about the frame yet.

I don't see a reason why this shouldn't be done.

@marcoesposito1988 for reference.
