### PR TITLE
rviz plugin: stop execution + update of start state to current

### DIFF
--- a/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -210,6 +210,7 @@ private:
   void computeExecuteButtonClicked();
   void computePlanAndExecuteButtonClicked();
   void computePlanAndExecuteButtonClickedDisplayHelper();
+  void updateStartStateToCurrent();
   void populateConstraintsList();
   void populateConstraintsList(const std::vector<std::string> &constr);
   void configureForPlanning();

--- a/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -143,6 +143,7 @@ private Q_SLOTS:
   void planButtonClicked();
   void executeButtonClicked();
   void planAndExecuteButtonClicked();
+  void stopButtonClicked();
   void allowReplanningToggled(bool checked);
   void allowLookingToggled(bool checked);
   void allowExternalProgramCommunication(bool enable);
@@ -210,7 +211,8 @@ private:
   void computeExecuteButtonClicked();
   void computePlanAndExecuteButtonClicked();
   void computePlanAndExecuteButtonClickedDisplayHelper();
-  void updateStartStateToCurrent();
+  void computeStopButtonClicked();
+  void onFinishedExecution(bool success);
   void populateConstraintsList();
   void populateConstraintsList(const std::vector<std::string> &constr);
   void configureForPlanning();

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -131,7 +131,7 @@ MotionPlanningDisplay::MotionPlanningDisplay() :
   show_workspace_property_ = new rviz::BoolProperty("Show Workspace", false, "Shows the axis-aligned bounding box for the workspace allowed for planning",
                                                     plan_category_,
                                                     SLOT(changedWorkspace()), this);
-  query_start_state_property_ = new rviz::BoolProperty("Query Start State", true, "Shows the start state for the motion planning query",
+  query_start_state_property_ = new rviz::BoolProperty("Query Start State", false, "Set a custom start state for the motion planning query",
                                                        plan_category_,
                                                        SLOT(changedQueryStartState()), this);
   query_goal_state_property_ = new rviz::BoolProperty("Query Goal State", true, "Shows the goal state for the motion planning query",

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -70,6 +70,7 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay *pdisplay, rviz::
   connect( ui_->plan_button, SIGNAL( clicked() ), this, SLOT( planButtonClicked() ));
   connect( ui_->execute_button, SIGNAL( clicked() ), this, SLOT( executeButtonClicked() ));
   connect( ui_->plan_and_execute_button, SIGNAL( clicked() ), this, SLOT( planAndExecuteButtonClicked() ));
+  connect( ui_->stop_button, SIGNAL( clicked() ), this, SLOT( stopButtonClicked() ));
   connect( ui_->use_start_state_button, SIGNAL( clicked() ), this, SLOT( useStartStateButtonClicked() ));
   connect( ui_->use_goal_state_button, SIGNAL( clicked() ), this, SLOT( useGoalStateButtonClicked() ));
   connect( ui_->database_connect_button, SIGNAL( clicked() ), this, SLOT( databaseConnectButtonClicked() ));

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -130,6 +130,8 @@ void MotionPlanningFrame::computeExecuteButtonClicked()
 {
   if (move_group_ && current_plan_)
     move_group_->execute(*current_plan_);
+
+  updateStartStateToCurrent();
 }
 
 void MotionPlanningFrame::computePlanAndExecuteButtonClicked()
@@ -139,6 +141,16 @@ void MotionPlanningFrame::computePlanAndExecuteButtonClicked()
   configureForPlanning();
   move_group_->move();
   ui_->plan_and_execute_button->setEnabled(true);
+
+  updateStartStateToCurrent();
+}
+
+void MotionPlanningFrame::updateStartStateToCurrent()
+{
+  if (ui_->start_state_selection->currentText() == "<current>")
+  {
+    useStartStateButtonClicked();
+  }
 }
 
 void MotionPlanningFrame::useStartStateButtonClicked()

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -55,14 +55,16 @@ void MotionPlanningFrame::planButtonClicked()
 void MotionPlanningFrame::executeButtonClicked()
 {
   ui_->execute_button->setEnabled(false);
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computeExecuteButtonClicked, this), "execute");
+  // execution is done in a separate thread, to not block other background jobs by blocking for synchronous execution
+  planning_display_->spawnBackgroundJob(boost::bind(&MotionPlanningFrame::computeExecuteButtonClicked, this));
 }
 
 void MotionPlanningFrame::planAndExecuteButtonClicked()
 {
   ui_->plan_and_execute_button->setEnabled(false);
   ui_->execute_button->setEnabled(false);
-  planning_display_->addBackgroundJob(boost::bind(&MotionPlanningFrame::computePlanAndExecuteButtonClicked, this), "plan and execute");
+  // execution is done in a separate thread, to not block other background jobs by blocking for synchronous execution
+  planning_display_->spawnBackgroundJob(boost::bind(&MotionPlanningFrame::computePlanAndExecuteButtonClicked, this));
 }
 
 void MotionPlanningFrame::stopButtonClicked()

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -149,6 +149,9 @@ void MotionPlanningFrame::computePlanAndExecuteButtonClicked()
   if (!move_group_)
     return;
   configureForPlanning();
