### PR TITLE
initialize RobotModel even if URDF is empty

### DIFF
--- a/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -92,11 +92,9 @@ void robot_model_loader::RobotModelLoader::configure(const Options &opt)
       rdf_loader_.reset(new rdf_loader::RDFLoader(opt.urdf_string_, opt.srdf_string_));
     else
       rdf_loader_.reset(new rdf_loader::RDFLoader(opt.robot_description_));
-  if (rdf_loader_->getURDF())
-  {
-    const boost::shared_ptr<srdf::Model> &srdf = rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : boost::shared_ptr<srdf::Model>(new srdf::Model());
-    model_.reset(new robot_model::RobotModel(rdf_loader_->getURDF(), srdf));
-  }
+
+  const boost::shared_ptr<srdf::Model> &srdf = rdf_loader_->getSRDF() ? rdf_loader_->getSRDF() : boost::shared_ptr<srdf::Model>(new srdf::Model());
+  model_.reset(new robot_model::RobotModel(rdf_loader_->getURDF(), srdf));
 
   if (model_ && !rdf_loader_->getRobotDescription().empty())
   {


### PR DESCRIPTION
There is no reason to have a null_ptr dangling here just because we didn't
find a robot description. We can just initialize an empty RobotModel.

Without this patch a null_ptr is passed to `getSharedStateMonitor` [here](https://github.com/ros-planning/moveit_ros/blob/kinetic-devel/planning_interface/robot_interface/src/wrap_python_robot_interface.cpp#L60) ,
while we _could_ add null-checks to all usages of the robot model,
I feel it's much more reasonable to simply generate an empty `RobotModel`.
This still prints a `ROS_ERROR` because `rdf_loader` fails to find the rosparam.

Please cherry-pick to jade and kinetic.

Fixes https://github.com/ros-planning/moveit_commander/issues/32 .
