### PR TITLE
removed mongo_ros from warehouse and update benchmarks calls

### DIFF
--- a/benchmarks/benchmarks/include/moveit/benchmarks/benchmark_execution.h
+++ b/benchmarks/benchmarks/include/moveit/benchmarks/benchmark_execution.h
@@ -92,7 +92,7 @@ class BenchmarkExecution
 {
 public:
 
-  BenchmarkExecution(const planning_scene::PlanningScenePtr &scene, const std::string &host, std::size_t port);
+  BenchmarkExecution(const planning_scene::PlanningScenePtr &scene, warehouse_ros::DatabaseConnection::Ptr conn);
 
   bool readOptions(const std::string &filename);
   void printOptions(std::ostream &out);

--- a/benchmarks/benchmarks/src/benchmark_execution.cpp
+++ b/benchmarks/benchmarks/src/benchmark_execution.cpp
@@ -93,12 +93,13 @@ void checkHeader(moveit_msgs::Constraints &c, const std::string &header_frame)
 }
 }
 
-moveit_benchmarks::BenchmarkExecution::BenchmarkExecution(const planning_scene::PlanningScenePtr &scene, const std::string &host, std::size_t port) :
+moveit_benchmarks::BenchmarkExecution::BenchmarkExecution(const planning_scene::PlanningScenePtr &scene, warehouse_ros::DatabaseConnection::Ptr conn) :
   planning_scene_(scene),
