### PR TITLE
fix #442: race conditions when updating PlanningScene state

### DIFF
--- a/move_group/src/default_capabilities/execute_service_capability.cpp
+++ b/move_group/src/default_capabilities/execute_service_capability.cpp
@@ -70,14 +70,12 @@ bool move_group::MoveGroupExecuteService::executeTrajectoryService(moveit_msgs::
       moveit_controller_manager::ExecutionStatus es = context_->trajectory_execution_manager_->waitForExecution();
       if (es == moveit_controller_manager::ExecutionStatus::SUCCEEDED)
         res.error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
+      else if (es == moveit_controller_manager::ExecutionStatus::PREEMPTED)
+        res.error_code.val = moveit_msgs::MoveItErrorCodes::PREEMPTED;
+      else if (es == moveit_controller_manager::ExecutionStatus::TIMED_OUT)
+        res.error_code.val = moveit_msgs::MoveItErrorCodes::TIMED_OUT;
       else
-        if (es == moveit_controller_manager::ExecutionStatus::PREEMPTED)
-          res.error_code.val = moveit_msgs::MoveItErrorCodes::PREEMPTED;
-        else
-          if (es == moveit_controller_manager::ExecutionStatus::TIMED_OUT)
-            res.error_code.val = moveit_msgs::MoveItErrorCodes::TIMED_OUT;
-          else
-            res.error_code.val = moveit_msgs::MoveItErrorCodes::CONTROL_FAILED;
+        res.error_code.val = moveit_msgs::MoveItErrorCodes::CONTROL_FAILED;
       ROS_INFO_STREAM("Execution completed: " << es.asString());
     }
     else

--- a/move_group/src/default_capabilities/execute_service_capability.cpp
+++ b/move_group/src/default_capabilities/execute_service_capability.cpp
@@ -76,6 +76,8 @@ bool move_group::MoveGroupExecuteService::executeTrajectoryService(moveit_msgs::
         res.error_code.val = moveit_msgs::MoveItErrorCodes::TIMED_OUT;
       else
         res.error_code.val = moveit_msgs::MoveItErrorCodes::CONTROL_FAILED;
+      // wait for all planning scene updates to be processed
+      context_->planning_scene_monitor_->syncSceneUpdates();
       ROS_INFO_STREAM("Execution completed: " << es.asString());
     }
     else

