### PR TITLE
Update moveit_ros metapackage cmakelists

### DIFF
--- a/moveit_ros/CMakeLists.txt
+++ b/moveit_ros/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8.3)
 project(moveit_ros)
 find_package(catkin REQUIRED)
 catkin_metapackage()


### PR DESCRIPTION
Without this small change, catkin thinks that the CMakeLists is nonstandard:

```
WARNING: The CMakeLists.txt of the metapackage 'moveit_ros' contains non standard content. Use the content of the following file instead: /home/jbinney/ws/transplanting/build/catkin_generated/metapackages/moveit_ros/CMakeLists.txt
```

Which causes catkin to treat the workspace as "NONHOMOGENOUS" and leads to 

```
CMake Error at /opt/ros/kinetic/share/catkin/cmake/catkin_workspace.cmake:95 (message):
  This workspace contains non-catkin packages in it, and catkin cannot build
  a non-homogeneous workspace without isolation.  Try the
  'catkin_make_isolated' command instead.
Call Stack (most recent call first):
  CMakeLists.txt:63 (catkin_workspace)


-- Configuring incomplete, errors occurred!
See also "/home/jbinney/ws/transplanting/build/CMakeFiles/CMakeOutput.log".
See also "/home/jbinney/ws/transplanting/build/CMakeFiles/CMakeError.log".
Invoking "cmake" failed
```
