### PR TITLE
Race conditions when updating PlanningScene: fixup #716

### DIFF
--- a/move_group/include/moveit/move_group/move_group_context.h
+++ b/move_group/include/moveit/move_group/move_group_context.h
@@ -38,6 +38,7 @@
 #define MOVEIT_MOVE_GROUP_CONTEXT_
 
 #include <moveit/macros/class_forward.h>
+#include <trajectory_msgs/JointTrajectory.h>
 
 namespace planning_scene_monitor
 {
@@ -71,6 +72,7 @@ struct MoveGroupContext
   ~MoveGroupContext();
 
   bool status() const;
+  bool validateTrajectory(const trajectory_msgs::JointTrajectory &trajectory) const;
 
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
   trajectory_execution_manager::TrajectoryExecutionManagerPtr trajectory_execution_manager_;

--- a/move_group/src/default_capabilities/execute_service_capability.cpp
+++ b/move_group/src/default_capabilities/execute_service_capability.cpp
@@ -82,8 +82,6 @@ bool move_group::MoveGroupExecuteService::executeTrajectoryService(moveit_msgs::
         res.error_code.val = moveit_msgs::MoveItErrorCodes::TIMED_OUT;
       else
         res.error_code.val = moveit_msgs::MoveItErrorCodes::CONTROL_FAILED;
-      // wait for all planning scene updates to be processed
-      context_->planning_scene_monitor_->syncSceneUpdates();
       ROS_INFO_STREAM("Execution completed: " << es.asString());
     }
     else

--- a/move_group/src/default_capabilities/execute_service_capability.cpp
+++ b/move_group/src/default_capabilities/execute_service_capability.cpp
@@ -62,6 +62,12 @@ bool move_group::MoveGroupExecuteService::executeTrajectoryService(moveit_msgs::
   //    robot_trajectory::RobotTrajectory to_exec(planning_scene_monitor_->getRobotModel(), ;
 
   context_->trajectory_execution_manager_->clear();
+  if (!context_->validateTrajectory(req.trajectory.joint_trajectory))
+  {
+    res.error_code.val = moveit_msgs::MoveItErrorCodes::FAILURE;
+    return true;
+  }
+
   if (context_->trajectory_execution_manager_->push(req.trajectory))
   {
     context_->trajectory_execution_manager_->execute();

--- a/move_group/src/move_group_context.cpp
+++ b/move_group/src/move_group_context.cpp
@@ -98,7 +98,7 @@ bool move_group::MoveGroupContext::validateTrajectory(const trajectory_msgs::Joi
 
   const planning_scene_monitor::CurrentStateMonitorPtr csm = planning_scene_monitor_->getStateMonitor();
   robot_state::RobotStatePtr current_state;
-  if (!csm->waitForCurrentState(1.0) || !(current_state = csm->getCurrentState()))
+  if (!csm->waitForCurrentState(ros::Time::now()) || !(current_state = csm->getCurrentState()))
   {
     ROS_WARN("Failed to receive full current joint state");
     return false;

--- a/planning/plan_execution/src/plan_execution.cpp
+++ b/planning/plan_execution/src/plan_execution.cpp
@@ -457,8 +457,6 @@ void plan_execution::PlanExecution::planningSceneUpdatedCallback(const planning_
 
 void plan_execution::PlanExecution::doneWithTrajectoryExecution(const moveit_controller_manager::ExecutionStatus &status)
 {
-  // sync all planning scene updates before continuing
-  planning_scene_monitor_->syncSceneUpdates();
   execution_complete_ = true;
 }
 

--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -44,6 +44,7 @@
 #include <boost/function.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
+#include <boost/thread/condition_variable.hpp>
 
 namespace planning_scene_monitor
 {
@@ -136,7 +137,11 @@ public:
    *  @return Returns the map from joint names to joint state values*/
   std::map<std::string, double> getCurrentStateValues() const;
 
-  /** @brief Wait for at most \e wait_time seconds until the complete current state is known. Return true if the full state is known */
+  /** @brief Wait for at most \e wait_time seconds for a robot state more recent than t */
+  bool waitForCurrentState(const ros::Time t=ros::Time::now(), double wait_time=1) const;
+
+  // TODO: rename functions to waitForCompleteState
+  /** @brief Wait for at most \e wait_time seconds until the complete robot state is known. Return true if the full state is known */
   bool waitForCurrentState(double wait_time) const;
 
   /** @brief Wait for at most \e wait_time seconds until the joint values from the group \e group are known. Return true if values for all joints in \e group are known */
@@ -191,6 +196,7 @@ private:
 
   mutable boost::mutex                         state_update_lock_;
   std::vector< JointStateUpdateCallback >      update_callbacks_;
+  mutable boost::condition_variable            state_update_condition_;
 };
 
 MOVEIT_CLASS_FORWARD(CurrentStateMonitor);

--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -341,6 +341,13 @@ public:
    * If there is no state monitor active, there will be no scene updates.
    * Hence, you can specify a timeout to wait for those updates. Default is 1s.
    */
+  bool waitForCurrentRobotState(const ros::Time &t, double wait_time = 1.);
+
+  /** \brief Wait current robot state and wait for all pending scene updates to be processed.
+   *
+   * Additionally to waitForCurrentRobotState() this processes also all already received scene updates
+   * as long as wait_time is not exceeded.
+   */
   bool syncSceneUpdates(const ros::Time &t = ros::Time::now(), double wait_time = 1.);
 
   /** \brief Lock the scene for reading (multiple threads can lock for reading at the same time) */

--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -525,6 +525,7 @@ private:
   ros::CallbackQueue                    callback_queue_;
   boost::scoped_ptr<ros::AsyncSpinner>  spinner_;
   ros::Time                             last_robot_motion_time_; /// Last time the robot has moved
+  bool                                  enforce_next_state_update_;
 };
 
 typedef boost::shared_ptr<PlanningSceneMonitor> PlanningSceneMonitorPtr;

--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -341,8 +341,7 @@ public:
    * If there is no state monitor active, there will be no scene updates.
    * Hence, you can specify a timeout to wait for those updates. Default is 1s.
    */
-  bool syncSceneUpdates(const ros::Time &t = ros::Time::now(),
-                        const ros::WallDuration &timeout = ros::WallDuration(1.));
+  bool syncSceneUpdates(const ros::Time &t = ros::Time::now(), double wait_time = 1.);
 
   /** \brief Lock the scene for reading (multiple threads can lock for reading at the same time) */
   void lockSceneRead();

--- a/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -336,8 +336,13 @@ public:
   /** @brief This function is called every time there is a change to the planning scene */
   void triggerSceneUpdateEvent(SceneUpdateType update_type);
 
-  /** \brief Wait until all pending scene updates with timestamps < t are incorporated */
-  void syncSceneUpdates(const ros::Time &t = ros::Time::now());
+  /** \brief Wait for robot state to become more recent than t.
+   *
+   * If there is no state monitor active, there will be no scene updates.
+   * Hence, you can specify a timeout to wait for those updates. Default is 1s.
+   */
+  bool syncSceneUpdates(const ros::Time &t = ros::Time::now(),
+                        const ros::WallDuration &timeout = ros::WallDuration(1.));
 
   /** \brief Lock the scene for reading (multiple threads can lock for reading at the same time) */
   void lockSceneRead();

--- a/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -404,10 +404,12 @@ void planning_scene_monitor::CurrentStateMonitor::jointStateCallback(const senso
       }
     }
   }
-  state_update_condition_.notify_all();
 
   // callbacks, if needed
   if (update)
     for (std::size_t i = 0 ; i < update_callbacks_.size() ; ++i)
       update_callbacks_[i](joint_state);
+
+  // notify *after* potential update callbacks
+  state_update_condition_.notify_all();
 }

--- a/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -619,9 +619,6 @@ public:
   /** \brief Given a \e plan, execute it while waiting for completion. Return true on success. */
   MoveItErrorCode execute(const Plan &plan);
 
-  /** \brief Validate that first point of given a \e plan matches current state of robot */
-  bool validatePlan(const Plan &plan);
-
   /** \brief Compute a Cartesian path that follows specified waypoints with a step size of at most \e eef_step meters
       between end effector configurations of consecutive points in the result \e trajectory. The reference frame for the
       waypoints is that specified by setPoseReferenceFrame(). No more than \e jump_threshold

--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -484,8 +484,11 @@ public:
     if (!current_state_monitor_->isActive())
       current_state_monitor_->startStateMonitor();
 
-    if (!current_state_monitor_->waitForCurrentState(opt_.group_name_, wait_seconds))
-      ROS_WARN("Joint values for monitored state are requested but the full state is not known");
+    if (!current_state_monitor_->waitForCurrentState(ros::Time::now(), wait_seconds))
+    {
+      ROS_ERROR("Failed to fetch current robot state");
+      return false;
+    }
 
     current_state = current_state_monitor_->getCurrentState();
     return true;

--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -689,38 +689,6 @@ public:
     }
   }
 
-  bool validatePlan(const Plan &plan)
-  {
-    robot_state::RobotStatePtr current_state;
-    if (!getCurrentState(current_state))
-      return false;
-    if (plan.trajectory_.joint_trajectory.points.empty())
-      return true;
-
-    const trajectory_msgs::JointTrajectory &trajectory = plan.trajectory_.joint_trajectory;
-    const std::vector<double> &positions = trajectory.points.front().positions;
-    std::size_t n = trajectory.joint_names.size();
-    if (positions.size() != n)
-      return false;
-
-    for (std::size_t i = 0; i < n; ++i)
-    {
-      const robot_model::JointModel *jm = robot_model_->getJointModel(trajectory.joint_names[i]);
-      if (!jm)
-      {
-        ROS_ERROR_STREAM("Unknown joint in trajectory: " << trajectory.joint_names[i]);
-        return false;
-      }
-      // TODO: check multi-DoF joints
-      if (fabs(current_state->getJointPositions(jm)[0] - positions[i]) > std::numeric_limits<float>::epsilon())
-      {
-        ROS_ERROR("Trajectory start deviates from current robot state");
-        return false;
-      }
-    }
-    return true;
-  }
-
   double computeCartesianPath(const std::vector<geometry_msgs::Pose> &waypoints, double step, double jump_threshold,
                               moveit_msgs::RobotTrajectory &msg, bool avoid_collisions, moveit_msgs::MoveItErrorCodes &error_code)
   {
@@ -1208,11 +1176,6 @@ moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGrou
 moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGroup::execute(const Plan &plan)
 {
   return impl_->execute(plan, true);
-}
-
-bool moveit::planning_interface::MoveGroup::validatePlan(const moveit::planning_interface::MoveGroup::Plan &plan)
-{
-  return impl_->validatePlan(plan);
 }
 
 moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGroup::plan(Plan &plan)

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -239,7 +239,7 @@ void MotionPlanningFrame::updateQueryStateHelper(robot_state::RobotState &state,
 
   if (v == "<current>")
   {
-    planning_display_->syncSceneUpdates();
+    planning_display_->waitForCurrentRobotState();
     const planning_scene_monitor::LockedPlanningSceneRO &ps = planning_display_->getPlanningSceneRO();
     if (ps)
       state = ps->getCurrentState();
@@ -403,7 +403,7 @@ void MotionPlanningFrame::remoteUpdateStartStateCallback(const std_msgs::EmptyCo
 {
   if (move_group_ && planning_display_)
   {
-    planning_display_->syncSceneUpdates();
+    planning_display_->waitForCurrentRobotState();
     const planning_scene_monitor::LockedPlanningSceneRO &ps = planning_display_->getPlanningSceneRO();
     if (ps)
     {
@@ -417,7 +417,7 @@ void MotionPlanningFrame::remoteUpdateGoalStateCallback(const std_msgs::EmptyCon
 {
   if (move_group_ && planning_display_)
   {
-    planning_display_->syncSceneUpdates();
+    planning_display_->waitForCurrentRobotState();
     const planning_scene_monitor::LockedPlanningSceneRO &ps = planning_display_->getPlanningSceneRO();
     if (ps)
     {

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -139,9 +139,7 @@ void MotionPlanningFrame::computeExecuteButtonClicked()
   if (move_group_ && current_plan_)
   {
     ui_->stop_button->setEnabled(true); // enable stopping
-    bool success =
-      move_group_->validatePlan(*current_plan_) &&
-      move_group_->execute(*current_plan_);
+    bool success = move_group_->execute(*current_plan_);
     onFinishedExecution(success);
   }
 }

--- a/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -107,8 +107,8 @@ public:
   const std::string getMoveGroupNS() const;
   const robot_model::RobotModelConstPtr& getRobotModel() const;
 
-  /// sync all planning scene updates up to time t
-  void syncSceneUpdates(const ros::Time &t = ros::Time::now());
+  /// wait for robot state more recent than t
+  bool syncSceneUpdates(const ros::Time &t = ros::Time::now());
   /// get read-only access to planning scene
   planning_scene_monitor::LockedPlanningSceneRO getPlanningSceneRO() const;
   /// get write access to planning scene

--- a/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
+++ b/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.h
@@ -108,7 +108,7 @@ public:
   const robot_model::RobotModelConstPtr& getRobotModel() const;
 
   /// wait for robot state more recent than t
-  bool syncSceneUpdates(const ros::Time &t = ros::Time::now());
+  bool waitForCurrentRobotState(const ros::Time &t = ros::Time::now());
   /// get read-only access to planning scene
   planning_scene_monitor::LockedPlanningSceneRO getPlanningSceneRO() const;
   /// get write access to planning scene

--- a/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -297,10 +297,11 @@ const robot_model::RobotModelConstPtr& PlanningSceneDisplay::getRobotModel() con
   }
 }
 
-void PlanningSceneDisplay::syncSceneUpdates(const ros::Time &t)
+bool PlanningSceneDisplay::syncSceneUpdates(const ros::Time &t)
 {
   if (planning_scene_monitor_)
-    planning_scene_monitor_->syncSceneUpdates(t);
+    return planning_scene_monitor_->syncSceneUpdates(t);
+  return false;
 }
 
 planning_scene_monitor::LockedPlanningSceneRO PlanningSceneDisplay::getPlanningSceneRO() const

--- a/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -297,10 +297,10 @@ const robot_model::RobotModelConstPtr& PlanningSceneDisplay::getRobotModel() con
   }
 }
 
-bool PlanningSceneDisplay::syncSceneUpdates(const ros::Time &t)
+bool PlanningSceneDisplay::waitForCurrentRobotState(const ros::Time &t)
 {
   if (planning_scene_monitor_)
-    return planning_scene_monitor_->syncSceneUpdates(t);
+    return planning_scene_monitor_->waitForCurrentRobotState(t);
   return false;
 }
 


### PR DESCRIPTION
This continues #716 and #724 which were both merged already. I repeat here my [comments](https://github.com/ros-planning/moveit_ros/pull/724#issuecomment-235284344) to #724:

@v4hn Realizing the simplification we agreed on in the phone call turned out to be rather difficult:
1. simplification of `stateUpdateTimerCallback()` (removing the additional timestamp check) caused dead locks. Hence, I reverted these changes.
2. I successfully moved `validatePlan()` from `MoveGroupInterface` (client side) to `MoveGroup`'s `ExecutionServiceCapability` (server side) - as agreed.
3. `Simplification of syncSceneUpdates()`: We definitely need both while loops and the timeout. When the robot doesn't move at all, we will never receive a scene update. The first loop is required to check for a recent robot state update directly in CSM, while the second loop (in case there is no CSM) waits - with a timeout - for a direct scene update. There is no way to omit this timeout. The only chance would be to trigger all input channels of PSM to send updates - which is not possible. However, in `move_group`, this doesn't pose a problem, because there is a CSM instantiated.
4. Removing `syncSceneUpdates()` after trajectory execution makes sense. Doing so, led to failure of the [test](https://gist.github.com/JeremyZoss/63dfdf24a97c5e6e7d65) suggested in #442. Now I fixed it. `CSM::waitForCurrentState()` didn't do what I expected from the name...

Some more thoughts:
- I suggest some more API changes: `syncSceneUpdates()` should be renamed to `waitForCurrentRobotState()`. 
- There are some methods `waitForCurrentState()` in `CurrentStateMonitor`, which actually should be renamed to `waitForCompleteState()` as they don't look at recent timestamps.
- I'm still arguing for a true method `syncSceneUpdates()` which incorporates all pending scene updates in the callback queue. I agree to @v4hn that this doesn't guarantee that all scene updates up to a given timestamp are incorporated, because - due to network delays - ROS messages might be received delayed. The only guarantee for a synchronous scene update is the new method `applyPlanningScene()`.
- I added some integration tests in moveit_ros/test. To this end, I imported a Fanuc robot description and moveit_config from ROS industrial. Please check, if that's fine.
