### PR TITLE
Added support for nodes handles with specific callbacks queues

### DIFF
--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -56,11 +56,20 @@ class CurrentStateMonitor
 {
 public:
 
-  /** @brief Constructor
+    /**
+     * @brief Constructor.
+     * @param robot_model The current kinematic model to build on
+     * @param tf A pointer to the tf transformer to use
+     */
+    CurrentStateMonitor(const robot_model::RobotModelConstPtr &robot_model, const boost::shared_ptr<tf::Transformer> &tf );
+
+  /** @brief Constructor.
    *  @param robot_model The current kinematic model to build on
    *  @param tf A pointer to the tf transformer to use
+   *  @param nh A ros::NodeHandle to pass node specific options
    */
-  CurrentStateMonitor(const robot_model::RobotModelConstPtr &robot_model, const boost::shared_ptr<tf::Transformer> &tf);
+  CurrentStateMonitor(const robot_model::RobotModelConstPtr &robot_model, const boost::shared_ptr<tf::Transformer> &tf,
+        ros::NodeHandle nh );
 
   ~CurrentStateMonitor();
 

--- a/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -38,8 +38,15 @@
 #include <tf_conversions/tf_eigen.h>
 #include <limits>
 
-planning_scene_monitor::CurrentStateMonitor::CurrentStateMonitor(const robot_model::RobotModelConstPtr &robot_model, const boost::shared_ptr<tf::Transformer> &tf)
-  : tf_(tf)
+planning_scene_monitor::CurrentStateMonitor::CurrentStateMonitor(const robot_model::RobotModelConstPtr &robot_model, const boost::shared_ptr<tf::Transformer> &tf )
+  : CurrentStateMonitor( robot_model, tf, ros::NodeHandle() )
+{
+}
+
+planning_scene_monitor::CurrentStateMonitor::CurrentStateMonitor(const robot_model::RobotModelConstPtr &robot_model, const boost::shared_ptr<tf::Transformer> &tf,
+                                                                 ros::NodeHandle nh )
+  : nh_( nh )
+  , tf_(tf)
   , robot_model_(robot_model)
   , robot_state_(robot_model)
   , state_monitor_started_(false)

--- a/planning_interface/common_planning_interface_objects/include/moveit/common_planning_interface_objects/common_objects.h
+++ b/planning_interface/common_planning_interface_objects/include/moveit/common_planning_interface_objects/common_objects.h
@@ -49,9 +49,29 @@ boost::shared_ptr<tf::Transformer> getSharedTF();
 
 robot_model::RobotModelConstPtr getSharedRobotModel(const std::string &robot_description);
 
-planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr &kmodel, const boost::shared_ptr<tf::Transformer> &tf);
+/**
+  @brief getSharedStateMonitor is a simpler version of getSharedStateMonitor(const robot_model::RobotModelConstPtr &kmodel, const boost::shared_ptr<tf::Transformer> &tf,
+    ros::NodeHandle nh = ros::NodeHandle() ). It calls this function using the default constructed ros::NodeHandle
 
-}
-}
+  @param kmodel
+  @param tf
+  @return
+ */
+planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr &kmodel, const boost::shared_ptr<tf::Transformer> &tf );
 
-#endif
+/**
+  @brief getSharedStateMonitor
+
+  @param kmodel
+  @param tf
+  @param nh A ros::NodeHandle to pass node specific configurations, such as callbacks queues.
+  @return
+ */
+planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr &kmodel, const boost::shared_ptr<tf::Transformer> &tf,
+    ros::NodeHandle nh );
+
+
+} // namespace planning interface
+} // namespace moveit
+
+#endif // end of MOVEIT_PLANNING_INTERFACE_COMMON_OBJECTS_

--- a/planning_interface/common_planning_interface_objects/src/common_objects.cpp
+++ b/planning_interface/common_planning_interface_objects/src/common_objects.cpp
@@ -96,7 +96,13 @@ robot_model::RobotModelConstPtr getSharedRobotModel(const std::string &robot_des
   }
 }
 
-planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr &kmodel, const boost::shared_ptr<tf::Transformer> &tf)
+planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr &kmodel, const boost::shared_ptr<tf::Transformer> &tf )
+{
+    return getSharedStateMonitor( kmodel, tf, ros::NodeHandle() );
+}
+
+planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot_model::RobotModelConstPtr &kmodel, const boost::shared_ptr<tf::Transformer> &tf,
+    ros::NodeHandle nh )
 {
   SharedStorage &s = getSharedStorage();
   boost::mutex::scoped_lock slock(s.lock_);
@@ -104,7 +110,7 @@ planning_scene_monitor::CurrentStateMonitorPtr getSharedStateMonitor(const robot
     return s.state_monitors_[kmodel->getName()];
   else
   {
-    planning_scene_monitor::CurrentStateMonitorPtr monitor(new planning_scene_monitor::CurrentStateMonitor(kmodel, tf));
+    planning_scene_monitor::CurrentStateMonitorPtr monitor(new planning_scene_monitor::CurrentStateMonitor(kmodel, tf, nh ));
     s.state_monitors_[kmodel->getName()] = monitor;
     return monitor;
   }

--- a/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -110,15 +110,22 @@ public:
     double planning_time_;
   };
 
-  /** \brief Construct a client for the MoveGroup action using a specified set of options \e opt. Optionally, specify a TF instance to use.
-      If not specified, one will be constructed internally. A timeout for connecting to the action server can also be specified. If it is not specified,
-      the wait time is unlimited. */
+  /**
+      \brief Construct a client for the MoveGroup action using a specified set of options \e opt.
+
+      \param opt. A MoveGroup::Options structure, if you pass a ros::NodeHandle with a specific callback queue, it has to be of type ros::CallbackQueue
+        (which is the default type of callback queues used in ROS)
+      \param tf. Specify a TF instance to use. If not specified, one will be constructed internally.
+      \param wait_for_server. Optional timeout for connecting to the action server. If it is not specified, the wait time is unlimited.
+    */
   MoveGroup(const Options &opt, const boost::shared_ptr<tf::Transformer> &tf = boost::shared_ptr<tf::Transformer>(),
             const ros::Duration &wait_for_server = ros::Duration(0, 0));
 
-  /** \brief Construct a client for the MoveGroup action for a particular \e group. Optionally, specify a TF instance to use.
+  /**
+      \brief Construct a client for the MoveGroup action for a particular \e group. Optionally, specify a TF instance to use.
       If not specified, one will be constructed internally. A timeout for connecting to the action server can also be specified. If it is not specified,
-      the wait time is unlimited. */
+      the wait time is unlimited.
+   */
   MoveGroup(const std::string &group, const boost::shared_ptr<tf::Transformer> &tf = boost::shared_ptr<tf::Transformer>(),
             const ros::Duration &wait_for_server = ros::Duration(0, 0));
 


### PR DESCRIPTION
Hello,

Working with MoveIt in my company showed the need for the possibility to pass node handles with specific callback queues to the move_group interface and the current state monitor.
These are the modifications that I made to have it working.
Let me know if there is anything you think I should update more.

Regards,
