### PR TITLE
Add manipulation msgs

### DIFF
--- a/manipulation/CMakeLists.txt
+++ b/manipulation/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
   moveit_ros_planning
   moveit_ros_move_group
   dynamic_reconfigure
+  manipulation_msgs
   roscpp
   rosconsole
   tf

--- a/manipulation/package.xml
+++ b/manipulation/package.xml
@@ -24,6 +24,7 @@
   <build_depend>moveit_ros_move_group</build_depend>
   <build_depend>moveit_ros_planning</build_depend>
   <build_depend>moveit_msgs</build_depend>
+  <build_depend>manipulation_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rosconsole</build_depend>
   <build_depend>tf</build_depend>


### PR DESCRIPTION
This missing dependency breaks the build when having to build the msgs from source because of https://github.com/ros-interactive-manipulation/manipulation_msgs/issues/7