+  // move_group::move() on the server side, will always start from the current state
+  // to suppress a warning, we pass an empty state (which encodes "start from current state")
+  move_group_->setStartStateToCurrentState();
   ui_->stop_button->setEnabled(true);
   bool success = move_group_->move();
   onFinishedExecution(success);

--- a/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -238,6 +238,16 @@
                </widget>
               </item>
               <item>
+               <widget class="QPushButton" name="stop_button">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="text">
+                 <string>&amp;Stop</string>
+                </property>
+               </widget>
+              </item>
+              <item>
                <widget class="QLabel" name="result_label">
                 <property name="layoutDirection">
                  <enum>Qt::LeftToRight</enum>
@@ -1601,6 +1611,7 @@
   <tabstop>plan_button</tabstop>
   <tabstop>execute_button</tabstop>
   <tabstop>plan_and_execute_button</tabstop>
+  <tabstop>stop_button</tabstop>
   <tabstop>start_state_selection</tabstop>
   <tabstop>use_start_state_button</tabstop>
   <tabstop>goal_state_selection</tabstop>

--- a/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -87,15 +87,21 @@ public:
 
   void queueRenderSceneGeometry();
 
-  // pass the execution of this function call to a separate thread that runs in the background
+  /** Queue this function call for execution within the background thread
+      All jobs are queued and processed in order by a single background thread. */
   void addBackgroundJob(const boost::function<void()> &job, const std::string &name);
 
-  // queue the execution of this function for the next time the main update() loop gets called
+  /** Directly spawn a (detached) background thread for execution of this function call
+      Should be used, when order of processing is not relevant / job can run in parallel.
+      Must be used, when job will be blocking. Using addBackgroundJob() in this case will block other queued jobs as well */
+  void spawnBackgroundJob(const boost::function<void()> &job);
+
+  /// queue the execution of this function for the next time the main update() loop gets called
   void addMainLoopJob(const boost::function<void()> &job);
 
   void waitForAllMainLoopJobs();
 
-  // remove all queued jobs
+  /// remove all queued jobs
   void clearJobs();
 
   const std::string getMoveGroupNS() const;

--- a/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -232,6 +232,11 @@ void PlanningSceneDisplay::addBackgroundJob(const boost::function<void()> &job, 
   background_process_.addJob(job, name);
 }
 
+void PlanningSceneDisplay::spawnBackgroundJob(const boost::function<void ()> &job)
+{
+  boost::thread t(job);
+}
+
 void PlanningSceneDisplay::addMainLoopJob(const boost::function<void()> &job)
 {
   boost::unique_lock<boost::mutex> ulock(main_loop_jobs_lock_);


### PR DESCRIPTION
This PR combines ideas of #709 and #710 (and would replaces those PRs) to allow
- stopping of an executed trajectory (not working for execute-only button, see [comment](https://github.com/ros-planning/moveit_ros/pull/709#discussion_r70888457) in #709)
- updating the start state after execution, if current state is selected in gui (fixes #646)

I consider this work-in-progress. @davetcoleman Should we address [this comment](https://github.com/ros-planning/moveit_ros/pull/709#discussion_r70888457) like suggested?
