### PR TITLE
don't destroy SharedStorage

### DIFF
--- a/planning_interface/common_planning_interface_objects/src/common_objects.cpp
+++ b/planning_interface/common_planning_interface_objects/src/common_objects.cpp
@@ -61,8 +61,15 @@ struct SharedStorage
 
 SharedStorage& getSharedStorage()
 {
+#if 0 // destruction of static storage interferes with static destruction in class_loader
+  // More specifically, class_loader's static variables might be already destroyed
+  // while being accessed again in the destructor of the class_loader-based kinematics plugin.
   static SharedStorage storage;
   return storage;
+#else // thus avoid destruction at all (until class_loader is fixed)
+  static SharedStorage *storage = new SharedStorage;
+  return *storage;
+#endif
 }
 }
 


### PR DESCRIPTION
…  to avoid interference with destruction of class_loader's static variables
This is actually a workaround for design issues in [class_loader](https://github.com/ros/class_loader/pull/34#issuecomment-205002900).
Fixes #592. Replaces #702 and #705.
