### PR TITLE
safer rviz display

### DIFF
--- a/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -95,6 +95,11 @@ class MotionPlanningDisplay : public PlanningSceneDisplay
   virtual void update(float wall_dt, float ros_dt);
   virtual void reset();
 
+  bool usesCurrentStartState() const
+  {
+    return !query_start_state_property_->getBool();
+  }
+
   robot_state::RobotStateConstPtr getQueryStartState() const
   {
     return query_start_state_->getState();

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -131,7 +131,7 @@ MotionPlanningDisplay::MotionPlanningDisplay() :
   show_workspace_property_ = new rviz::BoolProperty("Show Workspace", false, "Shows the axis-aligned bounding box for the workspace allowed for planning",
                                                     plan_category_,
                                                     SLOT(changedWorkspace()), this);
-  query_start_state_property_ = new rviz::BoolProperty("Query Start State", true, "Shows the start state for the motion planning query",
+  query_start_state_property_ = new rviz::BoolProperty("Query Start State", false, "Set a custom start state for the motion planning query",
                                                        plan_category_,
                                                        SLOT(changedQueryStartState()), this);
   query_goal_state_property_ = new rviz::BoolProperty("Query Goal State", true, "Shows the goal state for the motion planning query",

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -110,7 +110,10 @@ void MotionPlanningFrame::computePlanButtonClicked()
   current_plan_.reset(new moveit::planning_interface::MoveGroup::Plan());
   if (move_group_->plan(*current_plan_))
   {
-    ui_->execute_button->setEnabled(true);
+    if ( planning_display_->usesCurrentStartState() )
+      ui_->execute_button->setEnabled(true);
+    else
+      ui_->execute_button->setEnabled(false);
 
     // Success
     ui_->result_label->setText(QString("Time: ").append(

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -212,7 +212,14 @@ void MotionPlanningFrame::updateQueryStateHelper(robot_state::RobotState &state,
         else
           if (v == "<same as start>")
           {
-            state = *planning_display_->getQueryStartState();
+            if ( planning_display_->usesCurrentStartState() )
+            {
+              const planning_scene_monitor::LockedPlanningSceneRO &ps = planning_display_->getPlanningSceneRO();
+              if (ps)
+                state = ps->getCurrentState();
+            }
+            else
+              state = *planning_display_->getQueryStartState();
           }
           else
           {

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -338,7 +338,11 @@ void MotionPlanningFrame::configureWorkspace()
 
 void MotionPlanningFrame::configureForPlanning()
 {
-  move_group_->setStartState(*planning_display_->getQueryStartState());
+  if ( planning_display_->usesCurrentStartState() )
+    move_group_->setStartStateToCurrentState();
+  else
+    move_group_->setStartState(*planning_display_->getQueryStartState());
+
   move_group_->setJointValueTarget(*planning_display_->getQueryGoalState());
   move_group_->setPlanningTime(ui_->planning_time->value());
   move_group_->setNumPlanningAttempts(ui_->planning_attempts->value());

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -118,6 +118,7 @@ void MotionPlanningFrame::computePlanButtonClicked()
   }
   else
   {
+    ui_->execute_button->setEnabled(false);
     current_plan_.reset();
 
     // Failure


### PR DESCRIPTION
In #646 we discussed that the display should not allow execution of arbitrary generated plans for safety reasons.
This request proposes to make it the default use-case to have the interactive start-state marker disabled and disable execution if it is enabled.

While this disallows executing trajectories even if the selected start-state equals the current state, it is the safest way to implement this that came to my mind.

Improvements and comments are welcome!

Fixes #646 .
