### PR TITLE
Add methods to retrieve named states via the move_group

### DIFF
--- a/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -127,6 +127,9 @@ public:
   /** \brief Get the name of the group this instance operates on */
   const std::string& getName() const;
 
+  /** \brief Get the names of the named robot states available as targets, both either remembered states or default states from srdf */
+  const std::vector<std::string> getNamedTargets();
+
   /** \brief Get the RobotModel object. */
   robot_model::RobotModelConstPtr getRobotModel() const;
 
@@ -135,6 +138,12 @@ public:
 
   /** \brief Get the name of the frame in which the robot is planning */
   const std::string& getPlanningFrame() const;
+
+  /** \brief Get vector of names of joints available in move group */
+  const std::vector<std::string>& getJointNames();
+
+  /** \brief Get the joint angles for targets specified by name */
+  std::map<std::string,double> getNamedTargetValues(const std::string& name);
 
   /** \brief Get only the active (actuated) joints this instance operates on */
   const std::vector<std::string>& getActiveJoints() const;

--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -103,6 +103,7 @@ public:
       ROS_FATAL_STREAM(error);
       throw std::runtime_error(error);
     }
+
     joint_model_group_ = getRobotModel()->getJointModelGroup(opt.group_name_);
 
     joint_state_target_.reset(new robot_state::RobotState(getRobotModel()));
@@ -1099,6 +1100,21 @@ const std::string& moveit::planning_interface::MoveGroup::getName() const
   return impl_->getOptions().group_name_;
 }
 
+const std::vector<std::string> moveit::planning_interface::MoveGroup::getNamedTargets()
+{
+  const robot_model::RobotModelConstPtr& robot = getRobotModel();
+  const std::string& group = getName();
+  const robot_model::JointModelGroup* joint_group = robot->getJointModelGroup(group);
+
+  if (joint_group)
+  {
+    return joint_group->getDefaultStateNames();
+  }
+
+  std::vector<std::string> empty;
+  return empty;
+}
+
 robot_model::RobotModelConstPtr moveit::planning_interface::MoveGroup::getRobotModel() const
 {
   return impl_->getRobotModel();
@@ -1241,6 +1257,31 @@ void moveit::planning_interface::MoveGroup::setRandomTarget()
 {
   impl_->getJointStateTarget().setToRandomPositions();
   impl_->setTargetType(JOINT);
+}
+
+const std::vector<std::string>& moveit::planning_interface::MoveGroup::getJointNames()
+{
+  return impl_->getJointModelGroup()->getVariableNames();
+}
+
+std::map<std::string, double> moveit::planning_interface::MoveGroup::getNamedTargetValues(const std::string& name)
+{
+  std::map<std::string, std::vector<double> >::const_iterator it = remembered_joint_values_.find(name);
+  std::map<std::string,double> positions;
+
+  if (it != remembered_joint_values_.end())
+  {
+    std::vector<std::string> names = impl_->getJointModelGroup()->getVariableNames();
+    for (size_t x = 0; x < names.size(); ++x)
+    {
+      positions[names[x]] = it->second[x];
+    }
+  }
+  else
+  {
+    impl_->getJointModelGroup()->getVariableDefaultPositions(name, positions);
+  }
+  return positions;
 }
 
 bool moveit::planning_interface::MoveGroup::setNamedTarget(const std::string &name)

--- a/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
+++ b/planning_interface/move_group_interface/src/wrap_python_move_group.cpp
@@ -270,6 +270,18 @@ public:
     }
   }
 
