### PR TITLE
fix trajectory service blocking callback queue

### DIFF
--- a/move_group/src/default_capabilities/execute_service_capability.cpp
+++ b/move_group/src/default_capabilities/execute_service_capability.cpp
@@ -41,7 +41,7 @@
 move_group::MoveGroupExecuteService::MoveGroupExecuteService():
   MoveGroupCapability("ExecutePathService"),
   callback_queue_(),
-  spinner_(1, &callback_queue_)
+  spinner_(1 /* spinner threads */, &callback_queue_)
 {
 }
 
@@ -55,7 +55,7 @@ void move_group::MoveGroupExecuteService::initialize()
   // We need to serve each service request in a thread independent of the main spinner thread.
   // Otherwise, a synchronous execution request (i.e. waiting for the execution to finish) would block
   // execution of the main spinner thread.
-  // Hence, we use an own asynchronous spinner listening to our own callback queue.
+  // Hence, we use our own asynchronous spinner listening to our own callback queue.
   ros::AdvertiseServiceOptions ops;
   ops.template init<moveit_msgs::ExecuteKnownTrajectory::Request, moveit_msgs::ExecuteKnownTrajectory::Response>
       (EXECUTE_SERVICE_NAME, boost::bind(&MoveGroupExecuteService::executeTrajectoryService, this, _1, _2));

--- a/move_group/src/default_capabilities/execute_service_capability.cpp
+++ b/move_group/src/default_capabilities/execute_service_capability.cpp
@@ -39,13 +39,29 @@
 #include <moveit/move_group/capability_names.h>
 
 move_group::MoveGroupExecuteService::MoveGroupExecuteService():
-  MoveGroupCapability("ExecutePathService")
+  MoveGroupCapability("ExecutePathService"),
+  callback_queue_(),
+  spinner_(1, &callback_queue_)
 {
+}
+
+move_group::MoveGroupExecuteService::~MoveGroupExecuteService()
+{
+  spinner_.stop();
 }
 
 void move_group::MoveGroupExecuteService::initialize()
 {
-  execute_service_ = root_node_handle_.advertiseService(EXECUTE_SERVICE_NAME, &MoveGroupExecuteService::executeTrajectoryService, this);
+  // We need to serve each service request in a thread independent of the main spinner thread.
+  // Otherwise, a synchronous execution request (i.e. waiting for the execution to finish) would block
+  // execution of the main spinner thread.
+  // Hence, we use an own asynchronous spinner listening to our own callback queue.
+  ros::AdvertiseServiceOptions ops;
+  ops.template init<moveit_msgs::ExecuteKnownTrajectory::Request, moveit_msgs::ExecuteKnownTrajectory::Response>
+      (EXECUTE_SERVICE_NAME, boost::bind(&MoveGroupExecuteService::executeTrajectoryService, this, _1, _2));
+  ops.callback_queue = &callback_queue_;
+  execute_service_ = root_node_handle_.advertiseService(ops);
+  spinner_.start();
 }
 
 bool move_group::MoveGroupExecuteService::executeTrajectoryService(moveit_msgs::ExecuteKnownTrajectory::Request &req, moveit_msgs::ExecuteKnownTrajectory::Response &res)

--- a/move_group/src/default_capabilities/execute_service_capability.h
+++ b/move_group/src/default_capabilities/execute_service_capability.h
@@ -48,6 +48,7 @@ class MoveGroupExecuteService : public MoveGroupCapability
 public:
 
   MoveGroupExecuteService();
+  ~MoveGroupExecuteService();
 
   virtual void initialize();
 
@@ -56,6 +57,8 @@ private:
   bool executeTrajectoryService(moveit_msgs::ExecuteKnownTrajectory::Request &req, moveit_msgs::ExecuteKnownTrajectory::Response &res);
 
   ros::ServiceServer execute_service_;
+  ros::CallbackQueue callback_queue_;
+  ros::AsyncSpinner spinner_;
 };
 
 }

--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -130,19 +130,16 @@ public:
 
     current_state_monitor_ = getSharedStateMonitor( robot_model_, tf_, node_handle_ );
 
-    move_action_client_.reset(new actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction>(node_handle_,
-                                                                                              move_group::MOVE_ACTION,
-                                                                                              false));
+    move_action_client_.reset(new actionlib::SimpleActionClient<moveit_msgs::MoveGroupAction>
+                              (node_handle_, move_group::MOVE_ACTION, false));
     waitForAction(move_action_client_, wait_for_server, move_group::MOVE_ACTION);
 
-    pick_action_client_.reset(new actionlib::SimpleActionClient<moveit_msgs::PickupAction>(node_handle_,
-                                                                                           move_group::PICKUP_ACTION,
-                                                                                           false));
+    pick_action_client_.reset(new actionlib::SimpleActionClient<moveit_msgs::PickupAction>
+                              (node_handle_, move_group::PICKUP_ACTION, false));
     waitForAction(pick_action_client_, wait_for_server, move_group::PICKUP_ACTION);
 
-    place_action_client_.reset(new actionlib::SimpleActionClient<moveit_msgs::PlaceAction>(node_handle_,
-                                                                                           move_group::PLACE_ACTION,
-                                                                                           false));
+    place_action_client_.reset(new actionlib::SimpleActionClient<moveit_msgs::PlaceAction>
+                               (node_handle_, move_group::PLACE_ACTION, false));
     waitForAction(place_action_client_, wait_for_server, move_group::PLACE_ACTION);
 
     execute_service_ = node_handle_.serviceClient<moveit_msgs::ExecuteKnownTrajectory>(move_group::EXECUTE_SERVICE_NAME);


### PR DESCRIPTION
As an `ExecuteService` request might block (waiting for trajectory execution to finish),
processing of other events/callbacks from the main spinner thread would be blocked.

Hence, `ExecuteService` is now served  from a separate spinner thread, using a separate callback queue. This enables trajectory stopping in #713.

An alternative, IMHO even better approach is to turn the service into an action, which provides feedback and can be explicitly interrupted. I did that, but it requires several changes to existing moveit_config packages: as the service capability would be renamed (from `MoveGroupExecuteService` to `MoveGroupExecuteAction` all `move_group.launch` files would need an update.

However, I could think of a slow transition, adding the new capability in Kinetic and loading both the old and new capability in newly created `move_config` packages. In some later release we could remove the old service capability, hoping that meanwhile everybody has adapted their move configs.
What do you think of that idea?
