### PR TITLE
remove ~RobotModelLoader

### DIFF
--- a/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
+++ b/planning/robot_model_loader/include/moveit/robot_model_loader/robot_model_loader.h
@@ -97,8 +97,6 @@ public:
 
   RobotModelLoader(const std::string &robot_description, bool load_kinematics_solvers = true);
 
-  ~RobotModelLoader();
-
   /** @brief Get the constructed planning_models::RobotModel */
   const robot_model::RobotModelPtr& getModel() const
   {

--- a/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -51,13 +51,6 @@ robot_model_loader::RobotModelLoader::RobotModelLoader(const Options &opt)
   configure(opt);
 }
 
-robot_model_loader::RobotModelLoader::~RobotModelLoader()
-{
-  model_.reset();
-  rdf_loader_.reset();
-  kinematics_loader_.reset();
-}
-
 namespace
 {
 


### PR DESCRIPTION
The destructor only resetted shared_ptr of the class.
This automatically happens after the destructor finished anyway and the explicit resets disturb the default destructor order of the data structures.

Additionally this has the same effect as #702 and for some reason works around #592 over here.
This is not meant as a fix for #592, but it resolves the problem for the moment without adding new unnecessary code.
The real bug, as @rhaschke [pointed out](https://github.com/ros-planning/moveit_ros/pull/702#issuecomment-230703862), lies in internal design faults of pluginlib and class_loader and has to be resolved there.
