### PR TITLE
#592 fixed by manually resetting the kinematics loader

### DIFF
--- a/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
+++ b/planning/kinematics_plugin_loader/src/kinematics_plugin_loader.cpp
@@ -77,6 +77,14 @@ public:
   }
 
   /**
+   * \brief Explicit destructor to avoid bugs in unloading the library
+   */
+  ~KinematicsLoaderImpl( )
+  {
+      kinematics_loader_.reset(); // we delete it manually
+  }
+
+  /**
    * \brief Helper function to decide which, and how many, tip frames a planning group has
    * \param jmg - joint model group pointer
    * \return tips - list of valid links in a planning group to plan for


### PR DESCRIPTION
Issue #592 was very annoying and prevented properly exiting from a running program.

I think this solves the issue, it does for my quite complex software and for the very simple example provided by @fontysrobotics.

Valgrind seem to have some complaints but:
- it is still better to allow people to properly cleanup their own data than throw this exception and have memory leaks
- valgrind always complains with ros, log4cpp for example 
- I can't tell if this is valid complain from valgrind or not.

Please let me know if I need to provide additionnal information.
