### PR TITLE
Switch to std::shared_ptr for FCL and octomap types.

### DIFF
--- a/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map.h
+++ b/perception/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map.h
@@ -38,9 +38,9 @@
 #define MOVEIT_OCCUPANCY_MAP_MONITOR_OCCUPANCY_MAP_
 
 #include <octomap/octomap.h>
-#include <boost/shared_ptr.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/function.hpp>
+#include <memory>
 
 namespace occupancy_map_monitor
 {
@@ -115,8 +115,8 @@ private:
   boost::function<void()> update_callback_;
 };
 
-typedef boost::shared_ptr<OccMapTree> OccMapTreePtr;
-typedef boost::shared_ptr<const OccMapTree> OccMapTreeConstPtr;
+typedef std::shared_ptr<OccMapTree> OccMapTreePtr;
+typedef std::shared_ptr<const OccMapTree> OccMapTreeConstPtr;
 
 }
 

--- a/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/octomap_render.h
+++ b/visualization/rviz_plugin_render_tools/include/moveit/rviz_plugin_render_tools/octomap_render.h
@@ -37,6 +37,7 @@
 #ifndef MOVEIT_VISUALIZATION_SCENE_DISPLAY_RVIZ_OCTOMAP_RENDER_
 #define MOVEIT_VISUALIZATION_SCENE_DISPLAY_RVIZ_OCTOMAP_RENDER_
 
+#include <memory>
 #include <vector>
 #include <rviz/ogre_helpers/point_cloud.h>
 
@@ -73,7 +74,7 @@ class OcTreeRender
 {
 
 public:
-  OcTreeRender(const boost::shared_ptr<const octomap::OcTree> &octree,
+  OcTreeRender(const std::shared_ptr<const octomap::OcTree> &octree,
                OctreeVoxelRenderMode octree_voxel_rendering,
                OctreeVoxelColorMode octree_color_mode,
                std::size_t max_octree_depth,
@@ -85,13 +86,13 @@ private:
   void setColor( double z_pos, double min_z, double max_z, double color_factor, rviz::PointCloud::Point* point);
   void setProbColor( double prob, rviz::PointCloud::Point* point);
 
-  void octreeDecoding (const boost::shared_ptr<const octomap::OcTree> &octree,
+  void octreeDecoding (const std::shared_ptr<const octomap::OcTree> &octree,
                        OctreeVoxelRenderMode octree_voxel_rendering,
                        OctreeVoxelColorMode octree_color_mode);
 
   // Ogre-rviz point clouds
   std::vector<rviz::PointCloud*> cloud_;
-  boost::shared_ptr<const octomap::OcTree> octree_;
+  std::shared_ptr<const octomap::OcTree> octree_;
 
   Ogre::SceneNode* scene_node_;
   Ogre::SceneManager* scene_manager_;

--- a/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
+++ b/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
@@ -50,7 +50,7 @@ namespace moveit_rviz_plugin
 typedef std::vector<rviz::PointCloud::Point> VPoint;
 typedef std::vector<VPoint> VVPoint;
 
-OcTreeRender::OcTreeRender(const boost::shared_ptr<const octomap::OcTree> &octree,
+OcTreeRender::OcTreeRender(const std::shared_ptr<const octomap::OcTree> &octree,
                            OctreeVoxelRenderMode octree_voxel_rendering,
                            OctreeVoxelColorMode octree_color_mode,
                            std::size_t max_octree_depth,
@@ -152,7 +152,7 @@ void OcTreeRender::setColor( double z_pos, double min_z, double max_z, double co
 }
 
 
-void OcTreeRender::octreeDecoding (const boost::shared_ptr<const octomap::OcTree> &octree,
+void OcTreeRender::octreeDecoding (const std::shared_ptr<const octomap::OcTree> &octree,
                                    OctreeVoxelRenderMode octree_voxel_rendering,
                                    OctreeVoxelColorMode octree_color_mode)
 {


### PR DESCRIPTION
More `boost::shared_ptr` to `std::shared_ptr` conversions for FCL 0.5.

Needs ros-planning/geometric_shapes#47 and ros-planning/moveit_core#316

See also ros-planning/moveit_core#315