+  bp::dict getCurrentStateBoundedPython()
+  {
+    robot_state::RobotStatePtr current = getCurrentState();
+    current->enforceBounds();
+    moveit_msgs::RobotState rsmv;
+    robot_state::robotStateToRobotStateMsg(*current, rsmv);
+    bp::dict output;
+    for (size_t x = 0; x < rsmv.joint_state.name.size(); ++x)
+      output[rsmv.joint_state.name[x]] = rsmv.joint_state.position[x];
+    return output;
+  }  
+
   void setStartStatePython(const std::string &msg_str)
   {
     moveit_msgs::RobotState msg;
@@ -322,6 +334,22 @@ public:
   const char* getNameCStr() const
   {
     return getName().c_str();
+  }
+
+  bp::dict getNamedTargetValuesPython(const std::string& name)
+  {
+    bp::dict output;
+    std::map<std::string,double> positions = getNamedTargetValues(name);
+    std::map<std::string,double>::iterator iterator;
+
+    for (iterator = positions.begin(); iterator != positions.end(); iterator++)
+      output[iterator->first] = iterator->second;
+    return output;
+  }
+
+  bp::list getNamedTargetsPython()
+  {
+    return py_bindings_tools::listFromString(getNamedTargets());
   }
 
   bool movePython()
@@ -541,6 +569,9 @@ static void wrap_move_group_interface()
   MoveGroupClass.def("attach_object", &MoveGroupWrapper::attachObjectPython);
   MoveGroupClass.def("detach_object", &MoveGroupWrapper::detachObject);
   MoveGroupClass.def("retime_trajectory", &MoveGroupWrapper::retimeTrajectory);
+  MoveGroupClass.def("get_named_targets", &MoveGroupWrapper::getNamedTargetsPython);
+  MoveGroupClass.def("get_named_target_values", &MoveGroupWrapper::getNamedTargetValuesPython);
+  MoveGroupClass.def("get_current_state_bounded", &MoveGroupWrapper::getCurrentStateBoundedPython);
 }
 
 }

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -1248,10 +1248,17 @@ void MotionPlanningDisplay::load(const rviz::Config& config)
   if (frame_)
   {
     QString host;
+    ros::NodeHandle nh;
+    std::string host_param;
     if (config.mapGetString("MoveIt_Warehouse_Host", &host))
       frame_->ui_->database_host->setText(host);
+    else if (nh.getParam("warehouse_host", host_param))
+    {
+      host = QString::fromStdString(host_param);
+      frame_->ui_->database_host->setText(host);
+    }
     int port;
-    if (config.mapGetInt("MoveIt_Warehouse_Port", &port))
+    if (config.mapGetInt("MoveIt_Warehouse_Port", &port) || nh.getParam("warehouse_port", port))
       frame_->ui_->database_port->setValue(port);
     float d;
     if (config.mapGetFloat("MoveIt_Planning_Time", &d))

--- a/warehouse/warehouse/src/warehouse_services.cpp
+++ b/warehouse/warehouse/src/warehouse_services.cpp
@@ -86,6 +86,13 @@ bool getState(moveit_msgs::GetRobotStateFromWarehouse::Request&  request,
                moveit_msgs::GetRobotStateFromWarehouse::Response& response,
                moveit_warehouse::RobotStateStorage* rs)
 {
+  if (!rs->hasRobotState(request.name, request.robot))
+  {
+    ROS_ERROR_STREAM("No state called '" << request.name << "' for robot '" << request.robot << "'.");
+    moveit_msgs::RobotState dummy;
+    response.state = dummy;
+    return false;
+  }
   moveit_warehouse::RobotStateWithMetadata state_buffer;
   rs->getRobotState(state_buffer, request.name, request.robot);
   response.state = static_cast<const moveit_msgs::RobotState&>(*state_buffer);
@@ -96,6 +103,11 @@ bool renameState(moveit_msgs::RenameRobotStateInWarehouse::Request&  request,
                   moveit_msgs::RenameRobotStateInWarehouse::Response& response,
                   moveit_warehouse::RobotStateStorage* rs)
 {
+  if (!rs->hasRobotState(request.old_name, request.robot))
+  {
+    ROS_ERROR_STREAM("No state called '" << request.old_name << "' for robot '" << request.robot << "'.");
+    return false;
+  }
   rs->renameRobotState(request.old_name, request.new_name, request.robot);
   return true;
 }
@@ -104,6 +116,11 @@ bool deleteState(moveit_msgs::DeleteRobotStateFromWarehouse::Request&  request,
                   moveit_msgs::DeleteRobotStateFromWarehouse::Response& response,
                   moveit_warehouse::RobotStateStorage* rs)
 {
+  if (!rs->hasRobotState(request.name, request.robot))
+  {
+    ROS_ERROR_STREAM("No state called '" << request.name << "' for robot '" << request.robot << "'.");
+    return false;
+  }
   rs->removeRobotState(request.name, request.robot);
   return true;
 }


### PR DESCRIPTION
Rebased version of #693 
- This PR adds methods to retrieve named states via the move_group class.
- It also adds the corresponding python bindings for these methods.
- I also allows for the warehouse DB host to be specified from a parameter.