--- a/move_group/src/default_capabilities/plan_service_capability.cpp
+++ b/move_group/src/default_capabilities/plan_service_capability.cpp
@@ -51,7 +51,7 @@ void move_group::MoveGroupPlanService::initialize()
 bool move_group::MoveGroupPlanService::computePlanService(moveit_msgs::GetMotionPlan::Request &req, moveit_msgs::GetMotionPlan::Response &res)
 {
   ROS_INFO("Received new planning service request...");
-  context_->planning_scene_monitor_->updateFrameTransforms();
+  context_->planning_scene_monitor_->syncSceneUpdates();
 
   bool solved = false;
   planning_scene_monitor::LockedPlanningSceneRO ps(context_->planning_scene_monitor_);

--- a/planning/CMakeLists.txt
+++ b/planning/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-find_package(Boost REQUIRED system filesystem date_time program_options signals thread)
+find_package(Boost REQUIRED system filesystem date_time program_options signals thread chrono)
 find_package(catkin REQUIRED COMPONENTS
   moveit_core
   moveit_ros_perception

--- a/planning/plan_execution/src/plan_execution.cpp
+++ b/planning/plan_execution/src/plan_execution.cpp
@@ -457,6 +457,8 @@ void plan_execution::PlanExecution::planningSceneUpdatedCallback(const planning_
 
 void plan_execution::PlanExecution::doneWithTrajectoryExecution(const moveit_controller_manager::ExecutionStatus &status)
 {
+  // sync all planning scene updates before continuing
+  planning_scene_monitor_->syncSceneUpdates();
   execution_complete_ = true;
 }
 

--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -411,14 +411,9 @@ protected:
   planning_scene::PlanningSceneConstPtr scene_const_;
   planning_scene::PlanningScenePtr      parent_scene_; /// if diffs are monitored, this is the pointer to the parent scene
   boost::shared_mutex                   scene_update_mutex_; /// mutex for stored scene
-  ros::Time                             last_update_time_; /// Last time the scene was updated
-  ros::Time                             last_robot_motion_time_; /// Last time the robot has moved
-  bool                                  enforce_next_state_update_;
 
   ros::NodeHandle                       nh_;
   ros::NodeHandle                       root_nh_;
-  ros::CallbackQueue                    callback_queue_;
-  boost::scoped_ptr<ros::AsyncSpinner>  spinner_;
   boost::shared_ptr<tf::Transformer>    tf_;
   std::string                           robot_description_;
 
@@ -471,6 +466,7 @@ protected:
   /// lock access to update_callbacks_
   boost::recursive_mutex update_lock_;
   std::vector<boost::function<void(SceneUpdateType)> > update_callbacks_; /// List of callbacks to trigger when updates are received
+  ros::Time last_update_time_; /// Last time the state was updated
 
 private:
 
@@ -521,6 +517,11 @@ private:
 
   class DynamicReconfigureImpl;
   DynamicReconfigureImpl *reconfigure_impl_;
+
+  ros::CallbackQueue                    callback_queue_;
+  boost::scoped_ptr<ros::AsyncSpinner>  spinner_;
+  ros::Time                             last_robot_motion_time_; /// Last time the robot has moved
+  bool                                  enforce_next_state_update_;
 };
 
 typedef boost::shared_ptr<PlanningSceneMonitor> PlanningSceneMonitorPtr;

--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -336,6 +336,9 @@ public:
   /** @brief This function is called every time there is a change to the planning scene */
   void triggerSceneUpdateEvent(SceneUpdateType update_type);
 
+  /** \brief Wait until all pending scene updates with timestamps < t are incorporated */
+  void syncSceneUpdates(const ros::Time &t = ros::Time::now());
+
   /** \brief Lock the scene for reading (multiple threads can lock for reading at the same time) */
   void lockSceneRead();
 
@@ -408,9 +411,14 @@ protected:
   planning_scene::PlanningSceneConstPtr scene_const_;
   planning_scene::PlanningScenePtr      parent_scene_; /// if diffs are monitored, this is the pointer to the parent scene
   boost::shared_mutex                   scene_update_mutex_; /// mutex for stored scene
+  ros::Time                             last_update_time_; /// Last time the scene was updated
+  ros::Time                             last_robot_motion_time_; /// Last time the robot has moved
+  bool                                  enforce_next_state_update_;
 
   ros::NodeHandle                       nh_;
   ros::NodeHandle                       root_nh_;
+  ros::CallbackQueue                    callback_queue_;
+  boost::scoped_ptr<ros::AsyncSpinner>  spinner_;
   boost::shared_ptr<tf::Transformer>    tf_;
   std::string                           robot_description_;
 
@@ -463,7 +471,6 @@ protected:
   /// lock access to update_callbacks_
   boost::recursive_mutex update_lock_;
   std::vector<boost::function<void(SceneUpdateType)> > update_callbacks_; /// List of callbacks to trigger when updates are received
-  ros::Time last_update_time_; /// Last time the state was updated
 
 private:
 
@@ -505,7 +512,7 @@ private:
 
   /// Last time the state was updated from current_state_monitor_
   // Only access this from callback functions (and constructor)
-  ros::WallTime last_state_update_;
+  ros::WallTime wall_last_state_update_;
 
   robot_model_loader::RobotModelLoaderPtr rm_loader_;
   robot_model::RobotModelConstPtr robot_model_;

--- a/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -817,9 +817,9 @@ void planning_scene_monitor::PlanningSceneMonitor::lockSceneRead()
 
 void planning_scene_monitor::PlanningSceneMonitor::unlockSceneRead()
 {
-  scene_update_mutex_.unlock_shared();
   if (octomap_monitor_)
     octomap_monitor_->getOcTreePtr()->unlockRead();
+  scene_update_mutex_.unlock_shared();
 }
 
 void planning_scene_monitor::PlanningSceneMonitor::lockSceneWrite()
@@ -831,9 +831,9 @@ void planning_scene_monitor::PlanningSceneMonitor::lockSceneWrite()
 
 void planning_scene_monitor::PlanningSceneMonitor::unlockSceneWrite()
 {
-  scene_update_mutex_.unlock();
   if (octomap_monitor_)
     octomap_monitor_->getOcTreePtr()->unlockWrite();
+  scene_update_mutex_.unlock();
 }
 
 void planning_scene_monitor::PlanningSceneMonitor::startSceneMonitor(const std::string &scene_topic)

--- a/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -619,6 +619,9 @@ public:
   /** \brief Given a \e plan, execute it while waiting for completion. Return true on success. */
   MoveItErrorCode execute(const Plan &plan);
 
+  /** \brief Validate that first point of given a \e plan matches current state of robot */
+  bool validatePlan(const Plan &plan);
+
   /** \brief Compute a Cartesian path that follows specified waypoints with a step size of at most \e eef_step meters
       between end effector configurations of consecutive points in the result \e trajectory. The reference frame for the
       waypoints is that specified by setPoseReferenceFrame(). No more than \e jump_threshold

--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -689,6 +689,38 @@ public:
     }
   }
 
+  bool validatePlan(const Plan &plan)
+  {
+    robot_state::RobotStatePtr current_state;
+    if (!getCurrentState(current_state))
+      return false;
+    if (plan.trajectory_.joint_trajectory.points.empty())
+      return true;
+
+    const trajectory_msgs::JointTrajectory &trajectory = plan.trajectory_.joint_trajectory;
+    const std::vector<double> &positions = trajectory.points.front().positions;
+    std::size_t n = trajectory.joint_names.size();
+    if (positions.size() != n)
+      return false;
+
+    for (std::size_t i = 0; i < n; ++i)
+    {
+      const robot_model::JointModel *jm = robot_model_->getJointModel(trajectory.joint_names[i]);
+      if (!jm)
+      {
+        ROS_ERROR_STREAM("Unknown joint in trajectory: " << trajectory.joint_names[i]);
+        return false;
+      }
+      // TODO: check multi-DoF joints
+      if (fabs(current_state->getJointPositions(jm)[0] - positions[i]) < std::numeric_limits<float>::epsilon())
+      {
+        ROS_ERROR("Trajectory start deviates from current robot state");
+        return false;
+      }
+    }
+    return true;
+  }
+
   double computeCartesianPath(const std::vector<geometry_msgs::Pose> &waypoints, double step, double jump_threshold,
                               moveit_msgs::RobotTrajectory &msg, bool avoid_collisions, moveit_msgs::MoveItErrorCodes &error_code)
   {
@@ -1176,6 +1208,11 @@ moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGrou
 moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGroup::execute(const Plan &plan)
 {
   return impl_->execute(plan, true);
+}
+
+bool moveit::planning_interface::MoveGroup::validatePlan(const moveit::planning_interface::MoveGroup::Plan &plan)
+{
+  return impl_->validatePlan(plan);
 }
 
 moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGroup::plan(Plan &plan)

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -139,7 +139,9 @@ void MotionPlanningFrame::computeExecuteButtonClicked()
   if (move_group_ && current_plan_)
   {
     ui_->stop_button->setEnabled(true); // enable stopping
-    bool success = move_group_->execute(*current_plan_);
+    bool success =
+      move_group_->validatePlan(*current_plan_) &&
+      move_group_->execute(*current_plan_);
     onFinishedExecution(success);
   }
 }

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -239,6 +239,7 @@ void MotionPlanningFrame::updateQueryStateHelper(robot_state::RobotState &state,
 
   if (v == "<current>")
   {
+    planning_display_->syncSceneUpdates();
     const planning_scene_monitor::LockedPlanningSceneRO &ps = planning_display_->getPlanningSceneRO();
     if (ps)
       state = ps->getCurrentState();
@@ -402,6 +403,7 @@ void MotionPlanningFrame::remoteUpdateStartStateCallback(const std_msgs::EmptyCo
 {
   if (move_group_ && planning_display_)
   {
+    planning_display_->syncSceneUpdates();
     robot_state::RobotState state = *planning_display_->getQueryStartState();
     const planning_scene_monitor::LockedPlanningSceneRO &ps = planning_display_->getPlanningSceneRO();
     if (ps)
@@ -416,6 +418,7 @@ void MotionPlanningFrame::remoteUpdateGoalStateCallback(const std_msgs::EmptyCon
 {
   if (move_group_ && planning_display_)
   {
+    planning_display_->syncSceneUpdates();
     robot_state::RobotState state = *planning_display_->getQueryStartState();
     const planning_scene_monitor::LockedPlanningSceneRO &ps = planning_display_->getPlanningSceneRO();
     if (ps)

--- a/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -106,7 +106,12 @@ public:
 
   const std::string getMoveGroupNS() const;
   const robot_model::RobotModelConstPtr& getRobotModel() const;
+
+  /// sync all planning scene updates up to time t
+  void syncSceneUpdates(const ros::Time &t = ros::Time::now());
+  /// get read-only access to planning scene
   planning_scene_monitor::LockedPlanningSceneRO getPlanningSceneRO() const;
+  /// get write access to planning scene
   planning_scene_monitor::LockedPlanningSceneRW getPlanningSceneRW();
   const planning_scene_monitor::PlanningSceneMonitorPtr& getPlanningSceneMonitor();
 

--- a/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -297,6 +297,12 @@ const robot_model::RobotModelConstPtr& PlanningSceneDisplay::getRobotModel() con
   }
 }
 
+void PlanningSceneDisplay::syncSceneUpdates(const ros::Time &t)
+{
+  if (planning_scene_monitor_)
+    planning_scene_monitor_->syncSceneUpdates(t);
+}
+
 planning_scene_monitor::LockedPlanningSceneRO PlanningSceneDisplay::getPlanningSceneRO() const
 {
   return planning_scene_monitor::LockedPlanningSceneRO(planning_scene_monitor_);


### PR DESCRIPTION
This wip branch is intended as joint collaboration branch to fix the race conditions in scene updates reported in #442. All developers are invited to contribute via additional PRs. I'm trying to centralize the discussion on this issue here.

Related PRs:
- #442 (reported issue)
- #671 (active waiting work-around)
- #686 (synchronous update work-around).

As pointed out in a [comment of #671](https://github.com/ros-planning/moveit_ros/pull/671#issuecomment-232843090) the fundamental underlying reason might be that scene update messages pile up in the callback queue (due to sequential processing by a single spinner thread). Hence, not only pending joint state updates may be missed, but also other scene updates.
Hence I suggest to modify `planning_scene_monitor::LockedPlanningSceneRO` such that it waits until all scene updates with `timestamp < ros::Time::now()` are processed and only then returns the current planning scene. Only this will ensure, that all pending scene updates are considered at a given time.

Proposed concrete changes:
- Have an own CallbackQueue and AsyncSpinner for a PlanningSceneMonitor (PSM) instance. This might conflict with #701.
- Handle the actual _incoming_ timestamps of planning scene updates. Currently, the throttling is performed [based on current timestamps](https://github.com/ros-planning/moveit_ros/blob/indigo-devel/planning/planning_scene_monitor/src/planning_scene_monitor.cpp#L1133).
- As this will conflict with throttling of (state) updates (requesting a LockedPlanningSceneRO will enforce to consider all pending updates), we need another mechanism for throttling. Essentially we have two use cases: 1. Another thread within move_group needs to read the current state and wants to ensure to get all pending updates. 2. The PSM regularly should publishes scene updates. If there are no other accesses to the PSM in between, there is no reason to perform state updates in between.

Before starting along that route, I'm waiting for positive feedback from some developers. And of course, I hope for active contributions. Please announce before you start to tackle a sub task.
