### PR TITLE
[joy.py] Installed python file might not be executable.

### DIFF
--- a/visualization/CMakeLists.txt
+++ b/visualization/CMakeLists.txt
@@ -99,7 +99,7 @@ install(FILES
   robot_state_rviz_plugin_description.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
-install(FILES python/moveit_ros_visualization/moveit_joy.py DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+install(PROGRAMS python/moveit_ros_visualization/moveit_joy.py DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 install(DIRECTORY icons DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 


### PR DESCRIPTION
```
$ ll /opt/ros/indigo/lib/python2.7/dist-packages/moveit_ros_visualization/moveit_joy.py
-rw-r--r-- 1 root root 23K Apr 12 12:01 /opt/ros/indigo/lib/python2.7/dist-packages/moveit_ros_visualization/moveit_joy.py
$ dpkg -p ros-indigo-moveit-ros-visualization | grep Ver
Version: 0.7.1-0trusty-20160618-030142-0700
```