-  pss_(host, port),
-  psws_(host, port),
-  cs_(host, port),
-  rs_(host, port)
+  pss_(conn),
+  psws_(conn),
+  cs_(conn),
+  tcs_(conn),
+  rs_(conn)
 {
   // load the pluginlib class loader
   try

--- a/benchmarks_gui/src/main_window.cpp
+++ b/benchmarks_gui/src/main_window.cpp
@@ -611,20 +611,27 @@ void MainWindow::dbConnectButtonClickedBackgroundJob()
       JobProcessing::addMainLoopJob(boost::bind(&setButtonState, ui_.db_connect_button, true, "Connecting...", "QPushButton { color : green }"));
       try
       {
-        planning_scene_storage_.reset(new moveit_warehouse::PlanningSceneStorage(database_host_,
-                                                                                 database_port_, 5.0));
-        robot_state_storage_.reset(new moveit_warehouse::RobotStateStorage(database_host_,
-                                                                           database_port_, 5.0));
-        constraints_storage_.reset(new moveit_warehouse::ConstraintsStorage(database_host_,
-                                                                            database_port_, 5.0));
-        trajectory_constraints_storage_.reset(new moveit_warehouse::TrajectoryConstraintsStorage(database_host_,
-                                                                                                 database_port_, 5.0));
+        warehouse_ros::DatabaseConnection::Ptr conn = moveit_warehouse::loadDatabase();
+	conn->setParams(database_host_, database_port_, 5.0);
+        if (conn->connect())
+	{
+        planning_scene_storage_.reset(new moveit_warehouse::PlanningSceneStorage(conn));
+        robot_state_storage_.reset(new moveit_warehouse::RobotStateStorage(conn));
+        constraints_storage_.reset(new moveit_warehouse::ConstraintsStorage(conn));
+        trajectory_constraints_storage_.reset(new moveit_warehouse::TrajectoryConstraintsStorage(conn));
         JobProcessing::addMainLoopJob(boost::bind(&setButtonState, ui_.db_connect_button, true, "Getting data...", "QPushButton { color : yellow }"));
 
         //Get all the scenes
         populatePlanningSceneList();
 
         JobProcessing::addMainLoopJob(boost::bind(&setButtonState, ui_.db_connect_button, true, "Disconnect", "QPushButton { color : blue }"));
+	}
+        else
+        {
+          JobProcessing::addMainLoopJob(boost::bind(&setButtonState, ui_.db_connect_button, false, "Connect", "QPushButton { color : green }"));
+          JobProcessing::addMainLoopJob(boost::bind(&showCriticalMessage, this, "Error", "Unable to connect to Database"));
+          return;
+        }      
       }
       catch(std::runtime_error &ex)
       {

--- a/benchmarks_gui/src/tab_states_and_goals.cpp
+++ b/benchmarks_gui/src/tab_states_and_goals.cpp
@@ -1079,9 +1079,17 @@ void MainWindow::runBenchmarkButtonClicked(void)
   {
     case QMessageBox::Yes:
     {
+      // Set up db
+      warehouse_ros::DatabaseConnection::Ptr conn = moveit_warehouse::loadDatabase();
+      conn->setParams(database_host_, database_port_, 10.0);
+      if (!conn->connect())
+      {
+        QMessageBox::warning(this, "Error", QString("Unable to connect to Database"));
+        break;
+      }
       QString outfilename =  run_benchmark_ui_.benchmark_output_folder_text->text().append("/config.cfg");
       moveit_benchmarks::BenchmarkType btype = 0;
-      moveit_benchmarks::BenchmarkExecution be(scene_display_->getPlanningSceneMonitor()->getPlanningScene(), database_host_, database_port_);
+      moveit_benchmarks::BenchmarkExecution be(scene_display_->getPlanningSceneMonitor()->getPlanningScene(), conn);
       if (run_benchmark_ui_.benchmark_include_planners_checkbox->isChecked())
         btype += moveit_benchmarks::BENCHMARK_PLANNERS;
       if (run_benchmark_ui_.benchmark_check_reachability_checkbox->isChecked())

--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -1019,8 +1019,12 @@ private:
   {
     try
     {
-      constraints_storage_.reset(new moveit_warehouse::ConstraintsStorage(host, port));
-      ROS_DEBUG("Connected to constraints database");
+      warehouse_ros::DatabaseConnection::Ptr conn = moveit_warehouse::loadDatabase();
+      conn->setParams(host, port);
+      if (conn->connect())
+      { 
+        constraints_storage_.reset(new moveit_warehouse::ConstraintsStorage(conn));
+      }
     }
     catch(std::runtime_error &ex)
     {

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_context.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_context.cpp
@@ -117,12 +117,19 @@ void MotionPlanningFrame::computeDatabaseConnectButtonClicked()
     planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 2));
     try
     {
-      planning_scene_storage_.reset(new moveit_warehouse::PlanningSceneStorage(ui_->database_host->text().toStdString(),
-                                                                               ui_->database_port->value(), 5.0));
-      robot_state_storage_.reset(new moveit_warehouse::RobotStateStorage(ui_->database_host->text().toStdString(),
-                                                                         ui_->database_port->value(), 5.0));
-      constraints_storage_.reset(new moveit_warehouse::ConstraintsStorage(ui_->database_host->text().toStdString(),
-                                                                          ui_->database_port->value(), 5.0));
+      warehouse_ros::DatabaseConnection::Ptr conn = moveit_warehouse::loadDatabase();
+      conn->setParams(ui_->database_host->text().toStdString(), ui_->database_port->value(), 5.0);
+      if (conn->connect())
+      {
+        planning_scene_storage_.reset(new moveit_warehouse::PlanningSceneStorage(conn));
+        robot_state_storage_.reset(new moveit_warehouse::RobotStateStorage(conn));
+        constraints_storage_.reset(new moveit_warehouse::ConstraintsStorage(conn));
+      }
+      else
+      {
+        planning_display_->addMainLoopJob(boost::bind(&MotionPlanningFrame::computeDatabaseConnectButtonClickedHelper, this, 3));
+        return;
+      }
     }
     catch(std::runtime_error &ex)
     {

--- a/warehouse/CHANGELOG.rst
+++ b/warehouse/CHANGELOG.rst
@@ -2,16 +2,12 @@
 Changelog for package moveit_ros_warehouse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.7.2 (2016-06-20)
-------------------
-
-0.7.1 (2016-04-11)
-------------------
-
-0.7.0 (2016-01-30)
+0.6.6 (2016-06-08)
 ------------------
 * Removed trailing whitespace from entire repository
+* comments addressed
 * changed to global node handle so warehouse connection params work correctly
+* camelCase
 * removed extraneous includes
 * added delete and rename
 * now takes port + host from param server

--- a/warehouse/package.xml
+++ b/warehouse/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>moveit_ros_warehouse</name>
-  <version>0.7.2</version>
+  <version>0.6.6</version>
   <description>Components of MoveIt connecting to MongoDB</description>
 
   <author email="isucan@google.com">Ioan Sucan</author>

--- a/warehouse/warehouse/include/moveit/warehouse/constraints_storage.h
+++ b/warehouse/warehouse/include/moveit/warehouse/constraints_storage.h
@@ -43,8 +43,8 @@
 namespace moveit_warehouse
 {
 
-typedef mongo_ros::MessageWithMetadata<moveit_msgs::Constraints>::ConstPtr ConstraintsWithMetadata;
-typedef boost::shared_ptr<mongo_ros::MessageCollection<moveit_msgs::Constraints> > ConstraintsCollection;
+typedef warehouse_ros::MessageWithMetadata<moveit_msgs::Constraints>::ConstPtr ConstraintsWithMetadata;
+typedef warehouse_ros::MessageCollection<moveit_msgs::Constraints>::Ptr ConstraintsCollection;
 
 class ConstraintsStorage : public MoveItMessageStorage
 {
@@ -56,13 +56,7 @@ public:
   static const std::string CONSTRAINTS_GROUP_NAME;
   static const std::string ROBOT_NAME;
 
-
-  /** \brief Initialize the constraints storage to connect to a specified \e host and \e port for the MongoDB.
-      If defaults are used for the parameters (empty host name, 0 port), the constructor looks for ROS params specifying
-      which host/port to use. NodeHandle::searchParam() is used starting from ~ to look for warehouse_port and warehouse_host.
-      If no values are found, the defaults are left to be the ones MongoDB uses.
-      If \e wait_seconds is above 0, then a maximum number of seconds can elapse until connection is successful, or a runtime exception is thrown. */
-  ConstraintsStorage(const std::string &host = "", const unsigned int port = 0, double wait_seconds = 5.0);
+  ConstraintsStorage(warehouse_ros::DatabaseConnection::Ptr conn);
 
   void addConstraints(const moveit_msgs::Constraints &msg, const std::string &robot = "", const std::string &group = "");
   bool hasConstraints(const std::string &name, const std::string &robot = "", const std::string &group = "") const;

--- a/warehouse/warehouse/include/moveit/warehouse/moveit_message_storage.h
+++ b/warehouse/warehouse/include/moveit/warehouse/moveit_message_storage.h
@@ -37,48 +37,32 @@
 #ifndef MOVEIT_MOVEIT_WAREHOUSE_MOVEIT_MESSAGE_STORAGE_
 #define MOVEIT_MOVEIT_WAREHOUSE_MOVEIT_MESSAGE_STORAGE_
 
-#include <mongo_ros/message_collection.h>
+#include <warehouse_ros/database_connection.h>
 #include <vector>
 #include <string>
 
 namespace moveit_warehouse
 {
 
-/** \brief This class provides the mechanism to connect to a MongoDB and reads needed ROS parameters when appropriate. */
+/** \brief This class provides the mechanism to connect to a database and reads needed ROS parameters when appropriate. */
 class MoveItMessageStorage
 {
 public:
-  /** \brief Initialize the storage to connect to a specified \e host and \e port for the MongoDB.
-      If defaults are used for the parameters (empty host name, 0 port), the constructor looks for ROS params specifying
-      which host/port to use. NodeHandle::searchParam() is used starting from ~ to look for warehouse_port and warehouse_host.
-      If these params are not found either, a final attempt is made to look for the param values under /moveit_warehouse/warehouse_*.
-      If no values are found, the defaults are left to be the ones MongoDB uses.
-      If \e wait_seconds is above 0, then a maximum number of seconds can elapse until connection is successful, or a runtime exception is thrown. */
-  MoveItMessageStorage(const std::string &host = "", const unsigned int port = 0, double wait_seconds = 5.0);
+  /// \brief Takes a warehouse_ros DatabaseConnection.  The DatabaseConnection is expected to have already been initialized.
+  MoveItMessageStorage(warehouse_ros::DatabaseConnection::Ptr conn);
 
-  virtual ~MoveItMessageStorage();
-
-  const std::string& getDatabaseHost() const
-  {
-    return db_host_;
-  }
-
-  unsigned int getDatabasePort() const
-  {
-    return db_port_;
-  }
+  virtual ~MoveItMessageStorage() {}
 
 protected:
-
   /// Keep only the \e names that match \e regex
   void filterNames(const std::string &regex, std::vector<std::string> &names) const;
 
-  void drop(const std::string &db);
-
-  std::string  db_host_;
-  unsigned int db_port_;
-  double       timeout_;
+  warehouse_ros::DatabaseConnection::Ptr conn_;
 };
+
+/// \brief Load a database connection
+typename warehouse_ros::DatabaseConnection::Ptr loadDatabase();
+
 }
 
 #endif

--- a/warehouse/warehouse/include/moveit/warehouse/planning_scene_storage.h
+++ b/warehouse/warehouse/include/moveit/warehouse/planning_scene_storage.h
@@ -45,13 +45,13 @@
 namespace moveit_warehouse
 {
 
-typedef mongo_ros::MessageWithMetadata<moveit_msgs::PlanningScene>::ConstPtr PlanningSceneWithMetadata;
-typedef mongo_ros::MessageWithMetadata<moveit_msgs::MotionPlanRequest>::ConstPtr MotionPlanRequestWithMetadata;
-typedef mongo_ros::MessageWithMetadata<moveit_msgs::RobotTrajectory>::ConstPtr RobotTrajectoryWithMetadata;
+typedef warehouse_ros::MessageWithMetadata<moveit_msgs::PlanningScene>::ConstPtr PlanningSceneWithMetadata;
+typedef warehouse_ros::MessageWithMetadata<moveit_msgs::MotionPlanRequest>::ConstPtr MotionPlanRequestWithMetadata;
+typedef warehouse_ros::MessageWithMetadata<moveit_msgs::RobotTrajectory>::ConstPtr RobotTrajectoryWithMetadata;
 
-typedef boost::shared_ptr<mongo_ros::MessageCollection<moveit_msgs::PlanningScene> > PlanningSceneCollection;
-typedef boost::shared_ptr<mongo_ros::MessageCollection<moveit_msgs::MotionPlanRequest> > MotionPlanRequestCollection;
-typedef boost::shared_ptr<mongo_ros::MessageCollection<moveit_msgs::RobotTrajectory> > RobotTrajectoryCollection;
+typedef warehouse_ros::MessageCollection<moveit_msgs::PlanningScene>::Ptr PlanningSceneCollection;
+typedef warehouse_ros::MessageCollection<moveit_msgs::MotionPlanRequest>::Ptr MotionPlanRequestCollection;
+typedef warehouse_ros::MessageCollection<moveit_msgs::RobotTrajectory>::Ptr RobotTrajectoryCollection;
 
 class PlanningSceneStorage : public MoveItMessageStorage
 {
@@ -62,12 +62,7 @@ public:
   static const std::string PLANNING_SCENE_ID_NAME;
   static const std::string MOTION_PLAN_REQUEST_ID_NAME;
 
-  /** \brief Initialize the planning scene storage to connect to a specified \e host and \e port for the MongoDB.
-      If defaults are used for the parameters (empty host name, 0 port), the constructor looks for ROS params specifying
-      which host/port to use. NodeHandle::searchParam() is used starting from ~ to look for warehouse_port and warehouse_host.
-      If no values are found, the defaults are left to be the ones MongoDB uses.
-      If \e wait_seconds is above 0, then a maximum number of seconds can elapse until connection is successful, or a runtime exception is thrown. */
-  PlanningSceneStorage(const std::string &host = "", const unsigned int port = 0, double wait_seconds = 5.0);
+  PlanningSceneStorage(warehouse_ros::DatabaseConnection::Ptr conn);
 
   void addPlanningScene(const moveit_msgs::PlanningScene &scene);
   void addPlanningQuery(const moveit_msgs::MotionPlanRequest &planning_query, const std::string &scene_name, const std::string &query_name = "");

--- a/warehouse/warehouse/include/moveit/warehouse/planning_scene_world_storage.h
+++ b/warehouse/warehouse/include/moveit/warehouse/planning_scene_world_storage.h
@@ -43,9 +43,8 @@
 namespace moveit_warehouse
 {
 
-typedef mongo_ros::MessageWithMetadata<moveit_msgs::PlanningSceneWorld>::ConstPtr PlanningSceneWorldWithMetadata;
-typedef boost::shared_ptr<mongo_ros::MessageCollection<moveit_msgs::PlanningSceneWorld> > PlanningSceneWorldCollection;
-
+typedef warehouse_ros::MessageWithMetadata<moveit_msgs::PlanningSceneWorld>::ConstPtr PlanningSceneWorldWithMetadata;
+typedef warehouse_ros::MessageCollection<moveit_msgs::PlanningSceneWorld>::Ptr PlanningSceneWorldCollection;
 
 class PlanningSceneWorldStorage : public MoveItMessageStorage
 {
@@ -54,13 +53,7 @@ public:
   static const std::string DATABASE_NAME;
   static const std::string PLANNING_SCENE_WORLD_ID_NAME;
 
-
-  /** \brief Initialize the planning scene world storage to connect to a specified \e host and \e port for the MongoDB.
-      If defaults are used for the parameters (empty host name, 0 port), the constructor looks for ROS params specifying
-      which host/port to use. NodeHandle::searchParam() is used starting from ~ to look for warehouse_port and warehouse_host.
-      If no values are found, the defaults are left to be the ones MongoDB uses.
-      If \e wait_seconds is above 0, then a maximum number of seconds can elapse until connection is successful, or a runtime exception is thrown. */
-  PlanningSceneWorldStorage(const std::string &host = "", const unsigned int port = 0, double wait_seconds = 5.0);
+  PlanningSceneWorldStorage(warehouse_ros::DatabaseConnection::Ptr conn);
 
   void addPlanningSceneWorld(const moveit_msgs::PlanningSceneWorld &msg, const std::string &name);
   bool hasPlanningSceneWorld(const std::string &name) const;

--- a/warehouse/warehouse/include/moveit/warehouse/state_storage.h
+++ b/warehouse/warehouse/include/moveit/warehouse/state_storage.h
@@ -43,8 +43,8 @@
 namespace moveit_warehouse
 {
 
-typedef mongo_ros::MessageWithMetadata<moveit_msgs::RobotState>::ConstPtr RobotStateWithMetadata;
-typedef boost::shared_ptr<mongo_ros::MessageCollection<moveit_msgs::RobotState> > RobotStateCollection;
+typedef warehouse_ros::MessageWithMetadata<moveit_msgs::RobotState>::ConstPtr RobotStateWithMetadata;
+typedef warehouse_ros::MessageCollection<moveit_msgs::RobotState>::Ptr RobotStateCollection;
 
 class RobotStateStorage : public MoveItMessageStorage
 {
@@ -55,12 +55,7 @@ public:
   static const std::string STATE_NAME;
   static const std::string ROBOT_NAME;
 
-  /** \brief Initialize the state storage to connect to a specified \e host and \e port for the MongoDB.
-      If defaults are used for the parameters (empty host name, 0 port), the constructor looks for ROS params specifying
-      which host/port to use. NodeHandle::searchParam() is used starting from ~ to look for warehouse_port and warehouse_host.
-      If no values are found, the defaults are left to be the ones MongoDB uses.
-      If \e wait_seconds is above 0, then a maximum number of seconds can elapse until connection is successful, or a runtime exception is thrown. */
-  RobotStateStorage(const std::string &host = "", const unsigned int port = 0, double wait_seconds = 5.0);
+  RobotStateStorage(warehouse_ros::DatabaseConnection::Ptr conn);
 
   void addRobotState(const moveit_msgs::RobotState &msg, const std::string &name, const std::string &robot = "");
   bool hasRobotState(const std::string &name, const std::string &robot = "") const;

--- a/warehouse/warehouse/include/moveit/warehouse/trajectory_constraints_storage.h
+++ b/warehouse/warehouse/include/moveit/warehouse/trajectory_constraints_storage.h
@@ -43,8 +43,8 @@
 namespace moveit_warehouse
 {
 
-typedef mongo_ros::MessageWithMetadata<moveit_msgs::TrajectoryConstraints>::ConstPtr TrajectoryConstraintsWithMetadata;
-typedef boost::shared_ptr<mongo_ros::MessageCollection<moveit_msgs::TrajectoryConstraints> > TrajectoryConstraintsCollection;
+typedef warehouse_ros::MessageWithMetadata<moveit_msgs::TrajectoryConstraints>::ConstPtr TrajectoryConstraintsWithMetadata;
+typedef warehouse_ros::MessageCollection<moveit_msgs::TrajectoryConstraints>::Ptr TrajectoryConstraintsCollection;
 
 class TrajectoryConstraintsStorage : public MoveItMessageStorage
 {
@@ -56,13 +56,7 @@ public:
   static const std::string CONSTRAINTS_GROUP_NAME;
   static const std::string ROBOT_NAME;
 
-
-  /** \brief Initialize the trajectory constraints storage to connect to a specified \e host and \e port for the MongoDB.
-      If defaults are used for the parameters (empty host name, 0 port), the constructor looks for ROS params specifying
-      which host/port to use. NodeHandle::searchParam() is used starting from ~ to look for warehouse_port and warehouse_host.
-      If no values are found, the defaults are left to be the ones MongoDB uses.
-      If \e wait_seconds is above 0, then a maximum number of seconds can elapse until connection is successful, or a runtime exception is thrown. */
-  TrajectoryConstraintsStorage(const std::string &host = "", const unsigned int port = 0, double wait_seconds = 5.0);
+  TrajectoryConstraintsStorage(warehouse_ros::DatabaseConnection::Ptr conn);
 
   void addTrajectoryConstraints(const moveit_msgs::TrajectoryConstraints &msg, const std::string &name, const std::string &robot = "", const std::string &group = "");
   bool hasTrajectoryConstraints(const std::string &name, const std::string &robot = "", const std::string &group = "") const;

--- a/warehouse/warehouse/include/moveit/warehouse/warehouse_connector.h
+++ b/warehouse/warehouse/include/moveit/warehouse/warehouse_connector.h
@@ -46,7 +46,7 @@ class WarehouseConnector
 {
 public:
 
-  WarehouseConnector(const std::string &mongoexec);
+  WarehouseConnector(const std::string &dbexec);
 
   ~WarehouseConnector();
 
@@ -54,7 +54,7 @@ public:
 
 private:
 
-  std::string mongoexec_;
+  std::string dbexec_;
   int child_pid_;
 };
 

--- a/warehouse/warehouse/src/import_from_text.cpp
+++ b/warehouse/warehouse/src/import_from_text.cpp
@@ -208,8 +208,8 @@ int main(int argc, char **argv)
     ("help", "Show help message")
     ("queries", boost::program_options::value<std::string>(), "Name of file containing motion planning queries.")
     ("scene", boost::program_options::value<std::string>(), "Name of file containing motion planning scene.")
-    ("host", boost::program_options::value<std::string>(), "Host for the MongoDB.")
-    ("port", boost::program_options::value<std::size_t>(), "Port for the MongoDB.");
+    ("host", boost::program_options::value<std::string>(), "Host for the DB.")
+    ("port", boost::program_options::value<std::size_t>(), "Port for the DB.");
 
   boost::program_options::variables_map vm;
   boost::program_options::store(boost::program_options::parse_command_line(argc, argv, desc), vm);
@@ -220,6 +220,12 @@ int main(int argc, char **argv)
     std::cout << desc << std::endl;
     return 1;
   }
+  // Set up db
+  warehouse_ros::DatabaseConnection::Ptr conn = moveit_warehouse::loadDatabase();
+  if (vm.count("host") && vm.count("port"))
+    conn->setParams(vm["host"].as<std::string>(), vm["port"].as<std::size_t>());
+  if (!conn->connect())
+    return 1;
 
   ros::AsyncSpinner spinner(1);
   spinner.start();
@@ -232,12 +238,9 @@ int main(int argc, char **argv)
     return 1;
   }
 
-  moveit_warehouse::PlanningSceneStorage pss(vm.count("host") ? vm["host"].as<std::string>() : "",
-                                             vm.count("port") ? vm["port"].as<std::size_t>() : 0);
-  moveit_warehouse::ConstraintsStorage cs(vm.count("host") ? vm["host"].as<std::string>() : "",
-                                          vm.count("port") ? vm["port"].as<std::size_t>() : 0);
-  moveit_warehouse::RobotStateStorage rs(vm.count("host") ? vm["host"].as<std::string>() : "",
-                                         vm.count("port") ? vm["port"].as<std::size_t>() : 0);
+  moveit_warehouse::PlanningSceneStorage pss(conn);
+  moveit_warehouse::ConstraintsStorage cs(conn);
+  moveit_warehouse::RobotStateStorage rs(conn);
 
   if (vm.count("scene"))
   {

--- a/warehouse/warehouse/src/moveit_message_storage.cpp
+++ b/warehouse/warehouse/src/moveit_message_storage.cpp
@@ -37,7 +37,6 @@
 #include <moveit/warehouse/moveit_message_storage.h>
 #include <warehouse_ros/database_loader.h>
 #include <boost/scoped_ptr.hpp>
-//#include <warehouse_ros_mongo/database_connection.h>
 #include <boost/regex.hpp>
 
 moveit_warehouse::MoveItMessageStorage::MoveItMessageStorage(warehouse_ros::DatabaseConnection::Ptr conn) :

--- a/warehouse/warehouse/src/planning_scene_storage.cpp
+++ b/warehouse/warehouse/src/planning_scene_storage.cpp
@@ -42,18 +42,20 @@ const std::string moveit_warehouse::PlanningSceneStorage::DATABASE_NAME = "movei
 const std::string moveit_warehouse::PlanningSceneStorage::PLANNING_SCENE_ID_NAME = "planning_scene_id";
 const std::string moveit_warehouse::PlanningSceneStorage::MOTION_PLAN_REQUEST_ID_NAME = "motion_request_id";
 
-moveit_warehouse::PlanningSceneStorage::PlanningSceneStorage(const std::string &host, const unsigned int port, double wait_seconds) :
-  MoveItMessageStorage(host, port, wait_seconds)
+using warehouse_ros::Metadata;
+using warehouse_ros::Query;
+
+moveit_warehouse::PlanningSceneStorage::PlanningSceneStorage(warehouse_ros::DatabaseConnection::Ptr conn) :
+  MoveItMessageStorage(conn)
 {
   createCollections();
-  ROS_DEBUG("Connected to MongoDB '%s' on host '%s' port '%u'.", DATABASE_NAME.c_str(), db_host_.c_str(), db_port_);
 }
 
 void moveit_warehouse::PlanningSceneStorage::createCollections()
 {
-  planning_scene_collection_.reset(new PlanningSceneCollection::element_type(DATABASE_NAME, "planning_scene", db_host_, db_port_, timeout_));
-  motion_plan_request_collection_.reset(new MotionPlanRequestCollection::element_type(DATABASE_NAME, "motion_plan_request", db_host_, db_port_, timeout_));
-  robot_trajectory_collection_.reset(new RobotTrajectoryCollection::element_type(DATABASE_NAME, "robot_trajectory", db_host_, db_port_, timeout_));
+  planning_scene_collection_ = conn_->openCollectionPtr<moveit_msgs::PlanningScene>(DATABASE_NAME, "planning_scene");
+  motion_plan_request_collection_ = conn_->openCollectionPtr<moveit_msgs::MotionPlanRequest>(DATABASE_NAME, "motion_plan_request");
+  robot_trajectory_collection_ = conn_->openCollectionPtr<moveit_msgs::RobotTrajectory>(DATABASE_NAME, "robot_trajectory");
 }
 
 void moveit_warehouse::PlanningSceneStorage::reset()
@@ -61,7 +63,7 @@ void moveit_warehouse::PlanningSceneStorage::reset()
   planning_scene_collection_.reset();
   motion_plan_request_collection_.reset();
   robot_trajectory_collection_.reset();
-  MoveItMessageStorage::drop(DATABASE_NAME);
+  conn_->dropDatabase(DATABASE_NAME);
   createCollections();
 }
 
@@ -73,23 +75,26 @@ void moveit_warehouse::PlanningSceneStorage::addPlanningScene(const moveit_msgs:
     removePlanningScene(scene.name);
     replace = true;
   }
-  mongo_ros::Metadata metadata(PLANNING_SCENE_ID_NAME, scene.name);
+  Metadata::Ptr metadata = planning_scene_collection_->createMetadata();
+  metadata->append(PLANNING_SCENE_ID_NAME, scene.name);
   planning_scene_collection_->insert(scene, metadata);
   ROS_DEBUG("%s scene '%s'", replace ? "Replaced" : "Added", scene.name.c_str());
 }
 
 bool moveit_warehouse::PlanningSceneStorage::hasPlanningScene(const std::string &name) const
 {
-  mongo_ros::Query q(PLANNING_SCENE_ID_NAME, name);
-  std::vector<PlanningSceneWithMetadata> planning_scenes = planning_scene_collection_->pullAllResults(q, true);
+  Query::Ptr q = planning_scene_collection_->createQuery();
+  q->append(PLANNING_SCENE_ID_NAME, name);
+  std::vector<PlanningSceneWithMetadata> planning_scenes = planning_scene_collection_->queryList(q, true);
   return !planning_scenes.empty();
 }
 
 std::string moveit_warehouse::PlanningSceneStorage::getMotionPlanRequestName(const moveit_msgs::MotionPlanRequest &planning_query, const std::string &scene_name) const
 {
   // get all existing motion planning requests for this planning scene
-  mongo_ros::Query q(PLANNING_SCENE_ID_NAME, scene_name);
-  std::vector<MotionPlanRequestWithMetadata> existing_requests = motion_plan_request_collection_->pullAllResults(q, false);
+  Query::Ptr q = motion_plan_request_collection_->createQuery();
+  q->append(PLANNING_SCENE_ID_NAME, scene_name);
+  std::vector<MotionPlanRequestWithMetadata> existing_requests = motion_plan_request_collection_->queryList(q, false);
 
   // if there are no requests stored, we are done
   if (existing_requests.empty())
@@ -136,8 +141,9 @@ std::string moveit_warehouse::PlanningSceneStorage::addNewPlanningRequest(const 
   if (id.empty())
   {
     std::set<std::string> used;
-    mongo_ros::Query q(PLANNING_SCENE_ID_NAME, scene_name);
-    std::vector<MotionPlanRequestWithMetadata> existing_requests = motion_plan_request_collection_->pullAllResults(q, true);
+    Query::Ptr q = motion_plan_request_collection_->createQuery();
+    q->append(PLANNING_SCENE_ID_NAME, scene_name);
+    std::vector<MotionPlanRequestWithMetadata> existing_requests = motion_plan_request_collection_->queryList(q, true);
     for (std::size_t i = 0 ; i < existing_requests.size() ; ++i)
       used.insert(existing_requests[i]->lookupString(MOTION_PLAN_REQUEST_ID_NAME));
     std::size_t index = existing_requests.size();
@@ -147,8 +153,9 @@ std::string moveit_warehouse::PlanningSceneStorage::addNewPlanningRequest(const 
       index++;
     } while (used.find(id) != used.end());
   }
-  mongo_ros::Metadata metadata(PLANNING_SCENE_ID_NAME, scene_name,
-                               MOTION_PLAN_REQUEST_ID_NAME, id);
+  Metadata::Ptr metadata = motion_plan_request_collection_->createMetadata();
+  metadata->append(PLANNING_SCENE_ID_NAME, scene_name);
+  metadata->append(MOTION_PLAN_REQUEST_ID_NAME, id);
   motion_plan_request_collection_->insert(planning_query, metadata);
   ROS_DEBUG("Saved planning query '%s' for scene '%s'", id.c_str(), scene_name.c_str());
   return id;
@@ -159,18 +166,19 @@ void moveit_warehouse::PlanningSceneStorage::addPlanningResult(const moveit_msgs
   std::string id = getMotionPlanRequestName(planning_query, scene_name);
   if (id.empty())
     id = addNewPlanningRequest(planning_query, scene_name, "");
-  mongo_ros::Metadata metadata(PLANNING_SCENE_ID_NAME, scene_name,
-                               MOTION_PLAN_REQUEST_ID_NAME, id);
+  Metadata::Ptr metadata = robot_trajectory_collection_->createMetadata();
+  metadata->append(PLANNING_SCENE_ID_NAME, scene_name);
+  metadata->append(MOTION_PLAN_REQUEST_ID_NAME, id);
   robot_trajectory_collection_->insert(result, metadata);
 }
 
 void moveit_warehouse::PlanningSceneStorage::getPlanningSceneNames(std::vector<std::string> &names) const
 {
   names.clear();
-  mongo_ros::Query q;
-  std::vector<PlanningSceneWithMetadata> planning_scenes = planning_scene_collection_->pullAllResults(q, true, PLANNING_SCENE_ID_NAME, true);
+  Query::Ptr q = planning_scene_collection_->createQuery();
+  std::vector<PlanningSceneWithMetadata> planning_scenes = planning_scene_collection_->queryList(q, true, PLANNING_SCENE_ID_NAME, true);
   for (std::size_t i = 0; i < planning_scenes.size() ; ++i)
-    if (planning_scenes[i]->metadata.hasField(PLANNING_SCENE_ID_NAME.c_str()))
+    if (planning_scenes[i]->lookupField(PLANNING_SCENE_ID_NAME))
       names.push_back(planning_scenes[i]->lookupString(PLANNING_SCENE_ID_NAME));
 }
 
@@ -194,8 +202,9 @@ bool moveit_warehouse::PlanningSceneStorage::getPlanningSceneWorld(moveit_msgs::
 
 bool moveit_warehouse::PlanningSceneStorage::getPlanningScene(PlanningSceneWithMetadata &scene_m, const std::string &scene_name) const
 {
-  mongo_ros::Query q(PLANNING_SCENE_ID_NAME, scene_name);
-  std::vector<PlanningSceneWithMetadata> planning_scenes = planning_scene_collection_->pullAllResults(q, false);
+  Query::Ptr q = planning_scene_collection_->createQuery();
+  q->append(PLANNING_SCENE_ID_NAME, scene_name);
+  std::vector<PlanningSceneWithMetadata> planning_scenes = planning_scene_collection_->queryList(q, false);
   if (planning_scenes.empty())
   {
     ROS_WARN("Planning scene '%s' was not found in the database", scene_name.c_str());
@@ -209,9 +218,10 @@ bool moveit_warehouse::PlanningSceneStorage::getPlanningScene(PlanningSceneWithM
 
 bool moveit_warehouse::PlanningSceneStorage::getPlanningQuery(MotionPlanRequestWithMetadata &query_m, const std::string &scene_name, const std::string &query_name)
 {
-  mongo_ros::Query q(PLANNING_SCENE_ID_NAME, scene_name);
-  q.append(MOTION_PLAN_REQUEST_ID_NAME, query_name);
-  std::vector<MotionPlanRequestWithMetadata> planning_queries = motion_plan_request_collection_->pullAllResults(q, false);
+  Query::Ptr q = motion_plan_request_collection_->createQuery();
+  q->append(PLANNING_SCENE_ID_NAME, scene_name);
+  q->append(MOTION_PLAN_REQUEST_ID_NAME, query_name);
+  std::vector<MotionPlanRequestWithMetadata> planning_queries = motion_plan_request_collection_->queryList(q, false);
   if (planning_queries.empty())
   {
     ROS_ERROR("Planning query '%s' not found for scene '%s'", query_name.c_str(), scene_name.c_str());
@@ -226,17 +236,19 @@ bool moveit_warehouse::PlanningSceneStorage::getPlanningQuery(MotionPlanRequestW
 
 void moveit_warehouse::PlanningSceneStorage::getPlanningQueries(std::vector<MotionPlanRequestWithMetadata> &planning_queries, const std::string &scene_name) const
 {
-  mongo_ros::Query q(PLANNING_SCENE_ID_NAME, scene_name);
-  planning_queries = motion_plan_request_collection_->pullAllResults(q, false);
+  Query::Ptr q = motion_plan_request_collection_->createQuery();
+  q->append(PLANNING_SCENE_ID_NAME, scene_name);
+  planning_queries = motion_plan_request_collection_->queryList(q, false);
 }
 
 void moveit_warehouse::PlanningSceneStorage::getPlanningQueriesNames(std::vector<std::string> &query_names, const std::string &scene_name) const
 {
-  mongo_ros::Query q(PLANNING_SCENE_ID_NAME, scene_name);
-  std::vector<MotionPlanRequestWithMetadata> planning_queries = motion_plan_request_collection_->pullAllResults(q, true);
+  Query::Ptr q = motion_plan_request_collection_->createQuery();
+  q->append(PLANNING_SCENE_ID_NAME, scene_name);
+  std::vector<MotionPlanRequestWithMetadata> planning_queries = motion_plan_request_collection_->queryList(q, true);
   query_names.clear();
-  for (std::size_t i = 0 ; i < planning_queries.size() ; ++i)
-    if (planning_queries[i]->metadata.hasField(MOTION_PLAN_REQUEST_ID_NAME.c_str()))
+  for (std::size_t i = 0 ; i < planning_queries.size(); ++i)
+    if (planning_queries[i]->lookupField(MOTION_PLAN_REQUEST_ID_NAME))
       query_names.push_back(planning_queries[i]->lookupString(MOTION_PLAN_REQUEST_ID_NAME));
 }
 
@@ -262,11 +274,12 @@ void moveit_warehouse::PlanningSceneStorage::getPlanningQueriesNames(const std::
 
 void moveit_warehouse::PlanningSceneStorage::getPlanningQueries(std::vector<MotionPlanRequestWithMetadata> &planning_queries, std::vector<std::string> &query_names, const std::string &scene_name) const
 {
-  mongo_ros::Query q(PLANNING_SCENE_ID_NAME, scene_name);
-  planning_queries = motion_plan_request_collection_->pullAllResults(q, false);
+  Query::Ptr q = motion_plan_request_collection_->createQuery();
+  q->append(PLANNING_SCENE_ID_NAME, scene_name);
+  planning_queries = motion_plan_request_collection_->queryList(q, false);
   query_names.resize(planning_queries.size());
   for (std::size_t i = 0 ; i < planning_queries.size() ; ++i)
-    if (planning_queries[i]->metadata.hasField(MOTION_PLAN_REQUEST_ID_NAME.c_str()))
+    if (planning_queries[i]->lookupField(MOTION_PLAN_REQUEST_ID_NAME))
       query_names[i] = planning_queries[i]->lookupString(MOTION_PLAN_REQUEST_ID_NAME);
     else
       query_names[i].clear();
@@ -285,32 +298,38 @@ void moveit_warehouse::PlanningSceneStorage::getPlanningResults(std::vector<Robo
 void moveit_warehouse::PlanningSceneStorage::getPlanningResults(std::vector<RobotTrajectoryWithMetadata> &planning_results,
                                 const std::string &scene_name, const std::string &planning_query) const
 {
-  mongo_ros::Query q(PLANNING_SCENE_ID_NAME, scene_name);
-  q.append(MOTION_PLAN_REQUEST_ID_NAME, planning_query);
-  planning_results = robot_trajectory_collection_->pullAllResults(q, false);
+  Query::Ptr q = robot_trajectory_collection_->createQuery();
+  q->append(PLANNING_SCENE_ID_NAME, scene_name);
+  q->append(MOTION_PLAN_REQUEST_ID_NAME, planning_query);
+  planning_results = robot_trajectory_collection_->queryList(q, false);
 }
 
 bool moveit_warehouse::PlanningSceneStorage::hasPlanningQuery(const std::string &scene_name, const std::string &query_name) const
 {
-  mongo_ros::Query q(PLANNING_SCENE_ID_NAME, scene_name);
-  q.append(MOTION_PLAN_REQUEST_ID_NAME, query_name);
-  std::vector<MotionPlanRequestWithMetadata> queries = motion_plan_request_collection_->pullAllResults(q, true);
+  Query::Ptr q = motion_plan_request_collection_->createQuery();
+  q->append(PLANNING_SCENE_ID_NAME, scene_name);
+  q->append(MOTION_PLAN_REQUEST_ID_NAME, query_name);
+  std::vector<MotionPlanRequestWithMetadata> queries = motion_plan_request_collection_->queryList(q, true);
   return !queries.empty();
 }
 
 void moveit_warehouse::PlanningSceneStorage::renamePlanningScene(const std::string &old_scene_name, const std::string &new_scene_name)
 {
-  mongo_ros::Query q(PLANNING_SCENE_ID_NAME, old_scene_name);
-  mongo_ros::Metadata m(PLANNING_SCENE_ID_NAME, new_scene_name);
+  Query::Ptr q = planning_scene_collection_->createQuery();
+  q->append(PLANNING_SCENE_ID_NAME, old_scene_name);
+  Metadata::Ptr m = planning_scene_collection_->createMetadata();
+  m->append(PLANNING_SCENE_ID_NAME, new_scene_name);
   planning_scene_collection_->modifyMetadata(q, m);
   ROS_DEBUG("Renamed planning scene from '%s' to '%s'", old_scene_name.c_str(), new_scene_name.c_str());
 }
 
 void moveit_warehouse::PlanningSceneStorage::renamePlanningQuery(const std::string &scene_name, const std::string &old_query_name, const std::string &new_query_name)
 {
-  mongo_ros::Query q(PLANNING_SCENE_ID_NAME, scene_name);
-  q.append(MOTION_PLAN_REQUEST_ID_NAME, old_query_name);
-  mongo_ros::Metadata m(MOTION_PLAN_REQUEST_ID_NAME, new_query_name);
+  Query::Ptr q = motion_plan_request_collection_->createQuery();
+  q->append(PLANNING_SCENE_ID_NAME, scene_name);
+  q->append(MOTION_PLAN_REQUEST_ID_NAME, old_query_name);
+  Metadata::Ptr m = motion_plan_request_collection_->createMetadata();
+  m->append(MOTION_PLAN_REQUEST_ID_NAME, new_query_name);
   motion_plan_request_collection_->modifyMetadata(q, m);
   ROS_DEBUG("Renamed planning query for scene '%s' from '%s' to '%s'", scene_name.c_str(), old_query_name.c_str(), new_query_name.c_str());
 }
@@ -318,7 +337,8 @@ void moveit_warehouse::PlanningSceneStorage::renamePlanningQuery(const std::stri
 void moveit_warehouse::PlanningSceneStorage::removePlanningScene(const std::string &scene_name)
 {
   removePlanningQueries(scene_name);
-  mongo_ros::Query q(PLANNING_SCENE_ID_NAME, scene_name);
+  Query::Ptr q = planning_scene_collection_->createQuery();
+  q->append(PLANNING_SCENE_ID_NAME, scene_name);
   unsigned int rem = planning_scene_collection_->removeMessages(q);
   ROS_DEBUG("Removed %u PlanningScene messages (named '%s')", rem, scene_name.c_str());
 }
@@ -326,7 +346,8 @@ void moveit_warehouse::PlanningSceneStorage::removePlanningScene(const std::stri
 void moveit_warehouse::PlanningSceneStorage::removePlanningQueries(const std::string &scene_name)
 {
   removePlanningResults(scene_name);
-  mongo_ros::Query q(PLANNING_SCENE_ID_NAME, scene_name);
+  Query::Ptr q = motion_plan_request_collection_->createQuery();
+  q->append(PLANNING_SCENE_ID_NAME, scene_name);
   unsigned int rem = motion_plan_request_collection_->removeMessages(q);
   ROS_DEBUG("Removed %u MotionPlanRequest messages for scene '%s'", rem, scene_name.c_str());
 }
@@ -334,23 +355,26 @@ void moveit_warehouse::PlanningSceneStorage::removePlanningQueries(const std::st
 void moveit_warehouse::PlanningSceneStorage::removePlanningQuery(const std::string &scene_name, const std::string &query_name)
 {
   removePlanningResults(scene_name, query_name);
-  mongo_ros::Query q(PLANNING_SCENE_ID_NAME, scene_name);
-  q.append(MOTION_PLAN_REQUEST_ID_NAME, query_name);
+  Query::Ptr q = motion_plan_request_collection_->createQuery();
+  q->append(PLANNING_SCENE_ID_NAME, scene_name);
+  q->append(MOTION_PLAN_REQUEST_ID_NAME, query_name);
   unsigned int rem = motion_plan_request_collection_->removeMessages(q);
   ROS_DEBUG("Removed %u MotionPlanRequest messages for scene '%s', query '%s'", rem, scene_name.c_str(), query_name.c_str());
 }
 
 void moveit_warehouse::PlanningSceneStorage::removePlanningResults(const std::string &scene_name)
 {
-  mongo_ros::Query q(PLANNING_SCENE_ID_NAME, scene_name);
+  Query::Ptr q = robot_trajectory_collection_->createQuery();
+  q->append(PLANNING_SCENE_ID_NAME, scene_name);
   unsigned int rem = robot_trajectory_collection_->removeMessages(q);
   ROS_DEBUG("Removed %u RobotTrajectory messages for scene '%s'", rem, scene_name.c_str());
 }
 
 void moveit_warehouse::PlanningSceneStorage::removePlanningResults(const std::string &scene_name, const std::string &query_name)
 {
-  mongo_ros::Query q(PLANNING_SCENE_ID_NAME, scene_name);
-  q.append(MOTION_PLAN_REQUEST_ID_NAME, query_name);
+  Query::Ptr q = robot_trajectory_collection_->createQuery();
+  q->append(PLANNING_SCENE_ID_NAME, scene_name);
+  q->append(MOTION_PLAN_REQUEST_ID_NAME, query_name);
   unsigned int rem = robot_trajectory_collection_->removeMessages(q);
   ROS_DEBUG("Removed %u RobotTrajectory messages for scene '%s', query '%s'", rem, scene_name.c_str(), query_name.c_str());
 }

--- a/warehouse/warehouse/src/save_as_text.cpp
+++ b/warehouse/warehouse/src/save_as_text.cpp
@@ -78,8 +78,8 @@ int main(int argc, char **argv)
   boost::program_options::options_description desc;
   desc.add_options()
     ("help", "Show help message")
-    ("host", boost::program_options::value<std::string>(), "Host for the MongoDB.")
-    ("port", boost::program_options::value<std::size_t>(), "Port for the MongoDB.");
+    ("host", boost::program_options::value<std::string>(), "Host for the DB.")
+    ("port", boost::program_options::value<std::size_t>(), "Port for the DB.");
 
   boost::program_options::variables_map vm;
   boost::program_options::store(boost::program_options::parse_command_line(argc, argv, desc), vm);
@@ -90,20 +90,21 @@ int main(int argc, char **argv)
     std::cout << desc << std::endl;
     return 1;
   }
+  // Set up db
+  warehouse_ros::DatabaseConnection::Ptr conn = moveit_warehouse::loadDatabase();
+  if (vm.count("host") && vm.count("port"))
+    conn->setParams(vm["host"].as<std::string>(), vm["port"].as<std::size_t>());
+  if (!conn->connect())
+    return 1;
 
   ros::AsyncSpinner spinner(1);
   spinner.start();
 
   planning_scene_monitor::PlanningSceneMonitor psm(ROBOT_DESCRIPTION);
 
-  moveit_warehouse::PlanningSceneStorage pss(vm.count("host") ? vm["host"].as<std::string>() : "",
-                                             vm.count("port") ? vm["port"].as<std::size_t>() : 0);
-
-  moveit_warehouse::RobotStateStorage rss(vm.count("host") ? vm["host"].as<std::string>() : "",
-                                             vm.count("port") ? vm["port"].as<std::size_t>() : 0);
-
-  moveit_warehouse::ConstraintsStorage cs(vm.count("host") ? vm["host"].as<std::string>() : "",
-                                             vm.count("port") ? vm["port"].as<std::size_t>() : 0);
+  moveit_warehouse::PlanningSceneStorage pss(conn);
+  moveit_warehouse::RobotStateStorage rss(conn);
+  moveit_warehouse::ConstraintsStorage cs(conn);
 
   std::vector<std::string> scene_names;
   pss.getPlanningSceneNames(scene_names);
@@ -185,8 +186,6 @@ int main(int argc, char **argv)
         qfout.close();
       }
     }
-
-
   }
 
   ROS_INFO("Done.");

--- a/warehouse/warehouse/src/trajectory_constraints_storage.cpp
+++ b/warehouse/warehouse/src/trajectory_constraints_storage.cpp
@@ -42,22 +42,24 @@ const std::string moveit_warehouse::TrajectoryConstraintsStorage::CONSTRAINTS_ID
 const std::string moveit_warehouse::TrajectoryConstraintsStorage::CONSTRAINTS_GROUP_NAME = "group_id";
 const std::string moveit_warehouse::TrajectoryConstraintsStorage::ROBOT_NAME = "robot_id";
 
-moveit_warehouse::TrajectoryConstraintsStorage::TrajectoryConstraintsStorage(const std::string &host, const unsigned int port, double wait_seconds) :
-  MoveItMessageStorage(host, port, wait_seconds)
+using warehouse_ros::Metadata;
+using warehouse_ros::Query;
+
+moveit_warehouse::TrajectoryConstraintsStorage::TrajectoryConstraintsStorage(warehouse_ros::DatabaseConnection::Ptr conn) :
+  MoveItMessageStorage(conn)
 {
   createCollections();
-  ROS_DEBUG("Connected to MongoDB '%s' on host '%s' port '%u'.", DATABASE_NAME.c_str(), db_host_.c_str(), db_port_);
 }
 
 void moveit_warehouse::TrajectoryConstraintsStorage::createCollections(void)
 {
-  constraints_collection_.reset(new TrajectoryConstraintsCollection::element_type(DATABASE_NAME, "trajectory_constraints", db_host_, db_port_, timeout_));
+  constraints_collection_ = conn_->openCollectionPtr<moveit_msgs::TrajectoryConstraints>(DATABASE_NAME, "trajectory_constraints");
 }
 
 void moveit_warehouse::TrajectoryConstraintsStorage::reset(void)
 {
   constraints_collection_.reset();
-  MoveItMessageStorage::drop(DATABASE_NAME);
+  conn_->dropDatabase(DATABASE_NAME);
   createCollections();
 }
 
@@ -69,22 +71,23 @@ void moveit_warehouse::TrajectoryConstraintsStorage::addTrajectoryConstraints(co
     removeTrajectoryConstraints(name, robot, group);
     replace = true;
   }
-  mongo_ros::Metadata metadata(CONSTRAINTS_ID_NAME, name,
-                               ROBOT_NAME, robot,
-                               CONSTRAINTS_GROUP_NAME, group);
+  Metadata::Ptr metadata = constraints_collection_->createMetadata();
+  metadata->append(CONSTRAINTS_ID_NAME, name);
+  metadata->append(ROBOT_NAME, robot);
+  metadata->append(CONSTRAINTS_GROUP_NAME, group);
   constraints_collection_->insert(msg, metadata);
   ROS_DEBUG("%s constraints '%s'", replace ? "Replaced" : "Added", name.c_str());
 }
 
 bool moveit_warehouse::TrajectoryConstraintsStorage::hasTrajectoryConstraints(const std::string &name, const std::string &robot, const std::string &group) const
 {
-
-  mongo_ros::Query q(CONSTRAINTS_ID_NAME, name);
+  Query::Ptr q = constraints_collection_->createQuery();
+  q->append(CONSTRAINTS_ID_NAME, name);
   if (!robot.empty())
-    q.append(ROBOT_NAME, robot);
+    q->append(ROBOT_NAME, robot);
   if (!group.empty())
-    q.append(CONSTRAINTS_GROUP_NAME, group);
-  std::vector<TrajectoryConstraintsWithMetadata> constr = constraints_collection_->pullAllResults(q, true);
+    q->append(CONSTRAINTS_GROUP_NAME, group);
+  std::vector<TrajectoryConstraintsWithMetadata> constr = constraints_collection_->queryList(q, true);
   return !constr.empty();
 }
 
@@ -97,25 +100,26 @@ void moveit_warehouse::TrajectoryConstraintsStorage::getKnownTrajectoryConstrain
 void moveit_warehouse::TrajectoryConstraintsStorage::getKnownTrajectoryConstraints(std::vector<std::string> &names, const std::string &robot, const std::string &group) const
 {
   names.clear();
-  mongo_ros::Query q;
+  Query::Ptr q = constraints_collection_->createQuery();
   if (!robot.empty())
-    q.append(ROBOT_NAME, robot);
+    q->append(ROBOT_NAME, robot);
   if (!group.empty())
-    q.append(CONSTRAINTS_GROUP_NAME, group);
-  std::vector<TrajectoryConstraintsWithMetadata> constr = constraints_collection_->pullAllResults(q, true, CONSTRAINTS_ID_NAME, true);
+    q->append(CONSTRAINTS_GROUP_NAME, group);
+  std::vector<TrajectoryConstraintsWithMetadata> constr = constraints_collection_->queryList(q, true, CONSTRAINTS_ID_NAME, true);
   for (std::size_t i = 0; i < constr.size() ; ++i)
-    if (constr[i]->metadata.hasField(CONSTRAINTS_ID_NAME.c_str()))
+    if (constr[i]->lookupField(CONSTRAINTS_ID_NAME))
       names.push_back(constr[i]->lookupString(CONSTRAINTS_ID_NAME));
 }
 
 bool moveit_warehouse::TrajectoryConstraintsStorage::getTrajectoryConstraints(TrajectoryConstraintsWithMetadata &msg_m, const std::string &name, const std::string &robot, const std::string &group) const
 {
-  mongo_ros::Query q(CONSTRAINTS_ID_NAME, name);
+  Query::Ptr q = constraints_collection_->createQuery();
+  q->append(CONSTRAINTS_ID_NAME, name);
   if (!robot.empty())
-    q.append(ROBOT_NAME, robot);
+    q->append(ROBOT_NAME, robot);
   if (!group.empty())
-    q.append(CONSTRAINTS_GROUP_NAME, group);
-  std::vector<TrajectoryConstraintsWithMetadata> constr = constraints_collection_->pullAllResults(q, false);
+    q->append(CONSTRAINTS_GROUP_NAME, group);
+  std::vector<TrajectoryConstraintsWithMetadata> constr = constraints_collection_->queryList(q, false);
   if (constr.empty())
     return false;
   else
@@ -127,23 +131,26 @@ bool moveit_warehouse::TrajectoryConstraintsStorage::getTrajectoryConstraints(Tr
 
 void moveit_warehouse::TrajectoryConstraintsStorage::renameTrajectoryConstraints(const std::string &old_name, const std::string &new_name, const std::string &robot, const std::string &group)
 {
-  mongo_ros::Query q(CONSTRAINTS_ID_NAME, old_name);
+  Query::Ptr q = constraints_collection_->createQuery();
+  q->append(CONSTRAINTS_ID_NAME, old_name);
   if (!robot.empty())
-    q.append(ROBOT_NAME, robot);
+    q->append(ROBOT_NAME, robot);
   if (!group.empty())
-    q.append(CONSTRAINTS_GROUP_NAME, group);
-  mongo_ros::Metadata m(CONSTRAINTS_ID_NAME, new_name);
+    q->append(CONSTRAINTS_GROUP_NAME, group);
+  Metadata::Ptr m = constraints_collection_->createMetadata();
+  m->append(CONSTRAINTS_ID_NAME, new_name);
   constraints_collection_->modifyMetadata(q, m);
   ROS_DEBUG("Renamed constraints from '%s' to '%s'", old_name.c_str(), new_name.c_str());
 }
 
 void moveit_warehouse::TrajectoryConstraintsStorage::removeTrajectoryConstraints(const std::string &name, const std::string &robot, const std::string &group)
 {
-  mongo_ros::Query q(CONSTRAINTS_ID_NAME, name);
+  Query::Ptr q = constraints_collection_->createQuery();
+  q->append(CONSTRAINTS_ID_NAME, name);
   if (!robot.empty())
-    q.append(ROBOT_NAME, robot);
+    q->append(ROBOT_NAME, robot);
   if (!group.empty())
-    q.append(CONSTRAINTS_GROUP_NAME, group);
+    q->append(CONSTRAINTS_GROUP_NAME, group);
   unsigned int rem = constraints_collection_->removeMessages(q);
   ROS_DEBUG("Removed %u TrajectoryConstraints messages (named '%s')", rem, name.c_str());
 }

--- a/warehouse/warehouse/src/warehouse_connector.cpp
+++ b/warehouse/warehouse/src/warehouse_connector.cpp
@@ -34,16 +34,16 @@
 
 /* Author: E. Gil Jones */
 
-#include <mongo_ros/message_collection.h>
 #include <sys/types.h>
 #include <signal.h>
 #include <unistd.h>
+#include <ros/ros.h>
 #include <moveit/warehouse/warehouse_connector.h>
 
 namespace moveit_warehouse
 {
 
-WarehouseConnector::WarehouseConnector(const std::string &mongoexec) : mongoexec_(mongoexec), child_pid_(0)
+WarehouseConnector::WarehouseConnector(const std::string &dbexec) : dbexec_(dbexec), child_pid_(0)
 {
 }
 
@@ -68,13 +68,13 @@ bool WarehouseConnector::connectToDatabase(const std::string& dirname)
 
   if (child_pid_ == 0)
   {
-    std::size_t exec_file_pos = mongoexec_.find_last_of("/\\");
+    std::size_t exec_file_pos = dbexec_.find_last_of("/\\");
     if (exec_file_pos != std::string::npos)
     {
       char** argv = new char*[4];
-      std::size_t exec_length = 1 + mongoexec_.length() - exec_file_pos;
+      std::size_t exec_length = 1 + dbexec_.length() - exec_file_pos;
       argv[0] = new char[1 + exec_length];
-      snprintf(argv[0], exec_length, "%s", mongoexec_.substr(exec_file_pos + 1).c_str());
+      snprintf(argv[0], exec_length, "%s", dbexec_.substr(exec_file_pos + 1).c_str());
 
       argv[1] = new char[16];
       snprintf(argv[1], 15, "--dbpath");
@@ -84,7 +84,7 @@ bool WarehouseConnector::connectToDatabase(const std::string& dirname)
 
       argv[3] = NULL;
 
-      int code = execv(mongoexec_.c_str(), argv);
+      int code = execv(dbexec_.c_str(), argv);
       delete[] argv[0];
       delete[] argv[1];
       delete[] argv[2];

--- a/warehouse/warehouse/src/warehouse_services.cpp
+++ b/warehouse/warehouse/src/warehouse_services.cpp
@@ -137,8 +137,11 @@ int main(int argc, char **argv)
   node.param<std::string>("warehouse_host", host, "localhost");
   node.param<int>("warehouse_port", port, 33829);
 
+  warehouse_ros::DatabaseConnection::Ptr conn = moveit_warehouse::loadDatabase();
+  conn->setParams(host, port, 5.0);
+
   ROS_INFO("Connecting to warehouse on %s:%d", host.c_str(), port);
-  moveit_warehouse::RobotStateStorage rs(host, port);
+  moveit_warehouse::RobotStateStorage rs(conn);
 
   std::vector<std::string> names;
   rs.getKnownRobotStates(names);


### PR DESCRIPTION
Warehouse code on indigo-devel branch relies on warehouse_ros(indigo-devel) that still uses mongo_ros(deprecated since groovy). This ~~update~~ patch allow moveit to use jade-devel warehouse_ros that uses a connection handler instead of host:port pair.

Compiled and tested with catkin_make_isolated on a fedora 22 (4.4.13-200.fc22.x86_64) box, with warehouse_ros(jade-devel branch), since it uses a different branch for this the CI does not build correctly. not sure how to indicate the correct release level to CI.
