### PR TITLE
Changing minimum value for jump_factor to 0.0

### DIFF
--- a/manipulation/pick_place/cfg/PickPlaceDynamicReconfigure.cfg
+++ b/manipulation/pick_place/cfg/PickPlaceDynamicReconfigure.cfg
@@ -6,6 +6,6 @@ gen = ParameterGenerator()
 gen.add("max_attempted_states_per_pose", int_t, 1, "The maximum number of robot configurations to attempt at a particular eef pose", 5, 1, 100)
 gen.add("max_consecutive_fail_attempts", int_t, 2, "The maximum consecutive failures at generating configurations matching a pose before failure", 3, 1, 10)
 gen.add("cartesian_motion_step_size", double_t, 3, "The distance (meters, for end-effector) between consecutive waypoints on Cartesian motions", 0.02, 0.005, 0.1)
-gen.add("jump_factor", double_t, 4, "The maximum allowed distance in configuration space between consecutive waypoints on Cartesian motions", 2.0, 0.01, 10.0)
+gen.add("jump_factor", double_t, 4, "The maximum allowed distance in configuration space between consecutive waypoints on Cartesian motions", 2.0, 0.0, 10.0)
 
 exit(gen.generate(PACKAGE, PACKAGE, "PickPlaceDynamicReconfigure"))


### PR DESCRIPTION
We should be able to set the minimum value for jump_factor to 0 to disable it.
So this change in the config allows us to disable this feature.

In the robot_state.cpp in line 1740 is a test if the value is greater then 0.0, so there should be the possibility to set this value to 0.

`bool test_joint_space_jump = jump_threshold > 0.0;`
