### PR TITLE
[moveit_ros_visualization] joy: Clean installation rule (addresses #638)

### DIFF
--- a/visualization/CMakeLists.txt
+++ b/visualization/CMakeLists.txt
@@ -36,7 +36,7 @@ find_package(catkin REQUIRED COMPONENTS
   rostest
 )
 find_package(Eigen REQUIRED)
-catkin_python_setup()
+
 catkin_package(
   LIBRARIES
     moveit_rviz_plugin_render_tools
@@ -54,6 +54,9 @@ catkin_package(
     moveit_ros_planning_interface
     moveit_ros_robot_interaction
     )
+
+catkin_install_python(PROGRAMS scripts/moveit_joy DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+catkin_python_setup()
 
 include_directories(rviz_plugin_render_tools/include
                     robot_state_rviz_plugin/include
@@ -82,8 +85,6 @@ install(FILES
   planning_scene_rviz_plugin_description.xml
   robot_state_rviz_plugin_description.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-
-install(PROGRAMS python/moveit_ros_visualization/moveit_joy.py DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 install(DIRECTORY icons DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 

--- a/visualization/scripts/moveit_joy
+++ b/visualization/scripts/moveit_joy
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2016, TORK (Tokyo Opensource Robotics Kyokai Association)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Tokyo Opensource Robotics Kyokai Association
+#    nor the names of its contributors may be used to endorse or promote 
+#    products derived from this software without specific prior written 
+#    permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from moveit_ros_visualization.moveit_joy import MoveitJoy
+import rospy
+
+if __name__ == "__main__":
+    rospy.init_node("moveit_joy")
+    app = MoveitJoy()
+    rospy.spin()

--- a/visualization/setup.py
+++ b/visualization/setup.py
@@ -3,6 +3,5 @@ from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup()
 d['packages'] = ['moveit_ros_visualization']
-d['scripts'] = []
-d['package_dir'] = {'': 'python'}
+d['package_dir'] = {'': 'src'}
 setup(**d)

--- a/visualization/src/moveit_ros_visualization/moveit_joy.py
+++ b/visualization/src/moveit_ros_visualization/moveit_joy.py
@@ -610,8 +610,3 @@ class MoveitJoy:
         self.marker_lock.acquire()
         self.initial_poses[self.current_pose_topic.split("/")[-1]] = new_pose.pose
         self.marker_lock.release()
-
-if __name__ == "__main__":
-    rospy.init_node("moveit_joy")
-    app = MoveitJoy()
-    rospy.spin()


### PR DESCRIPTION
Following [a document about installation of Python script and module](http://docs.ros.org/jade/api/catkin/html/howto/format2/installing_python.html) strictly as a cleaner solution to #638.
See also [an answer](http://answers.ros.org/question/224546/to-execute-modules-as-scripts-in-catkin/?answer=237926#post-id-237926).
