### PR TITLE
cherry-picked #713 from indigo-devel

### DIFF
--- a/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
+++ b/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.h
@@ -143,6 +143,7 @@ private Q_SLOTS:
   void planButtonClicked();
   void executeButtonClicked();
   void planAndExecuteButtonClicked();
+  void stopButtonClicked();
   void allowReplanningToggled(bool checked);
   void allowLookingToggled(bool checked);
   void allowExternalProgramCommunication(bool enable);
@@ -210,6 +211,8 @@ private:
   void computeExecuteButtonClicked();
   void computePlanAndExecuteButtonClicked();
   void computePlanAndExecuteButtonClickedDisplayHelper();
+  void computeStopButtonClicked();
+  void onFinishedExecution(bool success);
   void populateConstraintsList();
   void populateConstraintsList(const std::vector<std::string> &constr);
   void configureForPlanning();

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -131,7 +131,7 @@ MotionPlanningDisplay::MotionPlanningDisplay() :
   show_workspace_property_ = new rviz::BoolProperty("Show Workspace", false, "Shows the axis-aligned bounding box for the workspace allowed for planning",
                                                     plan_category_,
                                                     SLOT(changedWorkspace()), this);
-  query_start_state_property_ = new rviz::BoolProperty("Query Start State", true, "Shows the start state for the motion planning query",
+  query_start_state_property_ = new rviz::BoolProperty("Query Start State", false, "Set a custom start state for the motion planning query",
                                                        plan_category_,
                                                        SLOT(changedQueryStartState()), this);
   query_goal_state_property_ = new rviz::BoolProperty("Query Goal State", true, "Shows the goal state for the motion planning query",

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -70,6 +70,7 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay *pdisplay, rviz::
   connect( ui_->plan_button, SIGNAL( clicked() ), this, SLOT( planButtonClicked() ));
   connect( ui_->execute_button, SIGNAL( clicked() ), this, SLOT( executeButtonClicked() ));
   connect( ui_->plan_and_execute_button, SIGNAL( clicked() ), this, SLOT( planAndExecuteButtonClicked() ));
+  connect( ui_->stop_button, SIGNAL( clicked() ), this, SLOT( stopButtonClicked() ));
   connect( ui_->use_start_state_button, SIGNAL( clicked() ), this, SLOT( useStartStateButtonClicked() ));
   connect( ui_->use_goal_state_button, SIGNAL( clicked() ), this, SLOT( useGoalStateButtonClicked() ));
   connect( ui_->database_connect_button, SIGNAL( clicked() ), this, SLOT( databaseConnectButtonClicked() ));

--- a/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -267,6 +267,16 @@
                </widget>
               </item>
               <item>
+               <widget class="QPushButton" name="stop_button">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="text">
+                 <string>&amp;Stop</string>
+                </property>
+               </widget>
+              </item>
+              <item>
                <widget class="QLabel" name="result_label">
                 <property name="layoutDirection">
                  <enum>Qt::LeftToRight</enum>
@@ -1649,6 +1659,7 @@
   <tabstop>plan_button</tabstop>
   <tabstop>execute_button</tabstop>
   <tabstop>plan_and_execute_button</tabstop>
+  <tabstop>stop_button</tabstop>
   <tabstop>start_state_selection</tabstop>
   <tabstop>use_start_state_button</tabstop>
   <tabstop>goal_state_selection</tabstop>

--- a/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -87,15 +87,21 @@ public:
 
   void queueRenderSceneGeometry();
 
-  // pass the execution of this function call to a separate thread that runs in the background
+  /** Queue this function call for execution within the background thread
+      All jobs are queued and processed in order by a single background thread. */
   void addBackgroundJob(const boost::function<void()> &job, const std::string &name);
 
-  // queue the execution of this function for the next time the main update() loop gets called
+  /** Directly spawn a (detached) background thread for execution of this function call
+      Should be used, when order of processing is not relevant / job can run in parallel.
+      Must be used, when job will be blocking. Using addBackgroundJob() in this case will block other queued jobs as well */
+  void spawnBackgroundJob(const boost::function<void()> &job);
+
+  /// queue the execution of this function for the next time the main update() loop gets called
   void addMainLoopJob(const boost::function<void()> &job);
 
   void waitForAllMainLoopJobs();
 
-  // remove all queued jobs
+  /// remove all queued jobs
   void clearJobs();
 
   const std::string getMoveGroupNS() const;

--- a/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -232,6 +232,11 @@ void PlanningSceneDisplay::addBackgroundJob(const boost::function<void()> &job, 
   background_process_.addJob(job, name);
 }
 
+void PlanningSceneDisplay::spawnBackgroundJob(const boost::function<void ()> &job)
+{
+  boost::thread t(job);
+}
+
 void PlanningSceneDisplay::addMainLoopJob(const boost::function<void()> &job)
 {
   boost::unique_lock<boost::mutex> ulock(main_loop_jobs_lock_);


### PR DESCRIPTION
- cleanup structure of updateQueryStateHelper
- updateStartStateToCurrent after execution
- visualization: stop execution button
- suppress warning "Execution of motions should always start at the robot's current state." when planning+executing
- rviz display: disable Query Start State by default
