### PR TITLE
Add nodehandle for specific params

### DIFF
--- a/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
+++ b/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
@@ -60,6 +60,8 @@ public:
   OccupancyMapMonitor(const boost::shared_ptr<tf::Transformer> &tf,
                       const std::string &map_frame = "", double map_resolution = 0.0);
   OccupancyMapMonitor(double map_resolution = 0.0);
+  OccupancyMapMonitor(const boost::shared_ptr<tf::Transformer> &tf, ros::NodeHandle &nh,
+                      const std::string &map_frame = "", double map_resolution = 0.0);
 
   ~OccupancyMapMonitor();
 

--- a/perception/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/perception/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -65,6 +65,17 @@ OccupancyMapMonitor::OccupancyMapMonitor(const boost::shared_ptr<tf::Transformer
   initialize();
 }
 
+OccupancyMapMonitor::OccupancyMapMonitor(const boost::shared_ptr<tf::Transformer> &tf, ros::NodeHandle &nh, const std::string &map_frame, double map_resolution) :
+  tf_(tf),
+  map_frame_(map_frame),
+  map_resolution_(map_resolution),
+  debug_info_(false),
+  mesh_handle_count_(0),
+  nh_(nh)
+{
+  initialize();
+}
+
 void OccupancyMapMonitor::initialize()
 {
   /* load params from param server */


### PR DESCRIPTION
Add an new constructor for ocuupancy_map_monitor to read from specifc param files. Which could be very helpful if we want to maintain several octomap_monitors
