### PR TITLE
fixup #716

### DIFF
--- a/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/move_group/src/default_capabilities/move_action_capability.cpp
@@ -61,6 +61,7 @@ void move_group::MoveGroupMoveAction::initialize()
 void move_group::MoveGroupMoveAction::executeMoveCallback(const moveit_msgs::MoveGroupGoalConstPtr& goal)
 {
   setMoveState(PLANNING);
+  context_->planning_scene_monitor_->updateFrameTransforms();
 
   moveit_msgs::MoveGroupResult action_res;
   if (goal->planning_options.plan_only || !context_->allow_trajectory_execution_)
@@ -170,6 +171,7 @@ bool move_group::MoveGroupMoveAction::planUsingPlanningPipeline(const planning_i
 {
   setMoveState(PLANNING);
 
+  planning_scene_monitor::LockedPlanningSceneRO lscene(plan.planning_scene_monitor_);
   bool solved = false;
   planning_interface::MotionPlanResponse res;
   try

--- a/move_group/src/default_capabilities/plan_service_capability.cpp
+++ b/move_group/src/default_capabilities/plan_service_capability.cpp
@@ -52,6 +52,7 @@ bool move_group::MoveGroupPlanService::computePlanService(moveit_msgs::GetMotion
 {
   ROS_INFO("Received new planning service request...");
   context_->planning_scene_monitor_->syncSceneUpdates();
+  context_->planning_scene_monitor_->updateFrameTransforms();
 
   bool solved = false;
   planning_scene_monitor::LockedPlanningSceneRO ps(context_->planning_scene_monitor_);

--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -521,7 +521,6 @@ private:
   ros::CallbackQueue                    callback_queue_;
   boost::scoped_ptr<ros::AsyncSpinner>  spinner_;
   ros::Time                             last_robot_motion_time_; /// Last time the robot has moved
-  bool                                  enforce_next_state_update_;
 };
 
 typedef boost::shared_ptr<PlanningSceneMonitor> PlanningSceneMonitorPtr;

--- a/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -845,7 +845,7 @@ void planning_scene_monitor::PlanningSceneMonitor::syncSceneUpdates(const ros::T
     return;
 
   // Processing pending updates and wait for new incoming updates up to 1s.
-  // This is necessary as re-publishing is throttled.
+  // This is necessary as publishing planning scene diffs is throttled (2Hz by default).
   while (!callback_queue_.empty() || (ros::Time::now()-t).toSec() < 1.)
   {
     new_scene_update_condition_.wait_for(lock, boost::chrono::seconds(1));

--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -712,7 +712,7 @@ public:
         return false;
       }
       // TODO: check multi-DoF joints
-      if (fabs(current_state->getJointPositions(jm)[0] - positions[i]) < std::numeric_limits<float>::epsilon())
+      if (fabs(current_state->getJointPositions(jm)[0] - positions[i]) > std::numeric_limits<float>::epsilon())
       {
         ROS_ERROR("Trajectory start deviates from current robot state");
         return false;

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -406,11 +406,10 @@ void MotionPlanningFrame::remoteUpdateStartStateCallback(const std_msgs::EmptyCo
   if (move_group_ && planning_display_)
   {
     planning_display_->syncSceneUpdates();
-    robot_state::RobotState state = *planning_display_->getQueryStartState();
     const planning_scene_monitor::LockedPlanningSceneRO &ps = planning_display_->getPlanningSceneRO();
     if (ps)
     {
-      state = ps->getCurrentState();
+      robot_state::RobotState state = ps->getCurrentState();
       planning_display_->setQueryStartState(state);
     }
   }
@@ -421,11 +420,10 @@ void MotionPlanningFrame::remoteUpdateGoalStateCallback(const std_msgs::EmptyCon
   if (move_group_ && planning_display_)
   {
     planning_display_->syncSceneUpdates();
-    robot_state::RobotState state = *planning_display_->getQueryStartState();
     const planning_scene_monitor::LockedPlanningSceneRO &ps = planning_display_->getPlanningSceneRO();
     if (ps)
     {
-      state = ps->getCurrentState();
+      robot_state::RobotState state = ps->getCurrentState();
       planning_display_->setQueryGoalState(state);
     }
   }


### PR DESCRIPTION
There was a typo introduced when fixing review comments.

However, more important, another race condition showed up when using continuous controllers:
Due to throttling of planning scene updates in move_group's PSM, it takes a while until these updates are published and thus can be received e.g. in rviz. Hence, we need to wait for planning scene updates to arrive for a while (1s). As soon as an update arrives, waiting is finished.
